### PR TITLE
Fix Crash in Very Long Conversations

### DIFF
--- a/Session/Conversations/ConversationViewModel.m
+++ b/Session/Conversations/ConversationViewModel.m
@@ -173,7 +173,7 @@ NS_ASSUME_NONNULL_BEGIN
 static const int kYapDatabasePageSize = 100;
 
 // Never show more than n messages in conversation view when user arrives.
-static const int kConversationInitialMaxRangeSize = 25000; // TODO: Does it cause issues to set this so high?
+static const int kConversationInitialMaxRangeSize = 100;
 
 // Never show more than n messages in conversation view at a time.
 static const int kYapDatabaseRangeMaxLength = 25000;

--- a/SignalUtilitiesKit/Utilities/ThreadUtil.m
+++ b/SignalUtilitiesKit/Utilities/ThreadUtil.m
@@ -169,6 +169,12 @@ NS_ASSUME_NONNULL_BEGIN
     // the messages view the position of the unread indicator,
     // so that it can widen its "load window" to always show
     // the unread indicator.
+    //
+    // We'll load all of the unread messages. This number may be larger
+    // than the maxRangeSize. This is not the idealest solution for the
+    // crash when unread message number is over 100. We can do better if
+    // we just load maxRangeSize number of unread messages, but the unread
+    // indicator can still be at the correct position.
     __block long visibleUnseenMessageCount = 0;
     __block TSInteraction *interactionAfterUnreadIndicator = nil;
     __block BOOL hasMoreUnseenMessages = NO;

--- a/SignalUtilitiesKit/Utilities/ThreadUtil.m
+++ b/SignalUtilitiesKit/Utilities/ThreadUtil.m
@@ -198,14 +198,6 @@ NS_ASSUME_NONNULL_BEGIN
                                 visibleUnseenMessageCount++;
 
                                 interactionAfterUnreadIndicator = interaction;
-
-                                if (visibleUnseenMessageCount + 1 >= maxRangeSize) {
-                                    // If there are more unseen messages than can be displayed in the
-                                    // messages view, show the unread indicator at the top of the
-                                    // displayed messages.
-                                    *stop = YES;
-                                    hasMoreUnseenMessages = YES;
-                                }
                             }];
 
     if (!interactionAfterUnreadIndicator) {


### PR DESCRIPTION
The first time when a conversation screen is loaded, it used to load no more than 100 messages. 
So it will crash when the number of unread messages exceeds 100.
Either setting kConversationInitialMaxRangeSize to 25000 or this fix is loading all the unread messages. 
Thus the crash won't happen.
We can do better if we can only load no more than 100 messages and keep the unread indicator at the correct place at the same time. 
This will make the first-time loading of a conversation screen faster.  