### PR TITLE
Support Basic Deep Linking

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -38,7 +38,7 @@ PODS:
     - PromiseKit/CorePromise
   - PromiseKit/UIKit (6.13.1):
     - PromiseKit/CorePromise
-  - PureLayout (3.1.6)
+  - PureLayout (3.1.8)
   - Reachability (3.2)
   - SAMKeychain (1.5.3)
   - SignalCoreKit (1.0.0):
@@ -129,7 +129,7 @@ DEPENDENCIES:
   - Mantle (from `https://github.com/signalapp/Mantle`, branch `signal-master`)
   - NVActivityIndicatorView
   - PromiseKit
-  - PureLayout (~> 3.1.4)
+  - PureLayout (~> 3.1.8)
   - Reachability
   - SAMKeychain
   - SignalCoreKit (from `https://github.com/signalapp/SignalCoreKit.git`)
@@ -197,7 +197,7 @@ SPEC CHECKSUMS:
   Mantle: 2fa750afa478cd625a94230fbf1c13462f29395b
   NVActivityIndicatorView: 738e843cb8924e9e4fc3e559d0728031624bf860
   PromiseKit: 28fda91c973cc377875d8c0ea4f973013c05b6db
-  PureLayout: bd3c4ec3a3819ad387c99ebb72c6b129c3ed4d2d
+  PureLayout: a4afb3d79dd958564ce33d22c89f407280d8e6a8
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   SAMKeychain: 483e1c9f32984d50ca961e26818a534283b4cd5c
   SignalCoreKit: 4562b2bbd9830077439ca003f952a798457d4ea5
@@ -208,6 +208,6 @@ SPEC CHECKSUMS:
   YYImage: 6db68da66f20d9f169ceb94dfb9947c3867b9665
   ZXingObjC: fdbb269f25dd2032da343e06f10224d62f537bdb
 
-PODFILE CHECKSUM: 523f27e57b63690fcbf629f49664dabac3876654
+PODFILE CHECKSUM: 50e6a35c838ba28d2ee02bc6018fdd297c04e55f
 
 COCOAPODS: 1.10.1

--- a/Session/DMs/NewDMVC.swift
+++ b/Session/DMs/NewDMVC.swift
@@ -38,6 +38,19 @@ final class NewDMVC : BaseVC, UIPageViewControllerDataSource, UIPageViewControll
         return result
     }()
     
+    init(sessionID: String) {
+        super.init(nibName: nil, bundle: nil)
+        enterPublicKeyVC.setSessionID(sessionID: sessionID)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+    }
+    
     // MARK: Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -203,6 +216,10 @@ private final class EnterPublicKeyVC : UIViewController {
         result.distribution = .fillEqually
         return result
     }()
+    
+    func setSessionID(sessionID: String){
+        self.publicKeyTextView.insertText(sessionID);
+    }
     
     // MARK: Lifecycle
     override func viewDidLoad() {

--- a/Session/Home/HomeVC.swift
+++ b/Session/Home/HomeVC.swift
@@ -66,7 +66,7 @@ final class HomeVC : BaseVC, UITableViewDataSource, UITableViewDelegate, NewConv
         explanationLabel.text = NSLocalizedString("vc_home_empty_state_message", comment: "")
         let createNewPrivateChatButton = Button(style: .prominentOutline, size: .large)
         createNewPrivateChatButton.setTitle(NSLocalizedString("vc_home_empty_state_button_title", comment: ""), for: UIControl.State.normal)
-        createNewPrivateChatButton.addTarget(self, action: #selector(createNewDM), for: UIControl.Event.touchUpInside)
+        createNewPrivateChatButton.addTarget(self, action: #selector(createNewDM as () -> Void), for: UIControl.Event.touchUpInside)
         createNewPrivateChatButton.set(.width, to: 196)
         let result = UIStackView(arrangedSubviews: [ explanationLabel, createNewPrivateChatButton ])
         result.axis = .vertical
@@ -419,6 +419,12 @@ final class HomeVC : BaseVC, UITableViewDataSource, UITableViewDelegate, NewConv
     
     @objc func createNewDM() {
         let newDMVC = NewDMVC()
+        let navigationController = OWSNavigationController(rootViewController: newDMVC)
+        present(navigationController, animated: true, completion: nil)
+    }
+    
+    @objc func createNewDM(sessionID: String) {
+        let newDMVC = NewDMVC(sessionID: sessionID)
         let navigationController = OWSNavigationController(rootViewController: newDMVC)
         present(navigationController, animated: true, completion: nil)
     }

--- a/Session/Home/NewConversationButtonSet.swift
+++ b/Session/Home/NewConversationButtonSet.swift
@@ -218,6 +218,7 @@ protocol NewConversationButtonSetDelegate {
     
     func joinOpenGroup()
     func createNewDM()
+    func createNewDM(sessionID: String)
     func createClosedGroup()
 }
 

--- a/Session/Meta/AppDelegate.m
+++ b/Session/Meta/AppDelegate.m
@@ -789,4 +789,44 @@ static NSTimeInterval launchStartedAt;
     }];
 }
 
+# pragma mark - App Link
+- (BOOL)application:(UIApplication *)app
+            openURL:(NSURL *)incomingURL
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
+{
+    NSURLComponents *components = [[NSURLComponents alloc]  initWithURL:incomingURL resolvingAgainstBaseURL: true];
+    
+    // URL Scheme is sessionmessenger://DM?sessionID=1234
+    // We can later add more parameters like message etc.
+    NSString *intent = components.host;
+    if(intent != nil){
+        //Handle DM
+        if([intent isEqualToString: @"DM"]){
+            NSArray<NSURLQueryItem*> *params = [components queryItems];
+            NSPredicate *sessionIDPredicate = [NSPredicate predicateWithFormat:@"name == %@", @"sessionID"];
+            NSArray<NSURLQueryItem*> *matches = [params filteredArrayUsingPredicate: sessionIDPredicate];
+            if(matches.count > 0){
+                NSString *sessionID = matches.firstObject.value;
+                if(sessionID != nil){
+                    [self handleDM: sessionID];
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+- (void)handleDM:(NSString *)sessionID
+{
+    UIViewController *viewController = self.window.rootViewController;
+    if([viewController class] == [OWSNavigationController class]){
+        UIViewController *rVC = ((OWSNavigationController *)viewController).visibleViewController;
+        if([rVC class] == [HomeVC class]){
+            HomeVC *homeVC = (HomeVC *)rVC;
+            [homeVC createNewDMWithSessionID: sessionID];
+        }
+    }
+}
+
 @end

--- a/Session/Meta/Session-Info.plist
+++ b/Session/Meta/Session-Info.plist
@@ -2,35 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>PHPhotoLibraryPreventAutomaticLimitedAccessAlert</key>
-	<true/>
 	<key>BuildDetails</key>
 	<dict>
 		<key>CarthageVersion</key>
 		<string>0.36.0</string>
 		<key>OSXVersion</key>
 		<string>10.15.6</string>
-	</dict>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>public.loki.foundation</key>
-			<dict>
-				<key>NSExceptionRequiresForwardSecrecy</key>
-				<false/>
-			</dict>
-			<key>storage.seed1.loki.network</key>
-			<dict>
-				<key>NSExceptionRequiresForwardSecrecy</key>
-				<false/>
-			</dict>
-			<key>storage.seed3.loki.network</key>
-			<dict>
-				<key>NSExceptionRequiresForwardSecrecy</key>
-				<false/>
-			</dict>
-		</dict>
 	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
@@ -66,6 +43,16 @@
 				<string>sgnl</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>org.getsession</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>sessionmessenger</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
@@ -75,6 +62,27 @@
 	<string>public.app-category.social-networking</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>public.loki.foundation</key>
+			<dict>
+				<key>NSExceptionRequiresForwardSecrecy</key>
+				<false/>
+			</dict>
+			<key>storage.seed1.loki.network</key>
+			<dict>
+				<key>NSExceptionRequiresForwardSecrecy</key>
+				<false/>
+			</dict>
+			<key>storage.seed3.loki.network</key>
+			<dict>
+				<key>NSExceptionRequiresForwardSecrecy</key>
+				<false/>
+			</dict>
+		</dict>
+	</dict>
 	<key>NSAppleMusicUsageDescription</key>
 	<string>Signal needs to use Apple Music to play media attachments.</string>
 	<key>NSCameraUsageDescription</key>
@@ -82,13 +90,15 @@
 	<key>NSContactsUsageDescription</key>
 	<string>Signal uses your contacts to find users you know. We do not store your contacts on the server.</string>
 	<key>NSFaceIDUsageDescription</key>
-	<string>Session&apos;s Screen Lock feature uses Face ID.</string>
+	<string>Session's Screen Lock feature uses Face ID.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Session needs access to your microphone to record media.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Session needs access to your library to save photos.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Session needs access to your library to send photos.</string>
+	<key>PHPhotoLibraryPreventAutomaticLimitedAccessAlert</key>
+	<true/>
 	<key>UIAppFonts</key>
 	<array>
 		<string>ElegantIcons.ttf</string>


### PR DESCRIPTION
Contributor checklist

[x ] My commits are rebased on the latest master branch
[ x] My commits are in nice logical chunks
[ x] My contribution is fully baked and is ready to be merged as is
[ x] I have tested my contribution on these devices:
iPhone 11, iOS 14.5
iPhone 12 Pro Max, iOS 14.6
Description

This change adds application link support for Session iOS App.
Link Format: sessionmessenger://{action}?name1=value1&name2=value2 and so on.

This PR specifically handles "DM" action as follows,
sessionmessenger://DM?sessionID={sessionID or ONS}

This is a native application link. One can create a branch link which will first try application link then if it doesn't succeed then redirect to app store link for the platform.

Security:
This action just pulls up the "New DM" window and pastes the {sessionID or ONS} extracted from above. It doesn't actually send any DM.