### PR TITLE
Fix Open Group Message Timestamp Issue

### DIFF
--- a/Session/Conversations/Message Cells/VisibleMessageCell.swift
+++ b/Session/Conversations/Message Cells/VisibleMessageCell.swift
@@ -286,7 +286,7 @@ final class VisibleMessageCell : MessageCell, LinkPreviewViewDelegate {
         dateBreakLabel.font = .boldSystemFont(ofSize: Values.verySmallFontSize)
         dateBreakLabel.textColor = Colors.text
         dateBreakLabel.textAlignment = .center
-        let date = viewItem.interaction.receivedAtDate()
+        let date = viewItem.interaction.dateForUI()
         let description = DateUtil.formatDate(forConversationDateBreaks: date)
         dateBreakLabel.text = description
         headerView.addSubview(dateBreakLabel)

--- a/Session/Media Viewing & Editing/MediaGalleryViewController.swift
+++ b/Session/Media Viewing & Editing/MediaGalleryViewController.swift
@@ -120,7 +120,7 @@ public struct GalleryDate: Hashable, Comparable, Equatable {
     let month: Int
 
     init(message: TSMessage) {
-        let date = message.receivedAtDate()
+        let date = message.dateForUI()
 
         self.year = Calendar.current.component(.year, from: date)
         self.month = Calendar.current.component(.month, from: date)

--- a/SessionMessagingKit/Messages/Signal/TSInteraction.h
+++ b/SessionMessagingKit/Messages/Signal/TSInteraction.h
@@ -43,6 +43,8 @@ NSString *NSStringFromOWSInteractionType(OWSInteractionType value);
 
 - (uint64_t)timestampForUI;
 
+- (NSDate *)dateForUI;
+
 - (NSDate *)receivedAtDate;
 
 - (OWSInteractionType)interactionType;

--- a/SessionMessagingKit/Messages/Signal/TSInteraction.m
+++ b/SessionMessagingKit/Messages/Signal/TSInteraction.m
@@ -180,8 +180,14 @@ NSString *NSStringFromOWSInteractionType(OWSInteractionType value)
     return self.timestamp;
 }
 
+- (NSDate *)dateForUI
+{
+    return [NSDate ows_dateWithMillisecondsSince1970:self.timestampForUI];
+}
+
 - (NSDate *)receivedAtDate
 {
+    // This is only used for sorting threads
     return [NSDate ows_dateWithMillisecondsSince1970:self.receivedAtTimestamp];
 }
 
@@ -222,13 +228,8 @@ NSString *NSStringFromOWSInteractionType(OWSInteractionType value)
 
 - (uint64_t)sortId
 {
-    if ([self isKindOfClass:TSIncomingMessage.class] && ((TSIncomingMessage *) self).isOpenGroupMessage) {
-        if (((TSIncomingMessage *) self).serverTimestamp != nil) {
-            return ((TSIncomingMessage *) self).serverTimestamp.unsignedLongLongValue;
-        }
-        // For messages that don't have a serverTimestamp, it is the same to sort by the receivedAtTimestamp,
-        // since in the open group poller we sort messages by their server timestamp.
-        return ((TSIncomingMessage *) self).receivedAtTimestamp;
+    if ([self isKindOfClass:TSIncomingMessage.class] && ((TSIncomingMessage *) self).isOpenGroupMessage && ((TSIncomingMessage *) self).serverTimestamp != nil) {
+        return ((TSIncomingMessage *) self).serverTimestamp.unsignedLongLongValue;
     }
     return self.timestamp;
 }

--- a/SessionMessagingKit/Messages/Signal/TSInteraction.m
+++ b/SessionMessagingKit/Messages/Signal/TSInteraction.m
@@ -222,8 +222,13 @@ NSString *NSStringFromOWSInteractionType(OWSInteractionType value)
 
 - (uint64_t)sortId
 {
-    if ([self isKindOfClass:TSIncomingMessage.class] && ((TSIncomingMessage *) self).isOpenGroupMessage && ((TSIncomingMessage *) self).serverTimestamp != nil) {
-        return ((TSIncomingMessage *) self).serverTimestamp.unsignedLongLongValue;
+    if ([self isKindOfClass:TSIncomingMessage.class] && ((TSIncomingMessage *) self).isOpenGroupMessage) {
+        if (((TSIncomingMessage *) self).serverTimestamp != nil) {
+            return ((TSIncomingMessage *) self).serverTimestamp.unsignedLongLongValue;
+        }
+        // For messages that don't have a serverTimestamp, it is the same to sort by the receivedAtTimestamp,
+        // since in the open group poller we sort messages by their server timestamp.
+        return ((TSIncomingMessage *) self).receivedAtTimestamp;
     }
     return self.timestamp;
 }

--- a/SessionMessagingKit/Messages/Signal/TSInteraction.m
+++ b/SessionMessagingKit/Messages/Signal/TSInteraction.m
@@ -169,10 +169,8 @@ NSString *NSStringFromOWSInteractionType(OWSInteractionType value)
 
 - (uint64_t)timestampForUI
 {
-    if ([self isKindOfClass:TSIncomingMessage.class] && ((TSIncomingMessage *) self).isOpenGroupMessage) {
-        if (((TSIncomingMessage *) self).serverTimestamp)
-            return ((TSIncomingMessage *) self).serverTimestamp.unsignedLongLongValue;
-        return ((TSIncomingMessage *) self).receivedAtTimestamp;
+    if ([self isKindOfClass:TSIncomingMessage.class] && ((TSIncomingMessage *) self).isOpenGroupMessage && ((TSIncomingMessage *) self).serverTimestamp != nil) {
+        return ((TSIncomingMessage *) self).serverTimestamp.unsignedLongLongValue;
     }
     return _timestamp;
 }
@@ -184,9 +182,6 @@ NSString *NSStringFromOWSInteractionType(OWSInteractionType value)
 
 - (NSDate *)receivedAtDate
 {
-    if ([self isKindOfClass:TSIncomingMessage.class] && ((TSIncomingMessage *) self).isOpenGroupMessage && ((TSIncomingMessage *) self).serverTimestamp != nil) {
-        return [NSDate ows_dateWithMillisecondsSince1970:((TSIncomingMessage *) self).serverTimestamp.unsignedLongLongValue];
-    }
     return [NSDate ows_dateWithMillisecondsSince1970:self.receivedAtTimestamp];
 }
 
@@ -227,7 +222,7 @@ NSString *NSStringFromOWSInteractionType(OWSInteractionType value)
 
 - (uint64_t)sortId
 {
-    if ([self isKindOfClass:TSIncomingMessage.class] && ((TSIncomingMessage *) self).isOpenGroupMessage) {
+    if ([self isKindOfClass:TSIncomingMessage.class] && ((TSIncomingMessage *) self).isOpenGroupMessage && ((TSIncomingMessage *) self).serverTimestamp != nil) {
         return ((TSIncomingMessage *) self).serverTimestamp.unsignedLongLongValue;
     }
     return self.timestamp;

--- a/SessionMessagingKit/Messages/Signal/TSInteraction.m
+++ b/SessionMessagingKit/Messages/Signal/TSInteraction.m
@@ -170,7 +170,9 @@ NSString *NSStringFromOWSInteractionType(OWSInteractionType value)
 - (uint64_t)timestampForUI
 {
     if ([self isKindOfClass:TSIncomingMessage.class] && ((TSIncomingMessage *) self).isOpenGroupMessage) {
-        return ((TSIncomingMessage *) self).serverTimestamp.unsignedLongLongValue;
+        if (((TSIncomingMessage *) self).serverTimestamp)
+            return ((TSIncomingMessage *) self).serverTimestamp.unsignedLongLongValue;
+        return ((TSIncomingMessage *) self).receivedAtTimestamp;
     }
     return _timestamp;
 }
@@ -182,7 +184,7 @@ NSString *NSStringFromOWSInteractionType(OWSInteractionType value)
 
 - (NSDate *)receivedAtDate
 {
-    if ([self isKindOfClass:TSIncomingMessage.class] && ((TSIncomingMessage *) self).isOpenGroupMessage) {
+    if ([self isKindOfClass:TSIncomingMessage.class] && ((TSIncomingMessage *) self).isOpenGroupMessage && ((TSIncomingMessage *) self).serverTimestamp != nil) {
         return [NSDate ows_dateWithMillisecondsSince1970:((TSIncomingMessage *) self).serverTimestamp.unsignedLongLongValue];
     }
     return [NSDate ows_dateWithMillisecondsSince1970:self.receivedAtTimestamp];

--- a/SignalUtilitiesKit/Messaging/ThreadViewModel.swift
+++ b/SignalUtilitiesKit/Messaging/ThreadViewModel.swift
@@ -32,7 +32,7 @@ public class ThreadViewModel: NSObject {
         self.lastMessageText = thread.lastMessageText(transaction: transaction)
         let lastInteraction = thread.lastInteractionForInbox(transaction: transaction)
         self.lastMessageForInbox = lastInteraction
-        self.lastMessageDate = lastInteraction?.receivedAtDate() ?? thread.creationDate
+        self.lastMessageDate = lastInteraction?.dateForUI() ?? thread.creationDate
 
         if let contactThread = thread as? TSContactThread {
             self.contactIdentifier = contactThread.contactIdentifier()


### PR DESCRIPTION
Now we use the sent timestamp to sort messages and present the date and time in UI (in both Home Screen and Conversation Screen). The received timestamp is only used for sorting threads right now. 