### PR TITLE
Made app default to system-defined dark/light mode on first launch

### DIFF
--- a/Session/Meta/AppDelegate.m
+++ b/Session/Meta/AppDelegate.m
@@ -194,7 +194,7 @@ static NSTimeInterval launchStartedAt;
     mainWindow.rootViewController = [LoadingViewController new];
     [mainWindow makeKeyAndVisible];
 
-    LKAppMode appMode = [NSUserDefaults.standardUserDefaults integerForKey:@"appMode"];
+    LKAppMode appMode = [self getAppModeOrSystemDefault];
     [self setCurrentAppMode:appMode];
 
     if (@available(iOS 11, *)) {
@@ -245,7 +245,7 @@ static NSTimeInterval launchStartedAt;
 
     [self ensureRootViewController];
 
-    LKAppMode appMode = [NSUserDefaults.standardUserDefaults integerForKey:@"appMode"];
+    LKAppMode appMode = [self getCurrentAppMode];
     [self setCurrentAppMode:appMode];
 
     [AppReadiness runNowOrWhenAppDidBecomeReady:^{

--- a/Session/Meta/AppDelegate.swift
+++ b/Session/Meta/AppDelegate.swift
@@ -40,4 +40,20 @@ extension AppDelegate {
     @objc func stopClosedGroupPoller() {
         ClosedGroupPoller.shared.stop()
     }
+    
+    @objc func getAppModeOrSystemDefault() -> AppMode {
+        let userDefaults = UserDefaults.standard
+        
+        guard userDefaults.dictionaryRepresentation().keys.contains("appMode") else {
+            if #available(iOS 13.0, *) {
+                return UITraitCollection.current.userInterfaceStyle == .dark ? .dark : .light
+            } else {
+                return .light
+            }
+        }
+        
+        let mode = userDefaults.integer(forKey: "appMode")
+        return AppMode(rawValue: mode) ?? .light
+    }
+    
 }


### PR DESCRIPTION
### Contributor checklist
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 12 Pro, iOS 14.6
 * iPhone X Simulator, iOS 12.4
 * iPad Pro 11" Simulator, iOS 14.5

- - - - - - - - - -

### Description
Hi folks - it's my first contribution, so I figured I'd make it a small one. Let me know if there's anything style-wise that ain't quite right.

As per the [Apple HIG](https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/dark-mode), apps should 
> comply with the appearance mode people choose in Settings.

Before this change, on app launch AppDelegate would read a non-existent `appMode` value from NSUserDefaults, and because this value is an integer, it would default to `0` i.e. lightMode. I've added a check on launch that looks to see if the value exists, and if it doesn't reverts to the current system appearance. As this check takes place in AppDelegate, I've used `UITraitCollection.current.userInterfaceStyle` to get the user's appearance mode. If the user is running iOS 12, this logic is skipped, and retains current behaviour.

#### Tested the following way:
iPhone 12 Pro running iOS 14.6:
- fresh install when user has light system appearance
  - App defaults to light mode and sets `appMode` to `.light`
  - Dark/light mode button on settings screen retains light mode until toggled by user
  - Relaunching retains app setting
- fresh install when user has dark system appearance
  - App defaults to dark mode and sets `appMode` to `.dark`
  - Onboarding flow "looks good" in dark mode (might wanna check with UX folks 🤷 )
  - Dark/light mode button on settings screen retains light mode until toggled by user
  - Relaunching retains app setting
- user upgrades from previous build
  - system-defined appearance mode is ignored in favour of `appMode` from `NSUserDefaults`

iPhone X Sim running iOS 12.4
- App always defaults to light mode (current behaviour)

iPad Pro Sim running iOS 14.5:
- App defaults to system-defined appearance on fresh install
- Relaunch uses value from `NSUserDefaults`