### PR TITLE
Disable table view scroll when swiping to reply in a conversation

### DIFF
--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -468,6 +468,15 @@ extension ConversationVC : InputViewDelegate, MessageCellDelegate, ContextMenuAc
             }
         }
     }
+    
+    func handleViewItemSwiped(_ viewItem: ConversationViewItem, state: SwipeState) {
+        switch state {
+        case .began:
+            messagesTableView.isScrollEnabled = false
+        case .ended, .cancelled:
+            messagesTableView.isScrollEnabled = true
+        }
+    }
 
     func showFailedMessageSheet(for tsMessage: TSOutgoingMessage) {
         let thread = self.thread

--- a/Session/Conversations/Message Cells/MessageCell.swift
+++ b/Session/Conversations/Message Cells/MessageCell.swift
@@ -1,5 +1,11 @@
 import UIKit
 
+public enum SwipeState {
+    case began
+    case ended
+    case cancelled
+}
+
 class MessageCell : UITableViewCell {
     weak var delegate: MessageCellDelegate?
     var viewItem: ConversationViewItem? { didSet { update() } }
@@ -55,6 +61,7 @@ protocol MessageCellDelegate : AnyObject {
     func handleViewItemLongPressed(_ viewItem: ConversationViewItem)
     func handleViewItemTapped(_ viewItem: ConversationViewItem, gestureRecognizer: UITapGestureRecognizer)
     func handleViewItemDoubleTapped(_ viewItem: ConversationViewItem)
+    func handleViewItemSwiped(_ viewItem: ConversationViewItem, state: SwipeState)
     func showFullText(_ viewItem: ConversationViewItem)
     func openURL(_ url: URL)
     func handleReplyButtonTapped(for viewItem: ConversationViewItem)

--- a/Session/Conversations/Message Cells/VisibleMessageCell.swift
+++ b/Session/Conversations/Message Cells/VisibleMessageCell.swift
@@ -466,9 +466,12 @@ final class VisibleMessageCell : MessageCell, LinkPreviewViewDelegate {
     }
     
     @objc private func handlePan(_ gestureRecognizer: UIPanGestureRecognizer) {
+        guard let viewItem = viewItem else { return }
         let viewsToMove = [ bubbleView, profilePictureView, replyButton, timerView, messageStatusImageView ]
         let translationX = gestureRecognizer.translation(in: self).x.clamp(-CGFloat.greatestFiniteMagnitude, 0)
         switch gestureRecognizer.state {
+        case .began:
+            delegate?.handleViewItemSwiped(viewItem, state: .began)
         case .changed:
             // The idea here is to asymptotically approach a maximum drag distance
             let damping: CGFloat = 20
@@ -486,8 +489,10 @@ final class VisibleMessageCell : MessageCell, LinkPreviewViewDelegate {
             previousX = translationX
         case .ended, .cancelled:
             if abs(translationX) > VisibleMessageCell.swipeToReplyThreshold {
+                delegate?.handleViewItemSwiped(viewItem, state: .ended)
                 reply()
             } else {
+                delegate?.handleViewItemSwiped(viewItem, state: .cancelled)
                 resetReply()
             }
         default: break


### PR DESCRIPTION
### Contributor checklist
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
~- [ ] I have tested my contribution on these devices:~
~iDevice A, iOS X.Y.Z~
~iDevice B, iOS Z.Y~

**Note: I have not thoroughly tested this - only tested on iOS simulator using text and media message types**
- - - - - - - - - -

### Description
This is a proposal of sorts - when replying to messages using the swipe gesture on other popular messaging apps, the underlying scrolling is disabled until either the reply is triggered, or the gesture is cancelled. Currently, Session allows the user to continue scrolling vertically while swiping to reply:

![originalBehaviour](https://media1.giphy.com/media/dFGf04RgmfFLLLuTmD/giphy.gif)

I propose the swipe behaviour temporarily disables scroll on the underlying tableview, providing a familiar user experience. This looks like the following:

![newBehaviourImage](https://i.giphy.com/media/HHbu0hpDGfmNAhUDkj/giphy.webp)

### Notes

I considered using `UIGestureRecognizer.State` rather than creating the new `SwipeState` enum, but I figured it's a nicer interface only having to handle the particular enum cases we care about. The interface could be further simplified by removing the viewItem and `.cancelled` state too, but figured the `viewItem` makes this interface more consistent with the other delegate methods, and also makes it easier to refactor the "Retry" logic out of the cell and into the VC if you wanted to remove logic from View objects in future.