### PR TITLE
Fix Conversation Screen Scrolling Bugs (Part 2)

### DIFF
--- a/Session/Conversations/ConversationVC.swift
+++ b/Session/Conversations/ConversationVC.swift
@@ -286,6 +286,7 @@ final class ConversationVC : BaseVC, ConversationViewModelDelegate, OWSConversat
     }
     
     @objc func handleKeyboardWillShowNotification(_ notification: Notification) {
+        print("Ryan: handleKeyboardWillShowNotification")
         guard let newHeight = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue.size.height else { return }
         if (newHeight > initialKeyboardHeight && initialKeyboardHeight == 0) {
             initialKeyboardHeight = newHeight
@@ -296,12 +297,10 @@ final class ConversationVC : BaseVC, ConversationViewModelDelegate, OWSConversat
             scrollButton.pin(.bottom, to: .bottom, of: view, withInset: -(newHeight + 16)) // + 16 to match the bottom inset of the table view
             didConstrainScrollButton = true
         }
-        let shouldScroll = (newHeight > 200) // Arbitrary value that's higher than the collapsed size and lower than the expanded size
+        // let shouldScroll = (newHeight > 200) // Arbitrary value that's higher than the collapsed size and lower than the expanded size
         let newContentOffsetY = self.messagesTableView.contentOffset.y + newHeight - self.messagesTableView.keyboardHeight
-        if shouldScroll {
-            self.messagesTableView.contentOffset.y = newContentOffsetY
-            self.messagesTableView.keyboardHeight = newHeight
-        }
+        self.messagesTableView.contentOffset.y = newContentOffsetY
+        self.messagesTableView.keyboardHeight = newHeight
         self.scrollButton.alpha = 0
     }
     

--- a/Session/Conversations/ConversationVC.swift
+++ b/Session/Conversations/ConversationVC.swift
@@ -54,7 +54,7 @@ final class ConversationVC : BaseVC, ConversationViewModelDelegate, OWSConversat
         return messagesTableView.contentSize.height - tableViewUnobscuredHeight
     }
     
-    var lastContentOffset: CGFloat? = nil
+    var lastContentOffsetY: CGFloat? = nil
     var initialKeyboardHeight: CGFloat = 0
     
     lazy var viewModel = ConversationViewModel(thread: thread, focusMessageIdOnOpen: focusedMessageID, delegate: self)
@@ -222,7 +222,7 @@ final class ConversationVC : BaseVC, ConversationViewModelDelegate, OWSConversat
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        if let y = lastContentOffset {
+        if let y = lastContentOffsetY {
             messagesTableView.setContentOffset(CGPoint(x: 0, y: y), animated: false)
         }
     }
@@ -235,9 +235,9 @@ final class ConversationVC : BaseVC, ConversationViewModelDelegate, OWSConversat
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        lastContentOffset = messagesTableView.contentOffset.y
+        lastContentOffsetY = messagesTableView.contentOffset.y
         if (messagesTableView.keyboardHeight > initialKeyboardHeight) {
-            lastContentOffset! -= messagesTableView.keyboardHeight - initialKeyboardHeight
+            lastContentOffsetY! -= messagesTableView.keyboardHeight - initialKeyboardHeight
         }
         let text = snInputView.text
         if !text.isEmpty {
@@ -458,7 +458,7 @@ final class ConversationVC : BaseVC, ConversationViewModelDelegate, OWSConversat
         view.layoutIfNeeded()
         let firstContentPageTop: CGFloat = 0
         let contentOffsetY = max(firstContentPageTop, lastPageTop)
-        lastContentOffset = contentOffsetY
+        lastContentOffsetY = contentOffsetY
         messagesTableView.setContentOffset(CGPoint(x: 0, y: contentOffsetY), animated: isAnimated)
         print("Ryan: Scroll to bottom, contentOffSetY: \(self.messagesTableView.contentOffset.y)")
     }

--- a/Session/Conversations/ConversationVC.swift
+++ b/Session/Conversations/ConversationVC.swift
@@ -286,7 +286,6 @@ final class ConversationVC : BaseVC, ConversationViewModelDelegate, OWSConversat
     }
     
     @objc func handleKeyboardWillShowNotification(_ notification: Notification) {
-        print("Ryan: handleKeyboardWillShowNotification")
         guard let newHeight = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue.size.height else { return }
         if (newHeight > initialKeyboardHeight && initialKeyboardHeight == 0) {
             initialKeyboardHeight = newHeight

--- a/Session/Conversations/ConversationVC.swift
+++ b/Session/Conversations/ConversationVC.swift
@@ -182,7 +182,7 @@ final class ConversationVC : BaseVC, ConversationViewModelDelegate, OWSConversat
         addOrRemoveBlockedBanner()
         // Notifications
         let notificationCenter = NotificationCenter.default
-        notificationCenter.addObserver(self, selector: #selector(handleKeyboardWillChangeFrameNotification(_:)), name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(handleKeyboardWillChangeFrameNotification(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
         notificationCenter.addObserver(self, selector: #selector(handleKeyboardWillHideNotification(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
         notificationCenter.addObserver(self, selector: #selector(handleAudioDidFinishPlayingNotification(_:)), name: .SNAudioDidFinishPlaying, object: nil)
         notificationCenter.addObserver(self, selector: #selector(addOrRemoveBlockedBanner), name: NSNotification.Name(rawValue: kNSNotificationName_BlockListDidChange), object: nil)
@@ -308,14 +308,31 @@ final class ConversationVC : BaseVC, ConversationViewModelDelegate, OWSConversat
             didConstrainScrollButton = true
         }
         let shouldScroll = (newHeight > 200) // Arbitrary value that's higher than the collapsed size and lower than the expanded size
-        print("Ryan: keyboardWillChangeFrame, new height: \(newHeight), old height: \(self.messagesTableView.keyboardHeight), contentOffsetY: \(self.messagesTableView.contentOffset.y)")
-        UIView.animate(withDuration: 0.25) {
-            if shouldScroll {
-                self.messagesTableView.contentOffset.y += (newHeight - self.messagesTableView.keyboardHeight)
-                self.messagesTableView.keyboardHeight = newHeight
-            }
-            self.scrollButton.alpha = 0
+        let newContentOffsetY = self.messagesTableView.contentOffset.y + newHeight - self.messagesTableView.keyboardHeight
+        print("Ryan: keyboardWillChangeFrame, new height: \(newHeight), old height: \(self.messagesTableView.keyboardHeight), contentOffsetY: \(self.messagesTableView.contentOffset.y) newContentOffsetY: \(newContentOffsetY)")
+        
+        if shouldScroll {
+            self.messagesTableView.contentOffset.y = newContentOffsetY
+            self.messagesTableView.keyboardHeight = newHeight
         }
+        self.scrollButton.alpha = 0
+//        UIView.animate(withDuration: 0.25, animations: {
+//            if shouldScroll {
+//                self.messagesTableView.contentOffset.y = newContentOffsetY
+//                self.messagesTableView.keyboardHeight = newHeight
+//            }
+//            self.scrollButton.alpha = 0
+//        }, completion: {_ in
+//            print("Ryan: keyboardWillChangeFrame ***End Animation***, contentOffsetY: \(self.messagesTableView.contentOffset.y)")
+//        })
+//        UIView.animate(withDuration: 0.25) {
+//            if shouldScroll {
+//                self.messagesTableView.contentOffset.y += (newHeight - self.messagesTableView.keyboardHeight)
+//                self.messagesTableView.keyboardHeight = newHeight
+//            }
+//            print("Ryan: keyboardWillChangeFrame ***In Animation***, contentOffsetY: \(self.messagesTableView.contentOffset.y)")
+//            self.scrollButton.alpha = 0
+//        }
         print("Ryan: keyboardWillChangeFrame, contentOffsetY: \(self.messagesTableView.contentOffset.y)")
     }
     
@@ -472,6 +489,7 @@ final class ConversationVC : BaseVC, ConversationViewModelDelegate, OWSConversat
     }
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        print("Ryan: scrollViewDidScroll contentOffsetY: \(scrollView.contentOffset.y)")
         scrollButton.alpha = getScrollButtonOpacity()
         unreadCountView.alpha = scrollButton.alpha
         autoLoadMoreIfNeeded()


### PR DESCRIPTION
- Fix when coming back from conversation settings vc, the lastest message won't completely show.
- Fix when the keyboard is showing, the tableview can scroll disorderly.
- Fix when the keyboard is hiding, the tableview won't scroll down. (This happens with third-party keyboards that may have a button to hide the keyboard.)
- Fix when an attachment is sent without the keyboard ever shows before, the tableview won't completely show the latest message once the keyboard shows.