### PR TITLE
Authenticated Message Retrieval Part 2

### DIFF
--- a/SessionMessagingKit/Database/Storage+ClosedGroups.swift
+++ b/SessionMessagingKit/Database/Storage+ClosedGroups.swift
@@ -1,14 +1,12 @@
+import Sodium
 
 extension Storage {
-        
+
+    // MARK: Encryption Key Pairs
     private static func getClosedGroupEncryptionKeyPairCollection(for groupPublicKey: String) -> String {
         return "SNClosedGroupEncryptionKeyPairCollection-\(groupPublicKey)"
     }
-
-    private static let closedGroupPublicKeyCollection = "SNClosedGroupPublicKeyCollection"
-    private static let closedGroupFormationTimestampCollection = "SNClosedGroupFormationTimestampCollection"
-    private static let closedGroupZombieMembersCollection = "SNClosedGroupZombieMembersCollection"
-
+    
     public func getClosedGroupEncryptionKeyPairs(for groupPublicKey: String) -> [ECKeyPair] {
         let collection = Storage.getClosedGroupEncryptionKeyPairCollection(for: groupPublicKey)
         var timestampsAndKeyPairs: [(timestamp: Double, keyPair: ECKeyPair)] = []
@@ -25,16 +23,30 @@ extension Storage {
         return getClosedGroupEncryptionKeyPairs(for: groupPublicKey).last
     }
 
-    public func addClosedGroupEncryptionKeyPair(_ keyPair: ECKeyPair, for groupPublicKey: String, using transaction: Any) {
+    public func addClosedGroupEncryptionKeyPair(_ keyPair: ECKeyPair, for groupPublicKey: String, using transaction: Any) -> String {
         let collection = Storage.getClosedGroupEncryptionKeyPairCollection(for: groupPublicKey)
         let timestamp = String(Date().timeIntervalSince1970)
         (transaction as! YapDatabaseReadWriteTransaction).setObject(keyPair, forKey: timestamp, inCollection: collection)
+        return timestamp
     }
 
     public func removeAllClosedGroupEncryptionKeyPairs(for groupPublicKey: String, using transaction: Any) {
         let collection = Storage.getClosedGroupEncryptionKeyPairCollection(for: groupPublicKey)
         (transaction as! YapDatabaseReadWriteTransaction).removeAllObjects(inCollection: collection)
     }
+    
+    // MARK: Authentication Key Pairs
+    private static func getClosedGroupAuthenticationKeyPairCollection(for groupPublicKey: String) -> String {
+        return "SNClosedGroupAuthenticationKeyPairCollection-\(groupPublicKey)"
+    }
+    
+    public func addClosedGroupAuthenticationKeyPair(_ keyPair: Sign.KeyPair, for groupPublicKey: String, timestamp: String, using transaction: Any) {
+        let collection = Storage.getClosedGroupAuthenticationKeyPairCollection(for: groupPublicKey)
+        (transaction as! YapDatabaseReadWriteTransaction).setObject(keyPair, forKey: timestamp, inCollection: collection)
+    }
+    
+    // MARK: Public Keys
+    private static let closedGroupPublicKeyCollection = "SNClosedGroupPublicKeyCollection"
     
     public func getUserClosedGroupPublicKeys() -> Set<String> {
         var result: Set<String> = []
@@ -52,6 +64,9 @@ extension Storage {
         (transaction as! YapDatabaseReadWriteTransaction).removeObject(forKey: groupPublicKey, inCollection: Storage.closedGroupPublicKeyCollection)
     }
 
+    // MARK: Formation Timestamps
+    private static let closedGroupFormationTimestampCollection = "SNClosedGroupFormationTimestampCollection"
+    
     public func getClosedGroupFormationTimestamp(for groupPublicKey: String) -> UInt64? {
         var result: UInt64?
         Storage.read { transaction in
@@ -63,6 +78,9 @@ extension Storage {
     public func setClosedGroupFormationTimestamp(to timestamp: UInt64, for groupPublicKey: String, using transaction: Any) {
         (transaction as! YapDatabaseReadWriteTransaction).setObject(timestamp, forKey: groupPublicKey, inCollection: Storage.closedGroupFormationTimestampCollection)
     }
+    
+    // MARK: Zombie Members
+    private static let closedGroupZombieMembersCollection = "SNClosedGroupZombieMembersCollection"
     
     public func getZombieMembers(for groupPublicKey: String) -> Set<String> {
         var result: Set<String> = []
@@ -77,7 +95,8 @@ extension Storage {
     public func setZombieMembers(for groupPublicKey: String, to zombies: Set<String>, using transaction: Any) {
         (transaction as! YapDatabaseReadWriteTransaction).setObject(zombies, forKey: groupPublicKey, inCollection: Storage.closedGroupZombieMembersCollection)
     }
-
+    
+    // MARK: Convenience
     public func isClosedGroup(_ publicKey: String) -> Bool {
         getUserClosedGroupPublicKeys().contains(publicKey)
     }

--- a/SessionMessagingKit/Database/Storage+Shared.swift
+++ b/SessionMessagingKit/Database/Storage+Shared.swift
@@ -25,14 +25,14 @@ extension Storage {
         return OWSIdentityManager.shared().identityKeyPair()
     }
     
-    public func getUserED25519KeyPair() -> Box.KeyPair? {
+    public func getUserED25519KeyPair() -> Sign.KeyPair? {
         let dbConnection = OWSIdentityManager.shared().dbConnection
         let collection = OWSPrimaryStorageIdentityKeyStoreCollection
         guard let hexEncodedPublicKey = dbConnection.object(forKey: LKED25519PublicKey, inCollection: collection) as? String,
             let hexEncodedSecretKey = dbConnection.object(forKey: LKED25519SecretKey, inCollection: collection) as? String else { return nil }
-        let publicKey = Box.KeyPair.PublicKey(hex: hexEncodedPublicKey)
-        let secretKey = Box.KeyPair.SecretKey(hex: hexEncodedSecretKey)
-        return Box.KeyPair(publicKey: publicKey, secretKey: secretKey)
+        let publicKey = Sign.KeyPair.PublicKey(hex: hexEncodedPublicKey)
+        let secretKey = Sign.KeyPair.SecretKey(hex: hexEncodedSecretKey)
+        return Sign.KeyPair(publicKey: publicKey, secretKey: secretKey)
     }
 
     @objc public func getUser() -> Contact? {

--- a/SessionMessagingKit/Messages/Control Messages/ClosedGroupControlMessage.swift
+++ b/SessionMessagingKit/Messages/Control Messages/ClosedGroupControlMessage.swift
@@ -179,7 +179,7 @@ public final class ClosedGroupControlMessage : ControlMessage {
         switch closedGroupControlMessageProto.type {
         case .new:
             guard let publicKey = closedGroupControlMessageProto.publicKey, let name = closedGroupControlMessageProto.name,
-                let encryptionKeyPairAsProto = closedGroupControlMessageProto.encryptionKeyPair else { return nil }
+                let encryptionKeyPairAsProto = closedGroupControlMessageProto.x25519 else { return nil }
             let expirationTimer = closedGroupControlMessageProto.expirationTimer
             do {
                 let encryptionKeyPair = try ECKeyPair(publicKeyData: encryptionKeyPairAsProto.publicKey.removing05PrefixIfNeeded(), privateKeyData: encryptionKeyPairAsProto.privateKey)
@@ -222,7 +222,7 @@ public final class ClosedGroupControlMessage : ControlMessage {
                 closedGroupControlMessage.setName(name)
                 let encryptionKeyPairAsProto = SNProtoKeyPair.builder(publicKey: encryptionKeyPair.publicKey, privateKey: encryptionKeyPair.privateKey)
                 do {
-                    closedGroupControlMessage.setEncryptionKeyPair(try encryptionKeyPairAsProto.build())
+                    closedGroupControlMessage.setX25519(try encryptionKeyPairAsProto.build())
                 } catch {
                     SNLog("Couldn't construct closed group update proto from: \(self).")
                     return nil

--- a/SessionMessagingKit/Messages/Control Messages/ConfigurationMessage.swift
+++ b/SessionMessagingKit/Messages/Control Messages/ConfigurationMessage.swift
@@ -141,7 +141,7 @@ extension ConfigurationMessage {
         public static func fromProto(_ proto: SNProtoConfigurationMessageClosedGroup) -> ClosedGroup? {
             guard let publicKey = proto.publicKey?.toHexString(),
                 let name = proto.name,
-                let encryptionKeyPairAsProto = proto.encryptionKeyPair else { return nil }
+                let encryptionKeyPairAsProto = proto.x25519 else { return nil }
             let encryptionKeyPair: ECKeyPair
             do {
                 encryptionKeyPair = try ECKeyPair(publicKeyData: encryptionKeyPairAsProto.publicKey, privateKeyData: encryptionKeyPairAsProto.privateKey)
@@ -164,7 +164,7 @@ extension ConfigurationMessage {
             result.setName(name)
             do {
                 let encryptionKeyPairAsProto = try SNProtoKeyPair.builder(publicKey: encryptionKeyPair.publicKey, privateKey: encryptionKeyPair.privateKey).build()
-                result.setEncryptionKeyPair(encryptionKeyPairAsProto)
+                result.setX25519(encryptionKeyPairAsProto)
             } catch {
                 SNLog("Couldn't construct closed group proto from: \(self).")
                 return nil

--- a/SessionMessagingKit/Protos/Generated/SNProto.swift
+++ b/SessionMessagingKit/Protos/Generated/SNProto.swift
@@ -1412,13 +1412,16 @@ extension SNProtoDataMessageOpenGroupInvitation.SNProtoDataMessageOpenGroupInvit
 
     // MARK: - SNProtoDataMessageClosedGroupControlMessageKeyPairWrapperBuilder
 
-    @objc public class func builder(publicKey: Data, encryptedKeyPair: Data) -> SNProtoDataMessageClosedGroupControlMessageKeyPairWrapperBuilder {
-        return SNProtoDataMessageClosedGroupControlMessageKeyPairWrapperBuilder(publicKey: publicKey, encryptedKeyPair: encryptedKeyPair)
+    @objc public class func builder(publicKey: Data, x25519: Data) -> SNProtoDataMessageClosedGroupControlMessageKeyPairWrapperBuilder {
+        return SNProtoDataMessageClosedGroupControlMessageKeyPairWrapperBuilder(publicKey: publicKey, x25519: x25519)
     }
 
     // asBuilder() constructs a builder that reflects the proto's contents.
     @objc public func asBuilder() -> SNProtoDataMessageClosedGroupControlMessageKeyPairWrapperBuilder {
-        let builder = SNProtoDataMessageClosedGroupControlMessageKeyPairWrapperBuilder(publicKey: publicKey, encryptedKeyPair: encryptedKeyPair)
+        let builder = SNProtoDataMessageClosedGroupControlMessageKeyPairWrapperBuilder(publicKey: publicKey, x25519: x25519)
+        if let _value = ed25519 {
+            builder.setEd25519(_value)
+        }
         return builder
     }
 
@@ -1428,19 +1431,23 @@ extension SNProtoDataMessageOpenGroupInvitation.SNProtoDataMessageOpenGroupInvit
 
         @objc fileprivate override init() {}
 
-        @objc fileprivate init(publicKey: Data, encryptedKeyPair: Data) {
+        @objc fileprivate init(publicKey: Data, x25519: Data) {
             super.init()
 
             setPublicKey(publicKey)
-            setEncryptedKeyPair(encryptedKeyPair)
+            setX25519(x25519)
         }
 
         @objc public func setPublicKey(_ valueParam: Data) {
             proto.publicKey = valueParam
         }
 
-        @objc public func setEncryptedKeyPair(_ valueParam: Data) {
-            proto.encryptedKeyPair = valueParam
+        @objc public func setX25519(_ valueParam: Data) {
+            proto.x25519 = valueParam
+        }
+
+        @objc public func setEd25519(_ valueParam: Data) {
+            proto.ed25519 = valueParam
         }
 
         @objc public func build() throws -> SNProtoDataMessageClosedGroupControlMessageKeyPairWrapper {
@@ -1456,14 +1463,24 @@ extension SNProtoDataMessageOpenGroupInvitation.SNProtoDataMessageOpenGroupInvit
 
     @objc public let publicKey: Data
 
-    @objc public let encryptedKeyPair: Data
+    @objc public let x25519: Data
+
+    @objc public var ed25519: Data? {
+        guard proto.hasEd25519 else {
+            return nil
+        }
+        return proto.ed25519
+    }
+    @objc public var hasEd25519: Bool {
+        return proto.hasEd25519
+    }
 
     private init(proto: SessionProtos_DataMessage.ClosedGroupControlMessage.KeyPairWrapper,
                  publicKey: Data,
-                 encryptedKeyPair: Data) {
+                 x25519: Data) {
         self.proto = proto
         self.publicKey = publicKey
-        self.encryptedKeyPair = encryptedKeyPair
+        self.x25519 = x25519
     }
 
     @objc
@@ -1482,10 +1499,10 @@ extension SNProtoDataMessageOpenGroupInvitation.SNProtoDataMessageOpenGroupInvit
         }
         let publicKey = proto.publicKey
 
-        guard proto.hasEncryptedKeyPair else {
-            throw SNProtoError.invalidProtobuf(description: "\(logTag) missing required field: encryptedKeyPair")
+        guard proto.hasX25519 else {
+            throw SNProtoError.invalidProtobuf(description: "\(logTag) missing required field: x25519")
         }
-        let encryptedKeyPair = proto.encryptedKeyPair
+        let x25519 = proto.x25519
 
         // MARK: - Begin Validation Logic for SNProtoDataMessageClosedGroupControlMessageKeyPairWrapper -
 
@@ -1493,7 +1510,7 @@ extension SNProtoDataMessageOpenGroupInvitation.SNProtoDataMessageOpenGroupInvit
 
         let result = SNProtoDataMessageClosedGroupControlMessageKeyPairWrapper(proto: proto,
                                                                                publicKey: publicKey,
-                                                                               encryptedKeyPair: encryptedKeyPair)
+                                                                               x25519: x25519)
         return result
     }
 

--- a/SessionMessagingKit/Protos/Generated/SNProto.swift
+++ b/SessionMessagingKit/Protos/Generated/SNProto.swift
@@ -2129,13 +2129,16 @@ extension SNProtoDataMessage.SNProtoDataMessageBuilder {
         if let _value = name {
             builder.setName(_value)
         }
-        if let _value = encryptionKeyPair {
-            builder.setEncryptionKeyPair(_value)
+        if let _value = x25519 {
+            builder.setX25519(_value)
         }
         builder.setMembers(members)
         builder.setAdmins(admins)
         if hasExpirationTimer {
             builder.setExpirationTimer(expirationTimer)
+        }
+        if let _value = ed25519 {
+            builder.setEd25519(_value)
         }
         return builder
     }
@@ -2154,8 +2157,8 @@ extension SNProtoDataMessage.SNProtoDataMessageBuilder {
             proto.name = valueParam
         }
 
-        @objc public func setEncryptionKeyPair(_ valueParam: SNProtoKeyPair) {
-            proto.encryptionKeyPair = valueParam.proto
+        @objc public func setX25519(_ valueParam: SNProtoKeyPair) {
+            proto.x25519 = valueParam.proto
         }
 
         @objc public func addMembers(_ valueParam: Data) {
@@ -2182,6 +2185,10 @@ extension SNProtoDataMessage.SNProtoDataMessageBuilder {
             proto.expirationTimer = valueParam
         }
 
+        @objc public func setEd25519(_ valueParam: SNProtoKeyPair) {
+            proto.ed25519 = valueParam.proto
+        }
+
         @objc public func build() throws -> SNProtoConfigurationMessageClosedGroup {
             return try SNProtoConfigurationMessageClosedGroup.parseProto(proto)
         }
@@ -2193,7 +2200,9 @@ extension SNProtoDataMessage.SNProtoDataMessageBuilder {
 
     fileprivate let proto: SessionProtos_ConfigurationMessage.ClosedGroup
 
-    @objc public let encryptionKeyPair: SNProtoKeyPair?
+    @objc public let x25519: SNProtoKeyPair?
+
+    @objc public let ed25519: SNProtoKeyPair?
 
     @objc public var publicKey: Data? {
         guard proto.hasPublicKey else {
@@ -2231,9 +2240,11 @@ extension SNProtoDataMessage.SNProtoDataMessageBuilder {
     }
 
     private init(proto: SessionProtos_ConfigurationMessage.ClosedGroup,
-                 encryptionKeyPair: SNProtoKeyPair?) {
+                 x25519: SNProtoKeyPair?,
+                 ed25519: SNProtoKeyPair?) {
         self.proto = proto
-        self.encryptionKeyPair = encryptionKeyPair
+        self.x25519 = x25519
+        self.ed25519 = ed25519
     }
 
     @objc
@@ -2247,9 +2258,14 @@ extension SNProtoDataMessage.SNProtoDataMessageBuilder {
     }
 
     fileprivate class func parseProto(_ proto: SessionProtos_ConfigurationMessage.ClosedGroup) throws -> SNProtoConfigurationMessageClosedGroup {
-        var encryptionKeyPair: SNProtoKeyPair? = nil
-        if proto.hasEncryptionKeyPair {
-            encryptionKeyPair = try SNProtoKeyPair.parseProto(proto.encryptionKeyPair)
+        var x25519: SNProtoKeyPair? = nil
+        if proto.hasX25519 {
+            x25519 = try SNProtoKeyPair.parseProto(proto.x25519)
+        }
+
+        var ed25519: SNProtoKeyPair? = nil
+        if proto.hasEd25519 {
+            ed25519 = try SNProtoKeyPair.parseProto(proto.ed25519)
         }
 
         // MARK: - Begin Validation Logic for SNProtoConfigurationMessageClosedGroup -
@@ -2257,7 +2273,8 @@ extension SNProtoDataMessage.SNProtoDataMessageBuilder {
         // MARK: - End Validation Logic for SNProtoConfigurationMessageClosedGroup -
 
         let result = SNProtoConfigurationMessageClosedGroup(proto: proto,
-                                                            encryptionKeyPair: encryptionKeyPair)
+                                                            x25519: x25519,
+                                                            ed25519: ed25519)
         return result
     }
 

--- a/SessionMessagingKit/Protos/Generated/SNProto.swift
+++ b/SessionMessagingKit/Protos/Generated/SNProto.swift
@@ -1590,14 +1590,17 @@ extension SNProtoDataMessageClosedGroupControlMessageKeyPairWrapper.SNProtoDataM
         if let _value = name {
             builder.setName(_value)
         }
-        if let _value = encryptionKeyPair {
-            builder.setEncryptionKeyPair(_value)
+        if let _value = x25519 {
+            builder.setX25519(_value)
         }
         builder.setMembers(members)
         builder.setAdmins(admins)
         builder.setWrappers(wrappers)
         if hasExpirationTimer {
             builder.setExpirationTimer(expirationTimer)
+        }
+        if let _value = ed25519 {
+            builder.setEd25519(_value)
         }
         return builder
     }
@@ -1626,8 +1629,8 @@ extension SNProtoDataMessageClosedGroupControlMessageKeyPairWrapper.SNProtoDataM
             proto.name = valueParam
         }
 
-        @objc public func setEncryptionKeyPair(_ valueParam: SNProtoKeyPair) {
-            proto.encryptionKeyPair = valueParam.proto
+        @objc public func setX25519(_ valueParam: SNProtoKeyPair) {
+            proto.x25519 = valueParam.proto
         }
 
         @objc public func addMembers(_ valueParam: Data) {
@@ -1664,6 +1667,10 @@ extension SNProtoDataMessageClosedGroupControlMessageKeyPairWrapper.SNProtoDataM
             proto.expirationTimer = valueParam
         }
 
+        @objc public func setEd25519(_ valueParam: SNProtoKeyPair) {
+            proto.ed25519 = valueParam.proto
+        }
+
         @objc public func build() throws -> SNProtoDataMessageClosedGroupControlMessage {
             return try SNProtoDataMessageClosedGroupControlMessage.parseProto(proto)
         }
@@ -1677,9 +1684,11 @@ extension SNProtoDataMessageClosedGroupControlMessageKeyPairWrapper.SNProtoDataM
 
     @objc public let type: SNProtoDataMessageClosedGroupControlMessageType
 
-    @objc public let encryptionKeyPair: SNProtoKeyPair?
+    @objc public let x25519: SNProtoKeyPair?
 
     @objc public let wrappers: [SNProtoDataMessageClosedGroupControlMessageKeyPairWrapper]
+
+    @objc public let ed25519: SNProtoKeyPair?
 
     @objc public var publicKey: Data? {
         guard proto.hasPublicKey else {
@@ -1718,12 +1727,14 @@ extension SNProtoDataMessageClosedGroupControlMessageKeyPairWrapper.SNProtoDataM
 
     private init(proto: SessionProtos_DataMessage.ClosedGroupControlMessage,
                  type: SNProtoDataMessageClosedGroupControlMessageType,
-                 encryptionKeyPair: SNProtoKeyPair?,
-                 wrappers: [SNProtoDataMessageClosedGroupControlMessageKeyPairWrapper]) {
+                 x25519: SNProtoKeyPair?,
+                 wrappers: [SNProtoDataMessageClosedGroupControlMessageKeyPairWrapper],
+                 ed25519: SNProtoKeyPair?) {
         self.proto = proto
         self.type = type
-        self.encryptionKeyPair = encryptionKeyPair
+        self.x25519 = x25519
         self.wrappers = wrappers
+        self.ed25519 = ed25519
     }
 
     @objc
@@ -1742,13 +1753,18 @@ extension SNProtoDataMessageClosedGroupControlMessageKeyPairWrapper.SNProtoDataM
         }
         let type = SNProtoDataMessageClosedGroupControlMessageTypeWrap(proto.type)
 
-        var encryptionKeyPair: SNProtoKeyPair? = nil
-        if proto.hasEncryptionKeyPair {
-            encryptionKeyPair = try SNProtoKeyPair.parseProto(proto.encryptionKeyPair)
+        var x25519: SNProtoKeyPair? = nil
+        if proto.hasX25519 {
+            x25519 = try SNProtoKeyPair.parseProto(proto.x25519)
         }
 
         var wrappers: [SNProtoDataMessageClosedGroupControlMessageKeyPairWrapper] = []
         wrappers = try proto.wrappers.map { try SNProtoDataMessageClosedGroupControlMessageKeyPairWrapper.parseProto($0) }
+
+        var ed25519: SNProtoKeyPair? = nil
+        if proto.hasEd25519 {
+            ed25519 = try SNProtoKeyPair.parseProto(proto.ed25519)
+        }
 
         // MARK: - Begin Validation Logic for SNProtoDataMessageClosedGroupControlMessage -
 
@@ -1756,8 +1772,9 @@ extension SNProtoDataMessageClosedGroupControlMessageKeyPairWrapper.SNProtoDataM
 
         let result = SNProtoDataMessageClosedGroupControlMessage(proto: proto,
                                                                  type: type,
-                                                                 encryptionKeyPair: encryptionKeyPair,
-                                                                 wrappers: wrappers)
+                                                                 x25519: x25519,
+                                                                 wrappers: wrappers,
+                                                                 ed25519: ed25519)
         return result
     }
 

--- a/SessionMessagingKit/Protos/Generated/SessionProtos.pb.swift
+++ b/SessionMessagingKit/Protos/Generated/SessionProtos.pb.swift
@@ -755,14 +755,14 @@ struct SessionProtos_DataMessage {
     /// Clears the value of `name`. Subsequent reads from it will return its default value.
     mutating func clearName() {self._name = nil}
 
-    var encryptionKeyPair: SessionProtos_KeyPair {
-      get {return _encryptionKeyPair ?? SessionProtos_KeyPair()}
-      set {_encryptionKeyPair = newValue}
+    var x25519: SessionProtos_KeyPair {
+      get {return _x25519 ?? SessionProtos_KeyPair()}
+      set {_x25519 = newValue}
     }
-    /// Returns true if `encryptionKeyPair` has been explicitly set.
-    var hasEncryptionKeyPair: Bool {return self._encryptionKeyPair != nil}
-    /// Clears the value of `encryptionKeyPair`. Subsequent reads from it will return its default value.
-    mutating func clearEncryptionKeyPair() {self._encryptionKeyPair = nil}
+    /// Returns true if `x25519` has been explicitly set.
+    var hasX25519: Bool {return self._x25519 != nil}
+    /// Clears the value of `x25519`. Subsequent reads from it will return its default value.
+    mutating func clearX25519() {self._x25519 = nil}
 
     var members: [Data] = []
 
@@ -778,6 +778,15 @@ struct SessionProtos_DataMessage {
     var hasExpirationTimer: Bool {return self._expirationTimer != nil}
     /// Clears the value of `expirationTimer`. Subsequent reads from it will return its default value.
     mutating func clearExpirationTimer() {self._expirationTimer = nil}
+
+    var ed25519: SessionProtos_KeyPair {
+      get {return _ed25519 ?? SessionProtos_KeyPair()}
+      set {_ed25519 = newValue}
+    }
+    /// Returns true if `ed25519` has been explicitly set.
+    var hasEd25519: Bool {return self._ed25519 != nil}
+    /// Clears the value of `ed25519`. Subsequent reads from it will return its default value.
+    mutating func clearEd25519() {self._ed25519 = nil}
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -881,8 +890,9 @@ struct SessionProtos_DataMessage {
     fileprivate var _type: SessionProtos_DataMessage.ClosedGroupControlMessage.TypeEnum? = nil
     fileprivate var _publicKey: Data? = nil
     fileprivate var _name: String? = nil
-    fileprivate var _encryptionKeyPair: SessionProtos_KeyPair? = nil
+    fileprivate var _x25519: SessionProtos_KeyPair? = nil
     fileprivate var _expirationTimer: UInt32? = nil
+    fileprivate var _ed25519: SessionProtos_KeyPair? = nil
   }
 
   init() {}
@@ -2108,17 +2118,19 @@ extension SessionProtos_DataMessage.ClosedGroupControlMessage: SwiftProtobuf.Mes
     1: .same(proto: "type"),
     2: .same(proto: "publicKey"),
     3: .same(proto: "name"),
-    4: .same(proto: "encryptionKeyPair"),
+    4: .same(proto: "x25519"),
     5: .same(proto: "members"),
     6: .same(proto: "admins"),
     7: .same(proto: "wrappers"),
     8: .same(proto: "expirationTimer"),
+    9: .same(proto: "ed25519"),
   ]
 
   public var isInitialized: Bool {
     if self._type == nil {return false}
-    if let v = self._encryptionKeyPair, !v.isInitialized {return false}
+    if let v = self._x25519, !v.isInitialized {return false}
     if !SwiftProtobuf.Internal.areAllInitialized(self.wrappers) {return false}
+    if let v = self._ed25519, !v.isInitialized {return false}
     return true
   }
 
@@ -2131,11 +2143,12 @@ extension SessionProtos_DataMessage.ClosedGroupControlMessage: SwiftProtobuf.Mes
       case 1: try { try decoder.decodeSingularEnumField(value: &self._type) }()
       case 2: try { try decoder.decodeSingularBytesField(value: &self._publicKey) }()
       case 3: try { try decoder.decodeSingularStringField(value: &self._name) }()
-      case 4: try { try decoder.decodeSingularMessageField(value: &self._encryptionKeyPair) }()
+      case 4: try { try decoder.decodeSingularMessageField(value: &self._x25519) }()
       case 5: try { try decoder.decodeRepeatedBytesField(value: &self.members) }()
       case 6: try { try decoder.decodeRepeatedBytesField(value: &self.admins) }()
       case 7: try { try decoder.decodeRepeatedMessageField(value: &self.wrappers) }()
       case 8: try { try decoder.decodeSingularUInt32Field(value: &self._expirationTimer) }()
+      case 9: try { try decoder.decodeSingularMessageField(value: &self._ed25519) }()
       default: break
       }
     }
@@ -2151,7 +2164,7 @@ extension SessionProtos_DataMessage.ClosedGroupControlMessage: SwiftProtobuf.Mes
     if let v = self._name {
       try visitor.visitSingularStringField(value: v, fieldNumber: 3)
     }
-    if let v = self._encryptionKeyPair {
+    if let v = self._x25519 {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
     }
     if !self.members.isEmpty {
@@ -2166,6 +2179,9 @@ extension SessionProtos_DataMessage.ClosedGroupControlMessage: SwiftProtobuf.Mes
     if let v = self._expirationTimer {
       try visitor.visitSingularUInt32Field(value: v, fieldNumber: 8)
     }
+    if let v = self._ed25519 {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -2173,11 +2189,12 @@ extension SessionProtos_DataMessage.ClosedGroupControlMessage: SwiftProtobuf.Mes
     if lhs._type != rhs._type {return false}
     if lhs._publicKey != rhs._publicKey {return false}
     if lhs._name != rhs._name {return false}
-    if lhs._encryptionKeyPair != rhs._encryptionKeyPair {return false}
+    if lhs._x25519 != rhs._x25519 {return false}
     if lhs.members != rhs.members {return false}
     if lhs.admins != rhs.admins {return false}
     if lhs.wrappers != rhs.wrappers {return false}
     if lhs._expirationTimer != rhs._expirationTimer {return false}
+    if lhs._ed25519 != rhs._ed25519 {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/SessionMessagingKit/Protos/Generated/SessionProtos.pb.swift
+++ b/SessionMessagingKit/Protos/Generated/SessionProtos.pb.swift
@@ -848,21 +848,32 @@ struct SessionProtos_DataMessage {
       mutating func clearPublicKey() {self._publicKey = nil}
 
       /// @required
-      var encryptedKeyPair: Data {
-        get {return _encryptedKeyPair ?? Data()}
-        set {_encryptedKeyPair = newValue}
+      var x25519: Data {
+        get {return _x25519 ?? Data()}
+        set {_x25519 = newValue}
       }
-      /// Returns true if `encryptedKeyPair` has been explicitly set.
-      var hasEncryptedKeyPair: Bool {return self._encryptedKeyPair != nil}
-      /// Clears the value of `encryptedKeyPair`. Subsequent reads from it will return its default value.
-      mutating func clearEncryptedKeyPair() {self._encryptedKeyPair = nil}
+      /// Returns true if `x25519` has been explicitly set.
+      var hasX25519: Bool {return self._x25519 != nil}
+      /// Clears the value of `x25519`. Subsequent reads from it will return its default value.
+      mutating func clearX25519() {self._x25519 = nil}
+
+      /// The encrypted ed25519 key pair
+      var ed25519: Data {
+        get {return _ed25519 ?? Data()}
+        set {_ed25519 = newValue}
+      }
+      /// Returns true if `ed25519` has been explicitly set.
+      var hasEd25519: Bool {return self._ed25519 != nil}
+      /// Clears the value of `ed25519`. Subsequent reads from it will return its default value.
+      mutating func clearEd25519() {self._ed25519 = nil}
 
       var unknownFields = SwiftProtobuf.UnknownStorage()
 
       init() {}
 
       fileprivate var _publicKey: Data? = nil
-      fileprivate var _encryptedKeyPair: Data? = nil
+      fileprivate var _x25519: Data? = nil
+      fileprivate var _ed25519: Data? = nil
     }
 
     init() {}
@@ -2188,12 +2199,13 @@ extension SessionProtos_DataMessage.ClosedGroupControlMessage.KeyPairWrapper: Sw
   static let protoMessageName: String = SessionProtos_DataMessage.ClosedGroupControlMessage.protoMessageName + ".KeyPairWrapper"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "publicKey"),
-    2: .same(proto: "encryptedKeyPair"),
+    2: .same(proto: "x25519"),
+    3: .same(proto: "ed25519"),
   ]
 
   public var isInitialized: Bool {
     if self._publicKey == nil {return false}
-    if self._encryptedKeyPair == nil {return false}
+    if self._x25519 == nil {return false}
     return true
   }
 
@@ -2204,7 +2216,8 @@ extension SessionProtos_DataMessage.ClosedGroupControlMessage.KeyPairWrapper: Sw
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularBytesField(value: &self._publicKey) }()
-      case 2: try { try decoder.decodeSingularBytesField(value: &self._encryptedKeyPair) }()
+      case 2: try { try decoder.decodeSingularBytesField(value: &self._x25519) }()
+      case 3: try { try decoder.decodeSingularBytesField(value: &self._ed25519) }()
       default: break
       }
     }
@@ -2214,15 +2227,19 @@ extension SessionProtos_DataMessage.ClosedGroupControlMessage.KeyPairWrapper: Sw
     if let v = self._publicKey {
       try visitor.visitSingularBytesField(value: v, fieldNumber: 1)
     }
-    if let v = self._encryptedKeyPair {
+    if let v = self._x25519 {
       try visitor.visitSingularBytesField(value: v, fieldNumber: 2)
+    }
+    if let v = self._ed25519 {
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: SessionProtos_DataMessage.ClosedGroupControlMessage.KeyPairWrapper, rhs: SessionProtos_DataMessage.ClosedGroupControlMessage.KeyPairWrapper) -> Bool {
     if lhs._publicKey != rhs._publicKey {return false}
-    if lhs._encryptedKeyPair != rhs._encryptedKeyPair {return false}
+    if lhs._x25519 != rhs._x25519 {return false}
+    if lhs._ed25519 != rhs._ed25519 {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/SessionMessagingKit/Protos/Generated/SessionProtos.pb.swift
+++ b/SessionMessagingKit/Protos/Generated/SessionProtos.pb.swift
@@ -979,14 +979,14 @@ struct SessionProtos_ConfigurationMessage {
     /// Clears the value of `name`. Subsequent reads from it will return its default value.
     mutating func clearName() {self._name = nil}
 
-    var encryptionKeyPair: SessionProtos_KeyPair {
-      get {return _encryptionKeyPair ?? SessionProtos_KeyPair()}
-      set {_encryptionKeyPair = newValue}
+    var x25519: SessionProtos_KeyPair {
+      get {return _x25519 ?? SessionProtos_KeyPair()}
+      set {_x25519 = newValue}
     }
-    /// Returns true if `encryptionKeyPair` has been explicitly set.
-    var hasEncryptionKeyPair: Bool {return self._encryptionKeyPair != nil}
-    /// Clears the value of `encryptionKeyPair`. Subsequent reads from it will return its default value.
-    mutating func clearEncryptionKeyPair() {self._encryptionKeyPair = nil}
+    /// Returns true if `x25519` has been explicitly set.
+    var hasX25519: Bool {return self._x25519 != nil}
+    /// Clears the value of `x25519`. Subsequent reads from it will return its default value.
+    mutating func clearX25519() {self._x25519 = nil}
 
     var members: [Data] = []
 
@@ -1001,14 +1001,24 @@ struct SessionProtos_ConfigurationMessage {
     /// Clears the value of `expirationTimer`. Subsequent reads from it will return its default value.
     mutating func clearExpirationTimer() {self._expirationTimer = nil}
 
+    var ed25519: SessionProtos_KeyPair {
+      get {return _ed25519 ?? SessionProtos_KeyPair()}
+      set {_ed25519 = newValue}
+    }
+    /// Returns true if `ed25519` has been explicitly set.
+    var hasEd25519: Bool {return self._ed25519 != nil}
+    /// Clears the value of `ed25519`. Subsequent reads from it will return its default value.
+    mutating func clearEd25519() {self._ed25519 = nil}
+
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
     init() {}
 
     fileprivate var _publicKey: Data? = nil
     fileprivate var _name: String? = nil
-    fileprivate var _encryptionKeyPair: SessionProtos_KeyPair? = nil
+    fileprivate var _x25519: SessionProtos_KeyPair? = nil
     fileprivate var _expirationTimer: UInt32? = nil
+    fileprivate var _ed25519: SessionProtos_KeyPair? = nil
   }
 
   struct Contact {
@@ -2335,14 +2345,16 @@ extension SessionProtos_ConfigurationMessage.ClosedGroup: SwiftProtobuf.Message,
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "publicKey"),
     2: .same(proto: "name"),
-    3: .same(proto: "encryptionKeyPair"),
+    3: .same(proto: "x25519"),
     4: .same(proto: "members"),
     5: .same(proto: "admins"),
     6: .same(proto: "expirationTimer"),
+    7: .same(proto: "ed25519"),
   ]
 
   public var isInitialized: Bool {
-    if let v = self._encryptionKeyPair, !v.isInitialized {return false}
+    if let v = self._x25519, !v.isInitialized {return false}
+    if let v = self._ed25519, !v.isInitialized {return false}
     return true
   }
 
@@ -2354,10 +2366,11 @@ extension SessionProtos_ConfigurationMessage.ClosedGroup: SwiftProtobuf.Message,
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularBytesField(value: &self._publicKey) }()
       case 2: try { try decoder.decodeSingularStringField(value: &self._name) }()
-      case 3: try { try decoder.decodeSingularMessageField(value: &self._encryptionKeyPair) }()
+      case 3: try { try decoder.decodeSingularMessageField(value: &self._x25519) }()
       case 4: try { try decoder.decodeRepeatedBytesField(value: &self.members) }()
       case 5: try { try decoder.decodeRepeatedBytesField(value: &self.admins) }()
       case 6: try { try decoder.decodeSingularUInt32Field(value: &self._expirationTimer) }()
+      case 7: try { try decoder.decodeSingularMessageField(value: &self._ed25519) }()
       default: break
       }
     }
@@ -2370,7 +2383,7 @@ extension SessionProtos_ConfigurationMessage.ClosedGroup: SwiftProtobuf.Message,
     if let v = self._name {
       try visitor.visitSingularStringField(value: v, fieldNumber: 2)
     }
-    if let v = self._encryptionKeyPair {
+    if let v = self._x25519 {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
     }
     if !self.members.isEmpty {
@@ -2382,16 +2395,20 @@ extension SessionProtos_ConfigurationMessage.ClosedGroup: SwiftProtobuf.Message,
     if let v = self._expirationTimer {
       try visitor.visitSingularUInt32Field(value: v, fieldNumber: 6)
     }
+    if let v = self._ed25519 {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: SessionProtos_ConfigurationMessage.ClosedGroup, rhs: SessionProtos_ConfigurationMessage.ClosedGroup) -> Bool {
     if lhs._publicKey != rhs._publicKey {return false}
     if lhs._name != rhs._name {return false}
-    if lhs._encryptionKeyPair != rhs._encryptionKeyPair {return false}
+    if lhs._x25519 != rhs._x25519 {return false}
     if lhs.members != rhs.members {return false}
     if lhs.admins != rhs.admins {return false}
     if lhs._expirationTimer != rhs._expirationTimer {return false}
+    if lhs._ed25519 != rhs._ed25519 {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/SessionMessagingKit/Protos/SessionProtos.proto
+++ b/SessionMessagingKit/Protos/SessionProtos.proto
@@ -122,9 +122,10 @@ message DataMessage {
 
     message KeyPairWrapper {
       // @required
-      required bytes publicKey        = 1; // The public key of the user the key pair is meant for
+      required bytes publicKey = 1; // The public key of the user the key pair is meant for
       // @required
-      required bytes encryptedKeyPair = 2; // The encrypted key pair
+      required bytes x25519    = 2; // The encrypted x25519 key pair
+      optional bytes ed25519   = 3; // The encrypted ed25519 key pair
     }
 
     // @required

--- a/SessionMessagingKit/Protos/SessionProtos.proto
+++ b/SessionMessagingKit/Protos/SessionProtos.proto
@@ -129,14 +129,15 @@ message DataMessage {
     }
 
     // @required
-    required Type           type              = 1;
-    optional bytes          publicKey         = 2;
-    optional string         name              = 3;
-    optional KeyPair        encryptionKeyPair = 4;
-    repeated bytes          members           = 5;
-    repeated bytes          admins            = 6;
-    repeated KeyPairWrapper wrappers          = 7;
-    optional uint32         expirationTimer   = 8;
+    required Type           type            = 1;
+    optional bytes          publicKey       = 2;
+    optional string         name            = 3;
+    optional KeyPair        x25519          = 4;
+    repeated bytes          members         = 5;
+    repeated bytes          admins          = 6;
+    repeated KeyPairWrapper wrappers        = 7;
+    optional uint32         expirationTimer = 8;
+    optional KeyPair        ed25519         = 9;
   }
 
   optional string                    body                      = 1;

--- a/SessionMessagingKit/Protos/SessionProtos.proto
+++ b/SessionMessagingKit/Protos/SessionProtos.proto
@@ -158,12 +158,13 @@ message DataMessage {
 message ConfigurationMessage {
 
   message ClosedGroup {
-    optional bytes   publicKey         = 1;
-    optional string  name              = 2;
-    optional KeyPair encryptionKeyPair = 3;
-    repeated bytes   members           = 4;
-    repeated bytes   admins            = 5;
-    optional uint32  expirationTimer   = 6;
+    optional bytes   publicKey       = 1;
+    optional string  name            = 2;
+    optional KeyPair x25519          = 3;
+    repeated bytes   members         = 4;
+    repeated bytes   admins          = 5;
+    optional uint32  expirationTimer = 6;
+    optional KeyPair ed25519         = 7;
   }
 
   message Contact {

--- a/SessionMessagingKit/Sending & Receiving/MessageReceiver+Handling.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageReceiver+Handling.swift
@@ -204,7 +204,7 @@ extension MessageReceiver {
             let allClosedGroupPublicKeys = storage.getUserClosedGroupPublicKeys()
             for closedGroup in message.closedGroups {
                 guard !allClosedGroupPublicKeys.contains(closedGroup.publicKey) else { continue }
-                handleNewClosedGroup(groupPublicKey: closedGroup.publicKey, name: closedGroup.name, x25519KeyPair: closedGroup.encryptionKeyPair,
+                handleNewClosedGroup(groupPublicKey: closedGroup.publicKey, name: closedGroup.name, x25519KeyPair: closedGroup.x25519KeyPair,
                     members: [String](closedGroup.members), admins: [String](closedGroup.admins), expirationTimer: closedGroup.expirationTimer, ed25519KeyPair: nil,
                     messageSentTimestamp: message.sentTimestamp!, using: transaction)
             }

--- a/SessionMessagingKit/Sending & Receiving/MessageReceiver+Handling.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageReceiver+Handling.swift
@@ -422,10 +422,10 @@ extension MessageReceiver {
             return SNLog("Ignoring closed group encryption key pair from non-admin.")
         }
         // Find our wrapper and decrypt it if possible
-        guard let wrapper = wrappers.first(where: { $0.publicKey == userPublicKey }), let encryptedKeyPair = wrapper.encryptedKeyPair else { return }
+        guard let wrapper = wrappers.first(where: { $0.publicKey == userPublicKey }), let encryptedX25519KeyPair = wrapper.encryptedX25519KeyPair else { return }
         let plaintext: Data
         do {
-            plaintext = try MessageReceiver.decryptWithSessionProtocol(ciphertext: encryptedKeyPair, using: userKeyPair).plaintext
+            plaintext = try MessageReceiver.decryptWithSessionProtocol(ciphertext: encryptedX25519KeyPair, using: userKeyPair).plaintext
         } catch {
             return SNLog("Couldn't decrypt closed group encryption key pair.")
         }

--- a/SessionMessagingKit/Sending & Receiving/MessageSender+ClosedGroups.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageSender+ClosedGroups.swift
@@ -74,8 +74,8 @@ extension MessageSender {
             privateKey: newKeyPair.privateKey).build()
         let plaintext = try! proto.serializedData()
         let wrappers = targetMembers.compactMap { publicKey -> ClosedGroupControlMessage.KeyPairWrapper in
-            let ciphertext = try! MessageSender.encryptWithSessionProtocol(plaintext, for: publicKey)
-            return ClosedGroupControlMessage.KeyPairWrapper(publicKey: publicKey, encryptedKeyPair: ciphertext)
+            let encryptedX25519KeyPair = try! MessageSender.encryptWithSessionProtocol(plaintext, for: publicKey)
+            return ClosedGroupControlMessage.KeyPairWrapper(publicKey: publicKey, encryptedX25519KeyPair: encryptedX25519KeyPair, encryptedED25519KeyPair: nil)
         }
         let closedGroupControlMessage = ClosedGroupControlMessage(kind: .encryptionKeyPair(publicKey: nil, wrappers: wrappers))
         var distributingKeyPairs = distributingClosedGroupEncryptionKeyPairs[groupPublicKey] ?? []
@@ -330,7 +330,7 @@ extension MessageSender {
         let contactThread = TSContactThread.getOrCreateThread(withContactSessionID: publicKey, transaction: transaction)
         guard let ciphertext = try? MessageSender.encryptWithSessionProtocol(plaintext, for: publicKey) else { return }
         SNLog("Sending latest encryption key pair to: \(publicKey).")
-        let wrapper = ClosedGroupControlMessage.KeyPairWrapper(publicKey: publicKey, encryptedKeyPair: ciphertext)
+        let wrapper = ClosedGroupControlMessage.KeyPairWrapper(publicKey: publicKey, encryptedX25519KeyPair: ciphertext, encryptedED25519KeyPair: nil)
         let closedGroupControlMessage = ClosedGroupControlMessage(kind: .encryptionKeyPair(publicKey: Data(hex: groupPublicKey), wrappers: [ wrapper ]))
         MessageSender.send(closedGroupControlMessage, in: contactThread, using: transaction)
     }

--- a/SessionMessagingKit/Storage.swift
+++ b/SessionMessagingKit/Storage.swift
@@ -15,7 +15,7 @@ public protocol SessionMessagingKitStorageProtocol {
 
     func getUserPublicKey() -> String?
     func getUserKeyPair() -> ECKeyPair?
-    func getUserED25519KeyPair() -> Box.KeyPair?
+    func getUserED25519KeyPair() -> Sign.KeyPair?
     func getUser() -> Contact?
     func getAllContacts() -> Set<Contact>
 

--- a/SessionNotificationServiceExtension/NotificationServiceExtension.swift
+++ b/SessionNotificationServiceExtension/NotificationServiceExtension.swift
@@ -61,7 +61,7 @@ public final class NotificationServiceExtension : UNNotificationServiceExtension
                         // TODO: We could consider actually handling the update here. Not sure if there's enough time though, seeing as though
                         // in some cases we need to send messages (e.g. our sender key) to a number of other users.
                         switch closedGroupControlMessage.kind {
-                        case .new(_, let name, _, _, _, _): snippet = "\(senderDisplayName) added you to \(name)"
+                        case .new(_, let name, _, _, _, _, _): snippet = "\(senderDisplayName) added you to \(name)"
                         default: return self.completeSilenty()
                         }
                     default: return self.completeSilenty()

--- a/SessionSnodeKit/SnodeAPI.swift
+++ b/SessionSnodeKit/SnodeAPI.swift
@@ -413,22 +413,28 @@ public final class SnodeAPI : NSObject {
     
     private static func getMessagesInternal(from snode: Snode, associatedWith publicKey: String) -> RawResponsePromise {
         let storage = SNSnodeKitConfiguration.shared.storage
-//        guard let userED25519KeyPair = storage.getUserED25519KeyPair() else { return Promise(error: Error.noKeyPair) }
+        let ed25519KeyPair: Sign.KeyPair?
+        if storage.isClosedGroup(publicKey) {
+            ed25519KeyPair = storage.getLatestClosedGroupAuthenticationKeyPair(for: publicKey)
+        } else {
+            ed25519KeyPair = storage.getUserED25519KeyPair()
+        }
+        guard let ed25519KeyPair = ed25519KeyPair else { return Promise(error: Error.noKeyPair) }
         // Get last message hash
         storage.pruneLastMessageHashInfoIfExpired(for: snode, associatedWith: publicKey)
         let lastHash = storage.getLastMessageHash(for: snode, associatedWith: publicKey) ?? ""
         // Construct signature
-//        let timestamp = UInt64(Int64(NSDate.millisecondTimestamp()) + SnodeAPI.clockOffset)
-//        let ed25519PublicKey = userED25519KeyPair.publicKey.toHexString()
-//        let verificationData = ("retrieve" + String(timestamp)).data(using: String.Encoding.utf8)!
-//        let signature = sodium.sign.signature(message: Bytes(verificationData), secretKey: userED25519KeyPair.secretKey)!
+        let timestamp = UInt64(Int64(NSDate.millisecondTimestamp()) + SnodeAPI.clockOffset)
+        let ed25519PublicKey = ed25519KeyPair.publicKey.toHexString()
+        let verificationData = ("retrieve" + String(timestamp)).data(using: String.Encoding.utf8)!
+        let signature = sodium.sign.signature(message: Bytes(verificationData), secretKey: ed25519KeyPair.secretKey)!
         // Make the request
         let parameters: JSON = [
             "pubKey" : Features.useTestnet ? publicKey.removing05PrefixIfNeeded() : publicKey,
             "lastHash" : lastHash,
-//            "timestamp" : timestamp,
-//            "pubkey_ed25519" : ed25519PublicKey,
-//            "signature" : signature.toBase64()!
+            "timestamp" : timestamp,
+            "pubkey_ed25519" : ed25519PublicKey,
+            "signature" : signature.toBase64()!
         ]
         return invoke(.getMessages, on: snode, associatedWith: publicKey, parameters: parameters)
     }

--- a/SessionSnodeKit/Storage.swift
+++ b/SessionSnodeKit/Storage.swift
@@ -11,7 +11,7 @@ public protocol SessionSnodeKitStorageProtocol {
     func writeSync(with block: @escaping (Any) -> Void)
 
     func getUserPublicKey() -> String?
-    func getUserED25519KeyPair() -> Box.KeyPair?
+    func getUserED25519KeyPair() -> Sign.KeyPair?
     func getOnionRequestPaths() -> [OnionRequestAPI.Path]
     func setOnionRequestPaths(to paths: [OnionRequestAPI.Path], using transaction: Any)
     func getSnodePool() -> Set<Snode>
@@ -25,4 +25,6 @@ public protocol SessionSnodeKitStorageProtocol {
     func pruneLastMessageHashInfoIfExpired(for snode: Snode, associatedWith publicKey: String)
     func getReceivedMessages(for publicKey: String) -> Set<String>
     func setReceivedMessages(to receivedMessages: Set<String>, for publicKey: String, using transaction: Any)
+    func getLatestClosedGroupAuthenticationKeyPair(for groupPublicKey: String) -> Sign.KeyPair?
+    func isClosedGroup(_ publicKey: String) -> Bool
 }

--- a/SignalUtilitiesKit/Messaging/ConfigurationMessage+Convenience.swift
+++ b/SignalUtilitiesKit/Messaging/ConfigurationMessage+Convenience.swift
@@ -20,8 +20,9 @@ extension ConfigurationMessage {
                     let groupID = thread.groupModel.groupId
                     let groupPublicKey = LKGroupUtilities.getDecodedGroupID(groupID)
                     guard storage.isClosedGroup(groupPublicKey),
-                        let encryptionKeyPair = storage.getLatestClosedGroupEncryptionKeyPair(for: groupPublicKey) else { return }
-                    let closedGroup = ClosedGroup(publicKey: groupPublicKey, name: thread.groupModel.groupName!, encryptionKeyPair: encryptionKeyPair,
+                        let x25519KeyPair = storage.getLatestClosedGroupEncryptionKeyPair(for: groupPublicKey) else { return }
+                    let ed25519KeyPair = storage.getLatestClosedGroupAuthenticationKeyPair(for: groupPublicKey)
+                    let closedGroup = ClosedGroup(publicKey: groupPublicKey, name: thread.groupModel.groupName!, x25519KeyPair: x25519KeyPair, ed25519KeyPair: ed25519KeyPair,
                         members: Set(thread.groupModel.groupMemberIds), admins: Set(thread.groupModel.groupAdminIds), expirationTimer: thread.disappearingMessagesDuration(with: transaction))
                     closedGroups.insert(closedGroup)
                 case .openGroup:


### PR DESCRIPTION
We don't yet have ED25519 key pairs for closed groups, so it looks like we'll have to:

• Extend the `ENCRYPTION_KEY_PAIR` closed group message to include an optional ED25519 key pair alongside the X25519 key pair.
• Update all clients to handle this and put the ED25519 key pair in the database upon receiving such a message.
• Update all clients to generate an ED25519 key pair alongside the X25519 key pair when (re-)generating the key pair for a closed group.
• Start using this ED25519 key pair for authenticated message retrieval if it's present.