### PR TITLE
Unsend Requests

### DIFF
--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		768A1A2B17FC9CD300E00ED8 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 768A1A2A17FC9CD300E00ED8 /* libz.dylib */; };
 		76C87F19181EFCE600C4ACAB /* MediaPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 76C87F18181EFCE600C4ACAB /* MediaPlayer.framework */; };
 		76EB054018170B33006006FC /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 76EB03C318170B33006006FC /* AppDelegate.m */; };
+		7B4C75CB26B37E0F0000AC89 /* UnsendRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4C75CA26B37E0F0000AC89 /* UnsendRequest.swift */; };
 		7BC01A3E241F40AB00BC7C55 /* NotificationServiceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC01A3D241F40AB00BC7C55 /* NotificationServiceExtension.swift */; };
 		7BC01A42241F40AB00BC7C55 /* SessionNotificationServiceExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 7BC01A3B241F40AB00BC7C55 /* SessionNotificationServiceExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		7BDCFC08242186E700641C39 /* NotificationServiceExtensionContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BDCFC07242186E700641C39 /* NotificationServiceExtensionContext.swift */; };
@@ -1097,6 +1098,7 @@
 		76C87F18181EFCE600C4ACAB /* MediaPlayer.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MediaPlayer.framework; path = System/Library/Frameworks/MediaPlayer.framework; sourceTree = SDKROOT; };
 		76EB03C218170B33006006FC /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		76EB03C318170B33006006FC /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		7B4C75CA26B37E0F0000AC89 /* UnsendRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsendRequest.swift; sourceTree = "<group>"; };
 		7BC01A3B241F40AB00BC7C55 /* SessionNotificationServiceExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = SessionNotificationServiceExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		7BC01A3D241F40AB00BC7C55 /* NotificationServiceExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceExtension.swift; sourceTree = "<group>"; };
 		7BC01A3F241F40AB00BC7C55 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -2375,6 +2377,7 @@
 				B8F5F60225EDE16F003BF8D4 /* DataExtractionNotification.swift */,
 				C300A5E62554B07300555489 /* ExpirationTimerUpdate.swift */,
 				C3DA9C0625AE7396008F7C7E /* ConfigurationMessage.swift */,
+				7B4C75CA26B37E0F0000AC89 /* UnsendRequest.swift */,
 			);
 			path = "Control Messages";
 			sourceTree = "<group>";
@@ -4619,6 +4622,7 @@
 				C3A3A156256E1B91004D228D /* ProtoUtils.m in Sources */,
 				C3471ECB2555356A00297E91 /* MessageSender+Encryption.swift in Sources */,
 				C352A32F2557549C00338F3E /* NotifyPNServerJob.swift in Sources */,
+				7B4C75CB26B37E0F0000AC89 /* UnsendRequest.swift in Sources */,
 				C300A5F22554B09800555489 /* MessageSender.swift in Sources */,
 				C3C2A74D2553A39700C340D1 /* VisibleMessage.swift in Sources */,
 				C32C5AAD256DBE8F003C73A2 /* TSInfoMessage.m in Sources */,

--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		76C87F19181EFCE600C4ACAB /* MediaPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 76C87F18181EFCE600C4ACAB /* MediaPlayer.framework */; };
 		76EB054018170B33006006FC /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 76EB03C318170B33006006FC /* AppDelegate.m */; };
 		7B4C75CB26B37E0F0000AC89 /* UnsendRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4C75CA26B37E0F0000AC89 /* UnsendRequest.swift */; };
+		7B4C75CD26BB92060000AC89 /* DeletedMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4C75CC26BB92060000AC89 /* DeletedMessageView.swift */; };
 		7BC01A3E241F40AB00BC7C55 /* NotificationServiceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC01A3D241F40AB00BC7C55 /* NotificationServiceExtension.swift */; };
 		7BC01A42241F40AB00BC7C55 /* SessionNotificationServiceExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 7BC01A3B241F40AB00BC7C55 /* SessionNotificationServiceExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		7BDCFC08242186E700641C39 /* NotificationServiceExtensionContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BDCFC07242186E700641C39 /* NotificationServiceExtensionContext.swift */; };
@@ -1099,6 +1100,7 @@
 		76EB03C218170B33006006FC /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		76EB03C318170B33006006FC /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		7B4C75CA26B37E0F0000AC89 /* UnsendRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsendRequest.swift; sourceTree = "<group>"; };
+		7B4C75CC26BB92060000AC89 /* DeletedMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletedMessageView.swift; sourceTree = "<group>"; };
 		7BC01A3B241F40AB00BC7C55 /* SessionNotificationServiceExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = SessionNotificationServiceExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		7BC01A3D241F40AB00BC7C55 /* NotificationServiceExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceExtension.swift; sourceTree = "<group>"; };
 		7BC01A3F241F40AB00BC7C55 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -2089,6 +2091,7 @@
 				B849789525D4A2F500D0D0B3 /* LinkPreviewView.swift */,
 				B8D84EA225DF745A005A043E /* LinkPreviewState.swift */,
 				B8EB20EF2640F7F000773E52 /* OpenGroupInvitationView.swift */,
+				7B4C75CC26BB92060000AC89 /* DeletedMessageView.swift */,
 			);
 			path = "Content Views";
 			sourceTree = "<group>";
@@ -4903,6 +4906,7 @@
 				B8D0A25025E3678700C1835E /* LinkDeviceVC.swift in Sources */,
 				3496957321A301A100DCFE74 /* OWSBackupJob.m in Sources */,
 				B894D0752339EDCF00B4D94D /* NukeDataModal.swift in Sources */,
+				7B4C75CD26BB92060000AC89 /* DeletedMessageView.swift in Sources */,
 				B897621C25D201F7004F83B2 /* ScrollToBottomButton.swift in Sources */,
 				346B66311F4E29B200E5122F /* CropScaleImageViewController.swift in Sources */,
 				45E5A6991F61E6DE001E4A8A /* MarqueeLabel.swift in Sources */,

--- a/Session/Conversations/Context Menu/ContextMenuVC+Action.swift
+++ b/Session/Conversations/Context Menu/ContextMenuVC+Action.swift
@@ -2,81 +2,44 @@
 extension ContextMenuVC {
 
     struct Action {
-        let icon: UIImage?
+        let icon: UIImage
         let title: String
-        let tag: String
         let work: () -> Void
 
         static func reply(_ viewItem: ConversationViewItem, _ delegate: ContextMenuActionDelegate?) -> Action {
             let title = "Reply"
-            let tag = "reply"
-            return Action(icon: UIImage(named: "ic_reply")!, title: title, tag: tag) { delegate?.reply(viewItem) }
+            return Action(icon: UIImage(named: "ic_reply")!, title: title) { delegate?.reply(viewItem) }
         }
 
         static func copy(_ viewItem: ConversationViewItem, _ delegate: ContextMenuActionDelegate?) -> Action {
             let title = "Copy"
-            let tag = "copy"
-            return Action(icon: UIImage(named: "ic_copy")!, title: title, tag: tag) { delegate?.copy(viewItem) }
+            return Action(icon: UIImage(named: "ic_copy")!, title: title) { delegate?.copy(viewItem) }
         }
 
         static func copySessionID(_ viewItem: ConversationViewItem, _ delegate: ContextMenuActionDelegate?) -> Action {
             let title = "Copy Session ID"
-            let tag = "copySessionID"
-            return Action(icon: UIImage(named: "ic_copy")!, title: title, tag: tag) { delegate?.copySessionID(viewItem) }
+            return Action(icon: UIImage(named: "ic_copy")!, title: title) { delegate?.copySessionID(viewItem) }
         }
 
         static func delete(_ viewItem: ConversationViewItem, _ delegate: ContextMenuActionDelegate?) -> Action {
             let title = "Delete"
-            let tag = "delete"
-            return Action(icon: UIImage(named: "ic_trash")!, title: title, tag: tag) { delegate?.delete(viewItem) }
-        }
-        
-        static func deleteLocally(_ viewItem: ConversationViewItem, _ delegate: ContextMenuActionDelegate?) -> Action {
-            let title = "Delete for me"
-            let tag = "deleteforme"
-            return Action(icon: nil, title: title, tag: tag) { delegate?.deleteLocally(viewItem) }
-        }
-        
-        static func deleteForEveryone(_ viewItem: ConversationViewItem, _ delegate: ContextMenuActionDelegate?) -> Action {
-            let tag = "deleteforeveryone"
-            var title = "Delete for everyone"
-            if !viewItem.isGroupThread {
-                title = "Delete for me and \(viewItem.interaction.thread.name())"
-            }
-            return Action(icon: nil, title: title, tag: tag) { delegate?.deleteForEveryone(viewItem) }
+            return Action(icon: UIImage(named: "ic_trash")!, title: title) { delegate?.delete(viewItem) }
         }
 
         static func save(_ viewItem: ConversationViewItem, _ delegate: ContextMenuActionDelegate?) -> Action {
             let title = "Save"
-            let tag = "save"
-            return Action(icon: UIImage(named: "ic_download")!, title: title, tag: tag) { delegate?.save(viewItem) }
+            return Action(icon: UIImage(named: "ic_download")!, title: title) { delegate?.save(viewItem) }
         }
 
         static func ban(_ viewItem: ConversationViewItem, _ delegate: ContextMenuActionDelegate?) -> Action {
             let title = "Ban User"
-            let tag = "banUser"
-            return Action(icon: UIImage(named: "ic_block")!, title: title, tag: tag) { delegate?.ban(viewItem) }
+            return Action(icon: UIImage(named: "ic_block")!, title: title) { delegate?.ban(viewItem) }
         }
         
         static func banAndDeleteAllMessages(_ viewItem: ConversationViewItem, _ delegate: ContextMenuActionDelegate?) -> Action {
             let title = "Ban and Delete All"
-            let tag = "banAndDeleteAll"
-            return Action(icon: UIImage(named: "ic_block")!, title: title, tag: tag) { delegate?.banAndDeleteAllMessages(viewItem) }
+            return Action(icon: UIImage(named: "ic_block")!, title: title) { delegate?.banAndDeleteAllMessages(viewItem) }
         }
-    }
-    
-    static func deleteActions(for viewItem: ConversationViewItem, delegate: ContextMenuActionDelegate?) -> [Action] {
-        switch viewItem.interaction.interactionType() {
-        case .outgoingMessage:
-            if let message = viewItem.interaction as? TSMessage, let _ = message.serverHash {
-                return [Action.deleteForEveryone(viewItem, delegate), Action.deleteLocally(viewItem, delegate)]
-            }
-            return [Action.deleteLocally(viewItem, delegate)]
-        case .incomingMessage:
-            return [Action.deleteLocally(viewItem, delegate)]
-        default: return [] // Should never occur
-        }
-        
     }
 
     static func actions(for viewItem: ConversationViewItem, delegate: ContextMenuActionDelegate?) -> [Action] {
@@ -119,14 +82,12 @@ extension ContextMenuVC {
 }
 
 // MARK: Delegate
-protocol ContextMenuActionDelegate : class {
+protocol ContextMenuActionDelegate : AnyObject {
     
     func reply(_ viewItem: ConversationViewItem)
     func copy(_ viewItem: ConversationViewItem)
     func copySessionID(_ viewItem: ConversationViewItem)
     func delete(_ viewItem: ConversationViewItem)
-    func deleteLocally(_ viewItem: ConversationViewItem)
-    func deleteForEveryone(_ viewItem: ConversationViewItem)
     func save(_ viewItem: ConversationViewItem)
     func ban(_ viewItem: ConversationViewItem)
     func banAndDeleteAllMessages(_ viewItem: ConversationViewItem)

--- a/Session/Conversations/Context Menu/ContextMenuVC+Action.swift
+++ b/Session/Conversations/Context Menu/ContextMenuVC+Action.swift
@@ -7,37 +7,37 @@ extension ContextMenuVC {
         let work: () -> Void
 
         static func reply(_ viewItem: ConversationViewItem, _ delegate: ContextMenuActionDelegate?) -> Action {
-            let title = "Reply"
+            let title = NSLocalizedString("context_menu_reply", comment: "")
             return Action(icon: UIImage(named: "ic_reply")!, title: title) { delegate?.reply(viewItem) }
         }
 
         static func copy(_ viewItem: ConversationViewItem, _ delegate: ContextMenuActionDelegate?) -> Action {
-            let title = "Copy"
+            let title = NSLocalizedString("copy", comment: "")
             return Action(icon: UIImage(named: "ic_copy")!, title: title) { delegate?.copy(viewItem) }
         }
 
         static func copySessionID(_ viewItem: ConversationViewItem, _ delegate: ContextMenuActionDelegate?) -> Action {
-            let title = "Copy Session ID"
+            let title = NSLocalizedString("vc_conversation_settings_copy_session_id_button_title", comment: "")
             return Action(icon: UIImage(named: "ic_copy")!, title: title) { delegate?.copySessionID(viewItem) }
         }
 
         static func delete(_ viewItem: ConversationViewItem, _ delegate: ContextMenuActionDelegate?) -> Action {
-            let title = "Delete"
+            let title = NSLocalizedString("TXT_DELETE_TITLE", comment: "")
             return Action(icon: UIImage(named: "ic_trash")!, title: title) { delegate?.delete(viewItem) }
         }
 
         static func save(_ viewItem: ConversationViewItem, _ delegate: ContextMenuActionDelegate?) -> Action {
-            let title = "Save"
+            let title = NSLocalizedString("context_menu_save", comment: "")
             return Action(icon: UIImage(named: "ic_download")!, title: title) { delegate?.save(viewItem) }
         }
 
         static func ban(_ viewItem: ConversationViewItem, _ delegate: ContextMenuActionDelegate?) -> Action {
-            let title = "Ban User"
+            let title = NSLocalizedString("context_menu_ban_user", comment: "")
             return Action(icon: UIImage(named: "ic_block")!, title: title) { delegate?.ban(viewItem) }
         }
         
         static func banAndDeleteAllMessages(_ viewItem: ConversationViewItem, _ delegate: ContextMenuActionDelegate?) -> Action {
-            let title = "Ban and Delete All"
+            let title = NSLocalizedString("context_menu_ban_and_delete_all", comment: "")
             return Action(icon: UIImage(named: "ic_block")!, title: title) { delegate?.banAndDeleteAllMessages(viewItem) }
         }
     }

--- a/Session/Conversations/Context Menu/ContextMenuVC+Action.swift
+++ b/Session/Conversations/Context Menu/ContextMenuVC+Action.swift
@@ -66,7 +66,12 @@ extension ContextMenuVC {
     }
     
     static func deleteActions(for viewItem: ConversationViewItem, delegate: ContextMenuActionDelegate?) -> [Action] {
-        return [Action.deleteForEveryone(viewItem, delegate), Action.deleteLocally(viewItem, delegate)]
+        switch viewItem.interaction.interactionType() {
+        case .outgoingMessage: return [Action.deleteForEveryone(viewItem, delegate), Action.deleteLocally(viewItem, delegate)]
+        case .incomingMessage: return [Action.deleteLocally(viewItem, delegate)]
+        default: return [] // Should never occur
+        }
+        
     }
 
     static func actions(for viewItem: ConversationViewItem, delegate: ContextMenuActionDelegate?) -> [Action] {

--- a/Session/Conversations/Context Menu/ContextMenuVC+Action.swift
+++ b/Session/Conversations/Context Menu/ContextMenuVC+Action.swift
@@ -2,44 +2,71 @@
 extension ContextMenuVC {
 
     struct Action {
-        let icon: UIImage
+        let icon: UIImage?
         let title: String
+        let tag: String
         let work: () -> Void
 
         static func reply(_ viewItem: ConversationViewItem, _ delegate: ContextMenuActionDelegate?) -> Action {
             let title = "Reply"
-            return Action(icon: UIImage(named: "ic_reply")!, title: title) { delegate?.reply(viewItem) }
+            let tag = "reply"
+            return Action(icon: UIImage(named: "ic_reply")!, title: title, tag: tag) { delegate?.reply(viewItem) }
         }
 
         static func copy(_ viewItem: ConversationViewItem, _ delegate: ContextMenuActionDelegate?) -> Action {
             let title = "Copy"
-            return Action(icon: UIImage(named: "ic_copy")!, title: title) { delegate?.copy(viewItem) }
+            let tag = "copy"
+            return Action(icon: UIImage(named: "ic_copy")!, title: title, tag: tag) { delegate?.copy(viewItem) }
         }
 
         static func copySessionID(_ viewItem: ConversationViewItem, _ delegate: ContextMenuActionDelegate?) -> Action {
             let title = "Copy Session ID"
-            return Action(icon: UIImage(named: "ic_copy")!, title: title) { delegate?.copySessionID(viewItem) }
+            let tag = "copySessionID"
+            return Action(icon: UIImage(named: "ic_copy")!, title: title, tag: tag) { delegate?.copySessionID(viewItem) }
         }
 
         static func delete(_ viewItem: ConversationViewItem, _ delegate: ContextMenuActionDelegate?) -> Action {
             let title = "Delete"
-            return Action(icon: UIImage(named: "ic_trash")!, title: title) { delegate?.delete(viewItem) }
+            let tag = "delete"
+            return Action(icon: UIImage(named: "ic_trash")!, title: title, tag: tag) { delegate?.delete(viewItem) }
+        }
+        
+        static func deleteLocally(_ viewItem: ConversationViewItem, _ delegate: ContextMenuActionDelegate?) -> Action {
+            let title = "Delete for me"
+            let tag = "deleteforme"
+            return Action(icon: nil, title: title, tag: tag) { delegate?.deleteLocally(viewItem) }
+        }
+        
+        static func deleteForEveryone(_ viewItem: ConversationViewItem, _ delegate: ContextMenuActionDelegate?) -> Action {
+            let tag = "deleteforeveryone"
+            var title = "Delete for everyone"
+            if !viewItem.isGroupThread {
+                title = "Delete for me and \(viewItem.interaction.thread.name())"
+            }
+            return Action(icon: nil, title: title, tag: tag) { delegate?.deleteForEveryone(viewItem) }
         }
 
         static func save(_ viewItem: ConversationViewItem, _ delegate: ContextMenuActionDelegate?) -> Action {
             let title = "Save"
-            return Action(icon: UIImage(named: "ic_download")!, title: title) { delegate?.save(viewItem) }
+            let tag = "save"
+            return Action(icon: UIImage(named: "ic_download")!, title: title, tag: tag) { delegate?.save(viewItem) }
         }
 
         static func ban(_ viewItem: ConversationViewItem, _ delegate: ContextMenuActionDelegate?) -> Action {
             let title = "Ban User"
-            return Action(icon: UIImage(named: "ic_block")!, title: title) { delegate?.ban(viewItem) }
+            let tag = "banUser"
+            return Action(icon: UIImage(named: "ic_block")!, title: title, tag: tag) { delegate?.ban(viewItem) }
         }
         
         static func banAndDeleteAllMessages(_ viewItem: ConversationViewItem, _ delegate: ContextMenuActionDelegate?) -> Action {
             let title = "Ban and Delete All"
-            return Action(icon: UIImage(named: "ic_block")!, title: title) { delegate?.banAndDeleteAllMessages(viewItem) }
+            let tag = "banAndDeleteAll"
+            return Action(icon: UIImage(named: "ic_block")!, title: title, tag: tag) { delegate?.banAndDeleteAllMessages(viewItem) }
         }
+    }
+    
+    static func deleteActions(for viewItem: ConversationViewItem, delegate: ContextMenuActionDelegate?) -> [Action] {
+        return [Action.deleteForEveryone(viewItem, delegate), Action.deleteLocally(viewItem, delegate)]
     }
 
     static func actions(for viewItem: ConversationViewItem, delegate: ContextMenuActionDelegate?) -> [Action] {
@@ -88,6 +115,8 @@ protocol ContextMenuActionDelegate : class {
     func copy(_ viewItem: ConversationViewItem)
     func copySessionID(_ viewItem: ConversationViewItem)
     func delete(_ viewItem: ConversationViewItem)
+    func deleteLocally(_ viewItem: ConversationViewItem)
+    func deleteForEveryone(_ viewItem: ConversationViewItem)
     func save(_ viewItem: ConversationViewItem)
     func ban(_ viewItem: ConversationViewItem)
     func banAndDeleteAllMessages(_ viewItem: ConversationViewItem)

--- a/Session/Conversations/Context Menu/ContextMenuVC+Action.swift
+++ b/Session/Conversations/Context Menu/ContextMenuVC+Action.swift
@@ -67,8 +67,13 @@ extension ContextMenuVC {
     
     static func deleteActions(for viewItem: ConversationViewItem, delegate: ContextMenuActionDelegate?) -> [Action] {
         switch viewItem.interaction.interactionType() {
-        case .outgoingMessage: return [Action.deleteForEveryone(viewItem, delegate), Action.deleteLocally(viewItem, delegate)]
-        case .incomingMessage: return [Action.deleteLocally(viewItem, delegate)]
+        case .outgoingMessage:
+            if let message = viewItem.interaction as? TSMessage, let _ = message.serverHash {
+                return [Action.deleteForEveryone(viewItem, delegate), Action.deleteLocally(viewItem, delegate)]
+            }
+            return [Action.deleteLocally(viewItem, delegate)]
+        case .incomingMessage:
+            return [Action.deleteLocally(viewItem, delegate)]
         default: return [] // Should never occur
         }
         

--- a/Session/Conversations/Context Menu/ContextMenuVC+ActionView.swift
+++ b/Session/Conversations/Context Menu/ContextMenuVC+ActionView.swift
@@ -26,20 +26,25 @@ extension ContextMenuVC {
         }
 
         private func setUpViewHierarchy() {
+            var subviews: [UIView] = []
             // Icon
-            let iconSize = ActionView.iconSize
-            let iconImageView = UIImageView(image: action.icon.resizedImage(to: CGSize(width: iconSize, height: iconSize))!.withTint(Colors.text))
-            let iconImageViewSize = ActionView.iconImageViewSize
-            iconImageView.set(.width, to: iconImageViewSize)
-            iconImageView.set(.height, to: iconImageViewSize)
-            iconImageView.contentMode = .center
+            if let icon = action.icon {
+                let iconSize = ActionView.iconSize
+                let iconImageView = UIImageView(image: icon.resizedImage(to: CGSize(width: iconSize, height: iconSize))!.withTint(Colors.text))
+                let iconImageViewSize = ActionView.iconImageViewSize
+                iconImageView.set(.width, to: iconImageViewSize)
+                iconImageView.set(.height, to: iconImageViewSize)
+                iconImageView.contentMode = .center
+                subviews.append(iconImageView)
+            }
             // Title
             let titleLabel = UILabel()
             titleLabel.text = action.title
             titleLabel.textColor = Colors.text
             titleLabel.font = .systemFont(ofSize: Values.mediumFontSize)
+            subviews.append(titleLabel)
             // Stack view
-            let stackView = UIStackView(arrangedSubviews: [ iconImageView, titleLabel ])
+            let stackView = UIStackView(arrangedSubviews: subviews)
             stackView.axis = .horizontal
             stackView.spacing = Values.smallSpacing
             stackView.alignment = .center
@@ -56,6 +61,7 @@ extension ContextMenuVC {
         // MARK: Interaction
         @objc private func handleTap() {
             action.work()
+            guard action.tag != "delete" else { return }
             dismiss()
         }
     }

--- a/Session/Conversations/Context Menu/ContextMenuVC+ActionView.swift
+++ b/Session/Conversations/Context Menu/ContextMenuVC+ActionView.swift
@@ -26,25 +26,20 @@ extension ContextMenuVC {
         }
 
         private func setUpViewHierarchy() {
-            var subviews: [UIView] = []
             // Icon
-            if let icon = action.icon {
-                let iconSize = ActionView.iconSize
-                let iconImageView = UIImageView(image: icon.resizedImage(to: CGSize(width: iconSize, height: iconSize))!.withTint(Colors.text))
-                let iconImageViewSize = ActionView.iconImageViewSize
-                iconImageView.set(.width, to: iconImageViewSize)
-                iconImageView.set(.height, to: iconImageViewSize)
-                iconImageView.contentMode = .center
-                subviews.append(iconImageView)
-            }
+            let iconSize = ActionView.iconSize
+            let iconImageView = UIImageView(image: action.icon.resizedImage(to: CGSize(width: iconSize, height: iconSize))!.withTint(Colors.text))
+            let iconImageViewSize = ActionView.iconImageViewSize
+            iconImageView.set(.width, to: iconImageViewSize)
+            iconImageView.set(.height, to: iconImageViewSize)
+            iconImageView.contentMode = .center
             // Title
             let titleLabel = UILabel()
             titleLabel.text = action.title
             titleLabel.textColor = Colors.text
             titleLabel.font = .systemFont(ofSize: Values.mediumFontSize)
-            subviews.append(titleLabel)
             // Stack view
-            let stackView = UIStackView(arrangedSubviews: subviews)
+            let stackView = UIStackView(arrangedSubviews: [ iconImageView, titleLabel ])
             stackView.axis = .horizontal
             stackView.spacing = Values.smallSpacing
             stackView.alignment = .center
@@ -61,7 +56,6 @@ extension ContextMenuVC {
         // MARK: Interaction
         @objc private func handleTap() {
             action.work()
-            guard action.tag != "delete" else { return }
             dismiss()
         }
     }

--- a/Session/Conversations/Context Menu/ContextMenuVC.swift
+++ b/Session/Conversations/Context Menu/ContextMenuVC.swift
@@ -108,7 +108,7 @@ final class ContextMenuVC : UIViewController {
     }
     
     func updateMenu(forDelete: Bool = false) -> CGFloat {
-        // Menu
+        // Menu: return the menuHeight
         menuView.subviews.forEach({ $0.removeFromSuperview() })
         let menuBackgroundView = UIView()
         menuBackgroundView.backgroundColor = Colors.receivedMessageBackground

--- a/Session/Conversations/Context Menu/ContextMenuVC.swift
+++ b/Session/Conversations/Context Menu/ContextMenuVC.swift
@@ -75,7 +75,19 @@ final class ContextMenuVC : UIViewController {
         } else {
             timestampLabel.pin(.left, to: .right, of: snapshot, withInset: Values.smallSpacing)
         }
-        self.updateMenu()
+        let menuHeight = self.updateMenu()
+        let spacing = Values.smallSpacing
+        let margin = max(UIApplication.shared.keyWindow!.safeAreaInsets.bottom, Values.mediumSpacing)
+        if frame.maxY + spacing + menuHeight > UIScreen.main.bounds.height - margin {
+            menuView.pin(.bottom, to: .top, of: snapshot, withInset: -spacing)
+        } else {
+            menuView.pin(.top, to: .bottom, of: snapshot, withInset: spacing)
+        }
+        switch viewItem.interaction.interactionType() {
+        case .outgoingMessage: menuView.pin(.right, to: .right, of: snapshot)
+        case .incomingMessage: menuView.pin(.left, to: .left, of: snapshot)
+        default: break // Should never occur
+        }
         // Tap gesture
         let mainTapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTap))
         view.addGestureRecognizer(mainTapGestureRecognizer)
@@ -95,7 +107,7 @@ final class ContextMenuVC : UIViewController {
         menuView.layer.shadowPath = UIBezierPath(roundedRect: menuView.bounds, cornerRadius: ContextMenuVC.menuCornerRadius).cgPath
     }
     
-    func updateMenu(forDelete: Bool = false) {
+    func updateMenu(forDelete: Bool = false) -> CGFloat {
         // Menu
         menuView.subviews.forEach({ $0.removeFromSuperview() })
         let menuBackgroundView = UIView()
@@ -111,19 +123,7 @@ final class ContextMenuVC : UIViewController {
         menuView.addSubview(menuStackView)
         menuStackView.pin(to: menuView)
         view.addSubview(menuView)
-        let menuHeight = CGFloat(actionViews.count) * ContextMenuVC.actionViewHeight
-        let spacing = Values.smallSpacing
-        let margin = max(UIApplication.shared.keyWindow!.safeAreaInsets.bottom, Values.mediumSpacing)
-        if frame.maxY + spacing + menuHeight > UIScreen.main.bounds.height - margin {
-            menuView.pin(.bottom, to: .top, of: snapshot, withInset: -spacing)
-        } else {
-            menuView.pin(.top, to: .bottom, of: snapshot, withInset: spacing)
-        }
-        switch viewItem.interaction.interactionType() {
-        case .outgoingMessage: menuView.pin(.right, to: .right, of: snapshot)
-        case .incomingMessage: menuView.pin(.left, to: .left, of: snapshot)
-        default: break // Should never occur
-        }
+        return CGFloat(actionViews.count) * ContextMenuVC.actionViewHeight
     }
 
     // MARK: Interaction

--- a/Session/Conversations/Context Menu/ContextMenuVC.swift
+++ b/Session/Conversations/Context Menu/ContextMenuVC.swift
@@ -75,7 +75,20 @@ final class ContextMenuVC : UIViewController {
         } else {
             timestampLabel.pin(.left, to: .right, of: snapshot, withInset: Values.smallSpacing)
         }
-        let menuHeight = self.updateMenu()
+        // Menu
+        let menuBackgroundView = UIView()
+        menuBackgroundView.backgroundColor = Colors.receivedMessageBackground
+        menuBackgroundView.layer.cornerRadius = ContextMenuVC.menuCornerRadius
+        menuBackgroundView.layer.masksToBounds = true
+        menuView.addSubview(menuBackgroundView)
+        menuBackgroundView.pin(to: menuView)
+        let actionViews = ContextMenuVC.actions(for: viewItem, delegate: delegate).map { ActionView(for: $0, dismiss: snDismiss) }
+        let menuStackView = UIStackView(arrangedSubviews: actionViews)
+        menuStackView.axis = .vertical
+        menuView.addSubview(menuStackView)
+        menuStackView.pin(to: menuView)
+        view.addSubview(menuView)
+        let menuHeight = CGFloat(actionViews.count) * ContextMenuVC.actionViewHeight
         let spacing = Values.smallSpacing
         let margin = max(UIApplication.shared.keyWindow!.safeAreaInsets.bottom, Values.mediumSpacing)
         if frame.maxY + spacing + menuHeight > UIScreen.main.bounds.height - margin {
@@ -105,25 +118,6 @@ final class ContextMenuVC : UIViewController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         menuView.layer.shadowPath = UIBezierPath(roundedRect: menuView.bounds, cornerRadius: ContextMenuVC.menuCornerRadius).cgPath
-    }
-    
-    func updateMenu(forDelete: Bool = false) -> CGFloat {
-        // Menu: return the menuHeight
-        menuView.subviews.forEach({ $0.removeFromSuperview() })
-        let menuBackgroundView = UIView()
-        menuBackgroundView.backgroundColor = Colors.receivedMessageBackground
-        menuBackgroundView.layer.cornerRadius = ContextMenuVC.menuCornerRadius
-        menuBackgroundView.layer.masksToBounds = true
-        menuView.addSubview(menuBackgroundView)
-        menuBackgroundView.pin(to: menuView)
-        let actions = forDelete ? ContextMenuVC.deleteActions(for: viewItem, delegate: delegate) : ContextMenuVC.actions(for: viewItem, delegate: delegate)
-        let actionViews = actions.map { ActionView(for: $0, dismiss: snDismiss) }
-        let menuStackView = UIStackView(arrangedSubviews: actionViews)
-        menuStackView.axis = .vertical
-        menuView.addSubview(menuStackView)
-        menuStackView.pin(to: menuView)
-        view.addSubview(menuView)
-        return CGFloat(actionViews.count) * ContextMenuVC.actionViewHeight
     }
 
     // MARK: Interaction

--- a/Session/Conversations/Context Menu/ContextMenuVC.swift
+++ b/Session/Conversations/Context Menu/ContextMenuVC.swift
@@ -75,14 +75,37 @@ final class ContextMenuVC : UIViewController {
         } else {
             timestampLabel.pin(.left, to: .right, of: snapshot, withInset: Values.smallSpacing)
         }
+        self.updateMenu()
+        // Tap gesture
+        let mainTapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTap))
+        view.addGestureRecognizer(mainTapGestureRecognizer)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        UIView.animate(withDuration: 0.25) {
+            self.blurView.effect = UIBlurEffect(style: .regular)
+            self.menuView.alpha = 1
+        }
+    }
+
+    // MARK: Updating
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        menuView.layer.shadowPath = UIBezierPath(roundedRect: menuView.bounds, cornerRadius: ContextMenuVC.menuCornerRadius).cgPath
+    }
+    
+    func updateMenu(forDelete: Bool = false) {
         // Menu
+        menuView.subviews.forEach({ $0.removeFromSuperview() })
         let menuBackgroundView = UIView()
         menuBackgroundView.backgroundColor = Colors.receivedMessageBackground
         menuBackgroundView.layer.cornerRadius = ContextMenuVC.menuCornerRadius
         menuBackgroundView.layer.masksToBounds = true
         menuView.addSubview(menuBackgroundView)
         menuBackgroundView.pin(to: menuView)
-        let actionViews = ContextMenuVC.actions(for: viewItem, delegate: delegate).map { ActionView(for: $0, dismiss: snDismiss) }
+        let actions = forDelete ? ContextMenuVC.deleteActions(for: viewItem, delegate: delegate) : ContextMenuVC.actions(for: viewItem, delegate: delegate)
+        let actionViews = actions.map { ActionView(for: $0, dismiss: snDismiss) }
         let menuStackView = UIStackView(arrangedSubviews: actionViews)
         menuStackView.axis = .vertical
         menuView.addSubview(menuStackView)
@@ -101,23 +124,6 @@ final class ContextMenuVC : UIViewController {
         case .incomingMessage: menuView.pin(.left, to: .left, of: snapshot)
         default: break // Should never occur
         }
-        // Tap gesture
-        let mainTapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTap))
-        view.addGestureRecognizer(mainTapGestureRecognizer)
-    }
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        UIView.animate(withDuration: 0.25) {
-            self.blurView.effect = UIBlurEffect(style: .regular)
-            self.menuView.alpha = 1
-        }
-    }
-
-    // MARK: Updating
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        menuView.layer.shadowPath = UIBezierPath(roundedRect: menuView.bounds, cornerRadius: ContextMenuVC.menuCornerRadius).cgPath
     }
 
     // MARK: Interaction

--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -555,6 +555,10 @@ extension ConversationVC : InputViewDelegate, MessageCellDelegate, ContextMenuAc
     }
     
     func delete(_ viewItem: ConversationViewItem) {
+        if (!self.isUnsendRequesEnabled) {
+            viewItem.deleteAction()
+            return
+        }
         
         func showInputAccessoryView() {
             UIView.animate(withDuration: 0.25, animations: {

--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -567,7 +567,8 @@ extension ConversationVC : InputViewDelegate, MessageCellDelegate, ContextMenuAc
             })
         }
         
-        if viewItem.interaction.interactionType() == .outgoingMessage {
+        if viewItem.interaction.interactionType() == .outgoingMessage,
+           let message = viewItem.interaction as? TSMessage, message.serverHash != nil  {
             let alertVC = UIAlertController.init(title: nil, message: nil, preferredStyle: .actionSheet)
             let deleteLocallyAction = UIAlertAction.init(title: NSLocalizedString("delete_message_for_me", comment: ""), style: .destructive) { _ in
                 self.deleteLocally(viewItem)
@@ -599,7 +600,8 @@ extension ConversationVC : InputViewDelegate, MessageCellDelegate, ContextMenuAc
     }
     
     private func buildUsendRequest(_ viewItem: ConversationViewItem) -> UnsendRequest? {
-        if let message = viewItem.interaction as? TSMessage, message.isOpenGroupMessage { return nil } 
+        if let message = viewItem.interaction as? TSMessage,
+           message.isOpenGroupMessage || message.serverHash == nil { return nil }
         let unsendRequest = UnsendRequest()
         switch viewItem.interaction.interactionType() {
         case .incomingMessage:

--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -365,7 +365,6 @@ extension ConversationVC : InputViewDelegate, MessageCellDelegate, ContextMenuAc
         // Show the context menu if applicable
         guard let index = viewItems.firstIndex(where: { $0 === viewItem }),
             let cell = messagesTableView.cellForRow(at: IndexPath(row: index, section: 0)) as? VisibleMessageCell,
-            let message = viewItem.interaction as? TSMessage, !message.isDeleted,
             let snapshot = cell.bubbleView.snapshotView(afterScreenUpdates: false), contextMenuWindow == nil,
             !ContextMenuVC.actions(for: viewItem, delegate: self).isEmpty else { return }
         UIImpactFeedbackGenerator(style: .heavy).impactOccurred()

--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -546,7 +546,22 @@ extension ConversationVC : InputViewDelegate, MessageCellDelegate, ContextMenuAc
     }
     
     func delete(_ viewItem: ConversationViewItem) {
-        let _ = self.contextMenuVC?.updateMenu(forDelete: true)
+        let alertVC = UIAlertController.init(title: nil, message: nil, preferredStyle: .actionSheet)
+        let deleteLocallyAction = UIAlertAction.init(title: "Delete just for me", style: .destructive) { _ in
+            self.deleteLocally(viewItem)
+        }
+        var title = "Delete for everyone"
+        if !viewItem.isGroupThread {
+            title = "Delete for me and \(viewItem.interaction.thread.name())"
+        }
+        let deleteRemotelyAction = UIAlertAction.init(title: title, style: .destructive) { _ in
+            self.deleteForEveryone(viewItem)
+        }
+        let cancelAction = UIAlertAction.init(title: "Cancel", style: .cancel, handler: nil)
+        alertVC.addAction(deleteLocallyAction)
+        alertVC.addAction(deleteRemotelyAction)
+        alertVC.addAction(cancelAction)
+        self.navigationController?.presentAlert(alertVC)
     }
     
     private func buildUsendRequest(_ viewItem: ConversationViewItem) -> UnsendRequest? {

--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -546,7 +546,15 @@ extension ConversationVC : InputViewDelegate, MessageCellDelegate, ContextMenuAc
     }
     
     func delete(_ viewItem: ConversationViewItem) {
-        viewItem.deleteAction()
+        self.contextMenuVC?.updateMenu(forDelete: true)
+    }
+    
+    func deleteLocally(_ viewItem: ConversationViewItem) {
+        // TODO: delete locally
+    }
+    
+    func deleteForEveryone(_ viewItem: ConversationViewItem) {
+        // TODO: delete for everyone
     }
     
     func save(_ viewItem: ConversationViewItem) {

--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -599,6 +599,7 @@ extension ConversationVC : InputViewDelegate, MessageCellDelegate, ContextMenuAc
     }
     
     private func buildUsendRequest(_ viewItem: ConversationViewItem) -> UnsendRequest? {
+        if let message = viewItem.interaction as? TSMessage, message.isOpenGroupMessage { return nil } 
         let unsendRequest = UnsendRequest()
         switch viewItem.interaction.interactionType() {
         case .incomingMessage:

--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -546,22 +546,28 @@ extension ConversationVC : InputViewDelegate, MessageCellDelegate, ContextMenuAc
     }
     
     func delete(_ viewItem: ConversationViewItem) {
-        let alertVC = UIAlertController.init(title: nil, message: nil, preferredStyle: .actionSheet)
-        let deleteLocallyAction = UIAlertAction.init(title: "Delete just for me", style: .destructive) { _ in
-            self.deleteLocally(viewItem)
+        if viewItem.interaction.interactionType() == .outgoingMessage {
+            let alertVC = UIAlertController.init(title: nil, message: nil, preferredStyle: .actionSheet)
+            let deleteLocallyAction = UIAlertAction.init(title: "Delete just for me", style: .destructive) { _ in
+                self.deleteLocally(viewItem)
+            }
+            alertVC.addAction(deleteLocallyAction)
+            
+            var title = "Delete for everyone"
+            if !viewItem.isGroupThread {
+                title = "Delete for me and \(viewItem.interaction.thread.name())"
+            }
+            let deleteRemotelyAction = UIAlertAction.init(title: title, style: .destructive) { _ in
+                self.deleteForEveryone(viewItem)
+            }
+            alertVC.addAction(deleteRemotelyAction)
+            
+            let cancelAction = UIAlertAction.init(title: "Cancel", style: .cancel, handler: nil)
+            alertVC.addAction(cancelAction)
+            self.navigationController?.presentAlert(alertVC)
+        } else {
+            deleteLocally(viewItem)
         }
-        var title = "Delete for everyone"
-        if !viewItem.isGroupThread {
-            title = "Delete for me and \(viewItem.interaction.thread.name())"
-        }
-        let deleteRemotelyAction = UIAlertAction.init(title: title, style: .destructive) { _ in
-            self.deleteForEveryone(viewItem)
-        }
-        let cancelAction = UIAlertAction.init(title: "Cancel", style: .cancel, handler: nil)
-        alertVC.addAction(deleteLocallyAction)
-        alertVC.addAction(deleteRemotelyAction)
-        alertVC.addAction(cancelAction)
-        self.navigationController?.presentAlert(alertVC)
     }
     
     private func buildUsendRequest(_ viewItem: ConversationViewItem) -> UnsendRequest? {

--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -548,21 +548,21 @@ extension ConversationVC : InputViewDelegate, MessageCellDelegate, ContextMenuAc
     func delete(_ viewItem: ConversationViewItem) {
         if viewItem.interaction.interactionType() == .outgoingMessage {
             let alertVC = UIAlertController.init(title: nil, message: nil, preferredStyle: .actionSheet)
-            let deleteLocallyAction = UIAlertAction.init(title: "Delete just for me", style: .destructive) { _ in
+            let deleteLocallyAction = UIAlertAction.init(title: NSLocalizedString("delete_message_for_me", comment: ""), style: .destructive) { _ in
                 self.deleteLocally(viewItem)
             }
             alertVC.addAction(deleteLocallyAction)
             
-            var title = "Delete for everyone"
+            var title = NSLocalizedString("delete_message_for_everyone", comment: "")
             if !viewItem.isGroupThread {
-                title = "Delete for me and \(viewItem.interaction.thread.name())"
+                title = String(format: NSLocalizedString("delete_message_for_me_and_recipient", comment: ""), viewItem.interaction.thread.name())
             }
             let deleteRemotelyAction = UIAlertAction.init(title: title, style: .destructive) { _ in
                 self.deleteForEveryone(viewItem)
             }
             alertVC.addAction(deleteRemotelyAction)
             
-            let cancelAction = UIAlertAction.init(title: "Cancel", style: .cancel, handler: nil)
+            let cancelAction = UIAlertAction.init(title: NSLocalizedString("TXT_CANCEL_TITLE", comment: ""), style: .cancel, handler: nil)
             alertVC.addAction(cancelAction)
             self.navigationController?.presentAlert(alertVC)
         } else {

--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -546,10 +546,19 @@ extension ConversationVC : InputViewDelegate, MessageCellDelegate, ContextMenuAc
     }
     
     func delete(_ viewItem: ConversationViewItem) {
+        
+        func showInputAccessoryView() {
+            UIView.animate(withDuration: 0.25, animations: {
+                self.inputAccessoryView?.isHidden = false
+                self.inputAccessoryView?.alpha = 1
+            })
+        }
+        
         if viewItem.interaction.interactionType() == .outgoingMessage {
             let alertVC = UIAlertController.init(title: nil, message: nil, preferredStyle: .actionSheet)
             let deleteLocallyAction = UIAlertAction.init(title: NSLocalizedString("delete_message_for_me", comment: ""), style: .destructive) { _ in
                 self.deleteLocally(viewItem)
+                showInputAccessoryView()
             }
             alertVC.addAction(deleteLocallyAction)
             
@@ -559,12 +568,18 @@ extension ConversationVC : InputViewDelegate, MessageCellDelegate, ContextMenuAc
             }
             let deleteRemotelyAction = UIAlertAction.init(title: title, style: .destructive) { _ in
                 self.deleteForEveryone(viewItem)
+                showInputAccessoryView()
             }
             alertVC.addAction(deleteRemotelyAction)
             
-            let cancelAction = UIAlertAction.init(title: NSLocalizedString("TXT_CANCEL_TITLE", comment: ""), style: .cancel, handler: nil)
+            let cancelAction = UIAlertAction.init(title: NSLocalizedString("TXT_CANCEL_TITLE", comment: ""), style: .cancel) {_ in
+                showInputAccessoryView()
+            }
             alertVC.addAction(cancelAction)
-            self.navigationController?.presentAlert(alertVC)
+            
+            self.inputAccessoryView?.isHidden = true
+            self.inputAccessoryView?.alpha = 0
+            self.presentAlert(alertVC)
         } else {
             deleteLocally(viewItem)
         }

--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -551,11 +551,6 @@ extension ConversationVC : InputViewDelegate, MessageCellDelegate, ContextMenuAc
     
     func deleteLocally(_ viewItem: ConversationViewItem) {
         viewItem.deleteLocallyAction()
-    }
-    
-    func deleteForEveryone(_ viewItem: ConversationViewItem) {
-        viewItem.deleteLocallyAction()
-        viewItem.deleteRemotelyAction()
         let unsendRequest = UnsendRequest()
         switch viewItem.interaction.interactionType() {
         case .incomingMessage:
@@ -569,6 +564,11 @@ extension ConversationVC : InputViewDelegate, MessageCellDelegate, ContextMenuAc
         SNMessagingKitConfiguration.shared.storage.write { transaction in
             MessageSender.send(unsendRequest, in: self.thread, using: transaction as! YapDatabaseReadWriteTransaction)
         }
+    }
+    
+    func deleteForEveryone(_ viewItem: ConversationViewItem) {
+        viewItem.deleteRemotelyAction()
+        deleteLocally(viewItem)
     }
     
     func save(_ viewItem: ConversationViewItem) {

--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -365,6 +365,7 @@ extension ConversationVC : InputViewDelegate, MessageCellDelegate, ContextMenuAc
         // Show the context menu if applicable
         guard let index = viewItems.firstIndex(where: { $0 === viewItem }),
             let cell = messagesTableView.cellForRow(at: IndexPath(row: index, section: 0)) as? VisibleMessageCell,
+            let message = viewItem.interaction as? TSMessage, !message.isDeleted,
             let snapshot = cell.bubbleView.snapshotView(afterScreenUpdates: false), contextMenuWindow == nil,
             !ContextMenuVC.actions(for: viewItem, delegate: self).isEmpty else { return }
         UIImpactFeedbackGenerator(style: .heavy).impactOccurred()

--- a/Session/Conversations/ConversationVC.swift
+++ b/Session/Conversations/ConversationVC.swift
@@ -4,7 +4,8 @@
 // • Photo rounding (the small corners don't have the correct rounding)
 // • Remaining search glitchiness
 
-final class ConversationVC : BaseVC, ConversationViewModelDelegate, OWSConversationSettingsViewDelegate, ConversationSearchControllerDelegate, UITableViewDataSource, UITableViewDelegate {
+final class ConversationVC : BaseVC, ConversationViewModelDelegate, OWSConversationSettingsViewDelegate, ConversationSearchControllerDelegate, UITableViewDataSource, UITableViewDelegate {    
+    let isUnsendRequesEnabled = false // Switch this to true if unsend request is done on all platforms
     let thread: TSThread
     let focusedMessageID: String? // This isn't actually used ATM
     var unreadViewItems: [ConversationViewItem] = []

--- a/Session/Conversations/ConversationVC.swift
+++ b/Session/Conversations/ConversationVC.swift
@@ -488,7 +488,7 @@ final class ConversationVC : BaseVC, ConversationViewModelDelegate, OWSConversat
     }
     
     func updateUnreadCountView() {
-        let visibleViewItems = (messagesTableView.indexPathsForVisibleRows ?? []).map { viewItems[$0.row] }
+        let visibleViewItems = (messagesTableView.indexPathsForVisibleRows ?? []).map { viewItems[ifValid: $0.row] }
         for visibleItem in visibleViewItems {
             guard let index = unreadViewItems.firstIndex(where: { $0 === visibleItem }) else { continue }
             unreadViewItems.remove(at: index)

--- a/Session/Conversations/ConversationViewItem.h
+++ b/Session/Conversations/ConversationViewItem.h
@@ -136,6 +136,8 @@ NSString *NSStringForOWSMessageCellType(OWSMessageCellType cellType);
 - (void)deleteLocallyAction;
 - (void)deleteRemotelyAction;
 
+- (void)deleteAction; // Remove this after the unsend request is enabled
+
 - (BOOL)canCopyMedia;
 - (BOOL)canSaveMedia;
 

--- a/Session/Conversations/ConversationViewItem.h
+++ b/Session/Conversations/ConversationViewItem.h
@@ -132,7 +132,8 @@ NSString *NSStringForOWSMessageCellType(OWSMessageCellType cellType);
 - (void)copyTextAction;
 - (void)shareMediaAction;
 - (void)saveMediaAction;
-- (void)deleteAction;
+- (void)deleteLocallyAction;
+- (void)deleteRemotelyAction;
 
 - (BOOL)canCopyMedia;
 - (BOOL)canSaveMedia;

--- a/Session/Conversations/ConversationViewItem.h
+++ b/Session/Conversations/ConversationViewItem.h
@@ -15,6 +15,7 @@ typedef NS_ENUM(NSInteger, OWSMessageCellType) {
     OWSMessageCellType_GenericAttachment,
     OWSMessageCellType_MediaMessage,
     OWSMessageCellType_OversizeTextDownloading,
+    OWSMessageCellType_DeletedMessage
 };
 
 NSString *NSStringForOWSMessageCellType(OWSMessageCellType cellType);

--- a/Session/Conversations/ConversationViewItem.m
+++ b/Session/Conversations/ConversationViewItem.m
@@ -1010,11 +1010,17 @@ NSString *NSStringForOWSMessageCellType(OWSMessageCellType cellType)
             }) retainUntilComplete];
         } else {
             NSString *groupPublicKey = [LKGroupUtilities getDecodedGroupID:groupThread.groupModel.groupId];
-            [SNSnodeAPI deleteMessageForPublickKey:groupPublicKey serverHash:message.serverHash];
+            [[SNSnodeAPI deleteMessageForPublickKey:groupPublicKey serverHashes:@[message.serverHash]].catch(^(NSError *error) {
+                // Roll back
+                [self.interaction save];
+            }) retainUntilComplete];
         }
     } else {
         TSContactThread *contactThread = (TSContactThread *)self.interaction.thread;
-        [SNSnodeAPI deleteMessageForPublickKey:contactThread.contactSessionID serverHash:message.serverHash];
+        [[SNSnodeAPI deleteMessageForPublickKey:contactThread.contactSessionID serverHashes:@[message.serverHash]].catch(^(NSError *error) {
+            // Roll back
+            [self.interaction save];
+        }) retainUntilComplete];
     }
     
 }

--- a/Session/Conversations/ConversationViewItem.m
+++ b/Session/Conversations/ConversationViewItem.m
@@ -979,6 +979,7 @@ NSString *NSStringForOWSMessageCellType(OWSMessageCellType cellType)
 
 - (void)deleteRemotelyAction
 {
+    // TODO: closed group and one-on-one chat
     TSMessage *message = (TSMessage *)self.interaction;
     
     if (self.isGroupThread) {
@@ -1009,22 +1010,14 @@ NSString *NSStringForOWSMessageCellType(OWSMessageCellType cellType)
             }) retainUntilComplete];
         } else {
             NSString *groupPublicKey = [LKGroupUtilities getDecodedGroupID:groupThread.groupModel.groupId];
-            NSArray *serverHashes = @[message.serverHash];
-            if ([message isKindOfClass:[TSOutgoingMessage class]] && ((TSOutgoingMessage *)message).syncMessageServerHash != nil) {
-                serverHashes = @[message.serverHash, ((TSOutgoingMessage *)message).syncMessageServerHash];
-            }
-            [[SNSnodeAPI deleteMessageForPublickKey:groupPublicKey serverHashes:serverHashes].catch(^(NSError *error) {
+            [[SNSnodeAPI deleteMessageForPublickKey:groupPublicKey serverHashes:@[message.serverHash]].catch(^(NSError *error) {
                 // Roll back
                 [self.interaction save];
             }) retainUntilComplete];
         }
     } else {
         TSContactThread *contactThread = (TSContactThread *)self.interaction.thread;
-        NSArray *serverHashes = @[message.serverHash];
-        if ([message isKindOfClass:[TSOutgoingMessage class]] && ((TSOutgoingMessage *)message).syncMessageServerHash != nil) {
-            serverHashes = @[message.serverHash, ((TSOutgoingMessage *)message).syncMessageServerHash];
-        }
-        [[SNSnodeAPI deleteMessageForPublickKey:contactThread.contactSessionID serverHashes:serverHashes].catch(^(NSError *error) {
+        [[SNSnodeAPI deleteMessageForPublickKey:contactThread.contactSessionID serverHashes:@[message.serverHash]].catch(^(NSError *error) {
             // Roll back
             [self.interaction save];
         }) retainUntilComplete];

--- a/Session/Conversations/ConversationViewItem.m
+++ b/Session/Conversations/ConversationViewItem.m
@@ -979,7 +979,6 @@ NSString *NSStringForOWSMessageCellType(OWSMessageCellType cellType)
 
 - (void)deleteRemotelyAction
 {
-    // TODO: closed group and one-on-one chat
     TSMessage *message = (TSMessage *)self.interaction;
     
     if (self.isGroupThread) {
@@ -1010,14 +1009,22 @@ NSString *NSStringForOWSMessageCellType(OWSMessageCellType cellType)
             }) retainUntilComplete];
         } else {
             NSString *groupPublicKey = [LKGroupUtilities getDecodedGroupID:groupThread.groupModel.groupId];
-            [[SNSnodeAPI deleteMessageForPublickKey:groupPublicKey serverHashes:@[message.serverHash]].catch(^(NSError *error) {
+            NSArray *serverHashes = @[message.serverHash];
+            if ([message isKindOfClass:[TSOutgoingMessage class]] && ((TSOutgoingMessage *)message).syncMessageServerHash != nil) {
+                serverHashes = @[message.serverHash, ((TSOutgoingMessage *)message).syncMessageServerHash];
+            }
+            [[SNSnodeAPI deleteMessageForPublickKey:groupPublicKey serverHashes:serverHashes].catch(^(NSError *error) {
                 // Roll back
                 [self.interaction save];
             }) retainUntilComplete];
         }
     } else {
         TSContactThread *contactThread = (TSContactThread *)self.interaction.thread;
-        [[SNSnodeAPI deleteMessageForPublickKey:contactThread.contactSessionID serverHashes:@[message.serverHash]].catch(^(NSError *error) {
+        NSArray *serverHashes = @[message.serverHash];
+        if ([message isKindOfClass:[TSOutgoingMessage class]] && ((TSOutgoingMessage *)message).syncMessageServerHash != nil) {
+            serverHashes = @[message.serverHash, ((TSOutgoingMessage *)message).syncMessageServerHash];
+        }
+        [[SNSnodeAPI deleteMessageForPublickKey:contactThread.contactSessionID serverHashes:serverHashes].catch(^(NSError *error) {
             // Roll back
             [self.interaction save];
         }) retainUntilComplete];

--- a/Session/Conversations/ConversationViewItem.m
+++ b/Session/Conversations/ConversationViewItem.m
@@ -470,6 +470,11 @@ NSString *NSStringForOWSMessageCellType(OWSMessageCellType cellType)
     self.hasViewState = YES;
 
     TSMessage *message = (TSMessage *)self.interaction;
+    
+    if (message.isDeleted) {
+        self.messageCellType = OWSMessageCellType_DeletedMessage;
+        return;
+    }
 
     // Check for quoted replies _before_ media album handling,
     // since that logic may exit early.

--- a/Session/Conversations/ConversationViewItem.m
+++ b/Session/Conversations/ConversationViewItem.m
@@ -974,7 +974,9 @@ NSString *NSStringForOWSMessageCellType(OWSMessageCellType cellType)
 
 - (void)deleteLocallyAction
 {
+    TSMessage *message = (TSMessage *)self.interaction;
     [LKStorage writeWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+        [MessageInvalidator invalidate:message with:transaction];
         [self.interaction removeWithTransaction:transaction];
         if (self.interaction.interactionType == OWSInteractionType_OutgoingMessage) {
             [LKStorage.shared cancelPendingMessageSendJobIfNeededForMessage:self.interaction.timestamp using:transaction];
@@ -984,7 +986,6 @@ NSString *NSStringForOWSMessageCellType(OWSMessageCellType cellType)
 
 - (void)deleteRemotelyAction
 {
-    // TODO: closed group and one-on-one chat
     TSMessage *message = (TSMessage *)self.interaction;
     
     if (self.isGroupThread) {

--- a/Session/Conversations/ConversationViewModel.m
+++ b/Session/Conversations/ConversationViewModel.m
@@ -830,6 +830,17 @@ NS_ASSUME_NONNULL_BEGIN
                 [updatedNeighborItemSet addObject:itemId];
             }
         }
+        
+        // Add the following item of a deleted message to update
+        // to show the date header of the deleted message if needed
+        for (NSString *deletedItemId in deletedItemIdSet) {
+            NSUInteger oldIndex = [oldItemIdList indexOfObject:deletedItemId];
+            id<ConversationViewItem> _Nullable nextItemId = (oldIndex + 1 < oldItemIdList.count ? oldItemIdList[oldIndex + 1] : nil);
+            if (nextItemId != nil) {
+                [updatedItemSet addObject:nextItemId];
+                [updatedNeighborItemSet addObject:nextItemId];
+            }
+        }
     }
 
     // 3. Updates.

--- a/Session/Conversations/ConversationViewModel.m
+++ b/Session/Conversations/ConversationViewModel.m
@@ -835,8 +835,8 @@ NS_ASSUME_NONNULL_BEGIN
         // to show the date header of the deleted message if needed
         for (NSString *deletedItemId in deletedItemIdSet) {
             NSUInteger oldIndex = [oldItemIdList indexOfObject:deletedItemId];
-            id<ConversationViewItem> _Nullable nextItemId = (oldIndex + 1 < oldItemIdList.count ? oldItemIdList[oldIndex + 1] : nil);
-            if (nextItemId != nil) {
+            if (oldIndex != NSNotFound && oldIndex + 1 < oldItemIdList.count) {
+                NSString *nextItemId = oldItemIdList[oldIndex + 1];
                 [updatedItemSet addObject:nextItemId];
                 [updatedNeighborItemSet addObject:nextItemId];
             }

--- a/Session/Conversations/ConversationViewModel.m
+++ b/Session/Conversations/ConversationViewModel.m
@@ -823,13 +823,18 @@ NS_ASSUME_NONNULL_BEGIN
             return [self.delegate conversationViewModelDidUpdate:ConversationUpdate.reloadUpdate];
         }
         
-        if ([viewItem.interaction isKindOfClass:TSMessage.class]) {
-            TSMessage *message = (TSMessage *)viewItem.interaction;
-            if ([MessageInvalidator isInvalidated:message]) {
-                [updatedItemSet addObject:itemId];
-                [updatedNeighborItemSet addObject:itemId];
-            }
+        if (!viewItem.hasCachedLayoutState) {
+            [updatedItemSet addObject:itemId];
+            [updatedNeighborItemSet addObject:itemId];
         }
+        
+//        if ([viewItem.interaction isKindOfClass:TSMessage.class]) {
+//            TSMessage *message = (TSMessage *)viewItem.interaction;
+//            if ([MessageInvalidator isInvalidated:message]) {
+//                [updatedItemSet addObject:itemId];
+//                [updatedNeighborItemSet addObject:itemId];
+//            }
+//        }
     }
 
     // 3. Updates.

--- a/Session/Conversations/ConversationViewModel.m
+++ b/Session/Conversations/ConversationViewModel.m
@@ -823,18 +823,13 @@ NS_ASSUME_NONNULL_BEGIN
             return [self.delegate conversationViewModelDidUpdate:ConversationUpdate.reloadUpdate];
         }
         
-        if (!viewItem.hasCachedLayoutState) {
-            [updatedItemSet addObject:itemId];
-            [updatedNeighborItemSet addObject:itemId];
+        if ([viewItem.interaction isKindOfClass:TSMessage.class]) {
+            TSMessage *message = (TSMessage *)viewItem.interaction;
+            if ([MessageInvalidator isInvalidated:message]) {
+                [updatedItemSet addObject:itemId];
+                [updatedNeighborItemSet addObject:itemId];
+            }
         }
-        
-//        if ([viewItem.interaction isKindOfClass:TSMessage.class]) {
-//            TSMessage *message = (TSMessage *)viewItem.interaction;
-//            if ([MessageInvalidator isInvalidated:message]) {
-//                [updatedItemSet addObject:itemId];
-//                [updatedNeighborItemSet addObject:itemId];
-//            }
-//        }
     }
 
     // 3. Updates.

--- a/Session/Conversations/Message Cells/Content Views/DeletedMessageView.swift
+++ b/Session/Conversations/Message Cells/Content Views/DeletedMessageView.swift
@@ -35,7 +35,7 @@ final class DeletedMessageView : UIView {
         // Body label
         let titleLabel = UILabel()
         titleLabel.lineBreakMode = .byTruncatingTail
-        titleLabel.text = "This message has been deleted."
+        titleLabel.text = NSLocalizedString("message_deleted", comment: "")
         titleLabel.textColor = textColor
         titleLabel.font = .systemFont(ofSize: Values.smallFontSize)
         // Stack view

--- a/Session/Conversations/Message Cells/Content Views/DeletedMessageView.swift
+++ b/Session/Conversations/Message Cells/Content Views/DeletedMessageView.swift
@@ -1,0 +1,51 @@
+
+final class DeletedMessageView : UIView {
+    private let viewItem: ConversationViewItem
+    private let textColor: UIColor
+    
+    // MARK: Settings
+    private static let iconSize: CGFloat = 18
+    private static let iconImageViewSize: CGFloat = 30
+    
+    // MARK: Lifecycle
+    init(viewItem: ConversationViewItem, textColor: UIColor) {
+        self.viewItem = viewItem
+        self.textColor = textColor
+        super.init(frame: CGRect.zero)
+        setUpViewHierarchy()
+    }
+    
+    override init(frame: CGRect) {
+        preconditionFailure("Use init(viewItem:textColor:) instead.")
+    }
+    
+    required init?(coder: NSCoder) {
+        preconditionFailure("Use init(viewItem:textColor:) instead.")
+    }
+    
+    private func setUpViewHierarchy() {
+        // Image view
+        let iconSize = DeletedMessageView.iconSize
+        let icon = UIImage(named: "ic_trash")?.withTint(textColor)?.resizedImage(to: CGSize(width: iconSize, height: iconSize))
+        let imageView = UIImageView(image: icon)
+        imageView.contentMode = .center
+        let iconImageViewSize = DeletedMessageView.iconImageViewSize
+        imageView.set(.width, to: iconImageViewSize)
+        imageView.set(.height, to: iconImageViewSize)
+        // Body label
+        let titleLabel = UILabel()
+        titleLabel.lineBreakMode = .byTruncatingTail
+        titleLabel.text = "This message has been deleted."
+        titleLabel.textColor = textColor
+        titleLabel.font = .systemFont(ofSize: Values.smallFontSize)
+        // Stack view
+        let stackView = UIStackView(arrangedSubviews: [ imageView, titleLabel ])
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.isLayoutMarginsRelativeArrangement = true
+        stackView.layoutMargins = UIEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 6)
+        addSubview(stackView)
+        stackView.pin(to: self, withInset: Values.smallSpacing)
+    }
+}
+

--- a/Session/Conversations/Message Cells/VisibleMessageCell.swift
+++ b/Session/Conversations/Message Cells/VisibleMessageCell.swift
@@ -202,7 +202,6 @@ final class VisibleMessageCell : MessageCell, LinkPreviewViewDelegate {
         doubleTapGestureRecognizer.numberOfTapsRequired = 2
         addGestureRecognizer(doubleTapGestureRecognizer)
         tapGestureRecognizer.require(toFail: doubleTapGestureRecognizer)
-        addGestureRecognizer(panGestureRecognizer)
     }
     
     // MARK: Updating
@@ -275,6 +274,12 @@ final class VisibleMessageCell : MessageCell, LinkPreviewViewDelegate {
         timerView.isHidden = !viewItem.isExpiringMessage
         timerViewOutgoingMessageConstraint.isActive = (direction == .outgoing)
         timerViewIncomingMessageConstraint.isActive = (direction == .incoming)
+        // Swipe to reply
+        if (message.isDeleted) {
+            removeGestureRecognizer(panGestureRecognizer)
+        } else {
+            addGestureRecognizer(panGestureRecognizer)
+        }
     }
     
     private func populateHeader(for viewItem: ConversationViewItem) {

--- a/Session/Conversations/Message Cells/VisibleMessageCell.swift
+++ b/Session/Conversations/Message Cells/VisibleMessageCell.swift
@@ -389,6 +389,10 @@ final class VisibleMessageCell : MessageCell, LinkPreviewViewDelegate {
                 snContentView.addSubview(documentView)
                 documentView.pin(to: snContentView)
             }
+        case .deletedMessage:
+            let deletedMessageView = DeletedMessageView(viewItem: viewItem, textColor: bodyLabelTextColor)
+            snContentView.addSubview(deletedMessageView)
+            deletedMessageView.pin(to: snContentView)
         default: return
         }
     }

--- a/Session/Meta/Translations/de.lproj/Localizable.strings
+++ b/Session/Meta/Translations/de.lproj/Localizable.strings
@@ -550,3 +550,6 @@
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
 "message_deleted" = "This message has been deleted";
+"delete_message_for_me" = "Delete just for me";
+"delete_message_for_everyone" = "Delete for everyone";
+"delete_message_for_me_and_recipient" = "Delete for me and %@";

--- a/Session/Meta/Translations/de.lproj/Localizable.strings
+++ b/Session/Meta/Translations/de.lproj/Localizable.strings
@@ -553,3 +553,7 @@
 "delete_message_for_me" = "Delete just for me";
 "delete_message_for_everyone" = "Delete for everyone";
 "delete_message_for_me_and_recipient" = "Delete for me and %@";
+"context_menu_reply" = "Reply";
+"context_menu_save" = "Save";
+"context_menu_ban_user" = "Ban User";
+"context_menu_ban_and_delete_all" = "Ban and Delete All";

--- a/Session/Meta/Translations/de.lproj/Localizable.strings
+++ b/Session/Meta/Translations/de.lproj/Localizable.strings
@@ -549,3 +549,4 @@
 "vc_conversation_settings_notify_for_mentions_only_title" = "Notify for Mentions Only";
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
+"message_deleted" = "This message has been deleted";

--- a/Session/Meta/Translations/en.lproj/Localizable.strings
+++ b/Session/Meta/Translations/en.lproj/Localizable.strings
@@ -553,3 +553,8 @@
 "delete_message_for_me" = "Delete just for me";
 "delete_message_for_everyone" = "Delete for everyone";
 "delete_message_for_me_and_recipient" = "Delete for me and %@";
+"context_menu_reply" = "Reply";
+"context_menu_save" = "Save";
+"context_menu_ban_user" = "Ban User";
+"context_menu_ban_and_delete_all" = "Ban and Delete All";
+

--- a/Session/Meta/Translations/en.lproj/Localizable.strings
+++ b/Session/Meta/Translations/en.lproj/Localizable.strings
@@ -550,3 +550,6 @@
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
 "message_deleted" = "This message has been deleted";
+"delete_message_for_me" = "Delete just for me";
+"delete_message_for_everyone" = "Delete for everyone";
+"delete_message_for_me_and_recipient" = "Delete for me and %@";

--- a/Session/Meta/Translations/en.lproj/Localizable.strings
+++ b/Session/Meta/Translations/en.lproj/Localizable.strings
@@ -549,3 +549,4 @@
 "vc_conversation_settings_notify_for_mentions_only_title" = "Notify for Mentions Only";
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
+"message_deleted" = "This message has been deleted";

--- a/Session/Meta/Translations/es.lproj/Localizable.strings
+++ b/Session/Meta/Translations/es.lproj/Localizable.strings
@@ -550,3 +550,6 @@
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
 "message_deleted" = "This message has been deleted";
+"delete_message_for_me" = "Delete just for me";
+"delete_message_for_everyone" = "Delete for everyone";
+"delete_message_for_me_and_recipient" = "Delete for me and %@";

--- a/Session/Meta/Translations/es.lproj/Localizable.strings
+++ b/Session/Meta/Translations/es.lproj/Localizable.strings
@@ -553,3 +553,7 @@
 "delete_message_for_me" = "Delete just for me";
 "delete_message_for_everyone" = "Delete for everyone";
 "delete_message_for_me_and_recipient" = "Delete for me and %@";
+"context_menu_reply" = "Reply";
+"context_menu_save" = "Save";
+"context_menu_ban_user" = "Ban User";
+"context_menu_ban_and_delete_all" = "Ban and Delete All";

--- a/Session/Meta/Translations/es.lproj/Localizable.strings
+++ b/Session/Meta/Translations/es.lproj/Localizable.strings
@@ -549,3 +549,4 @@
 "vc_conversation_settings_notify_for_mentions_only_title" = "Notify for Mentions Only";
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
+"message_deleted" = "This message has been deleted";

--- a/Session/Meta/Translations/fa.lproj/Localizable.strings
+++ b/Session/Meta/Translations/fa.lproj/Localizable.strings
@@ -550,3 +550,6 @@
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
 "message_deleted" = "This message has been deleted";
+"delete_message_for_me" = "Delete just for me";
+"delete_message_for_everyone" = "Delete for everyone";
+"delete_message_for_me_and_recipient" = "Delete for me and %@";

--- a/Session/Meta/Translations/fa.lproj/Localizable.strings
+++ b/Session/Meta/Translations/fa.lproj/Localizable.strings
@@ -553,3 +553,7 @@
 "delete_message_for_me" = "Delete just for me";
 "delete_message_for_everyone" = "Delete for everyone";
 "delete_message_for_me_and_recipient" = "Delete for me and %@";
+"context_menu_reply" = "Reply";
+"context_menu_save" = "Save";
+"context_menu_ban_user" = "Ban User";
+"context_menu_ban_and_delete_all" = "Ban and Delete All";

--- a/Session/Meta/Translations/fa.lproj/Localizable.strings
+++ b/Session/Meta/Translations/fa.lproj/Localizable.strings
@@ -549,3 +549,4 @@
 "vc_conversation_settings_notify_for_mentions_only_title" = "Notify for Mentions Only";
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
+"message_deleted" = "This message has been deleted";

--- a/Session/Meta/Translations/fi.lproj/Localizable.strings
+++ b/Session/Meta/Translations/fi.lproj/Localizable.strings
@@ -550,3 +550,6 @@
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
 "message_deleted" = "This message has been deleted";
+"delete_message_for_me" = "Delete just for me";
+"delete_message_for_everyone" = "Delete for everyone";
+"delete_message_for_me_and_recipient" = "Delete for me and %@";

--- a/Session/Meta/Translations/fi.lproj/Localizable.strings
+++ b/Session/Meta/Translations/fi.lproj/Localizable.strings
@@ -553,3 +553,7 @@
 "delete_message_for_me" = "Delete just for me";
 "delete_message_for_everyone" = "Delete for everyone";
 "delete_message_for_me_and_recipient" = "Delete for me and %@";
+"context_menu_reply" = "Reply";
+"context_menu_save" = "Save";
+"context_menu_ban_user" = "Ban User";
+"context_menu_ban_and_delete_all" = "Ban and Delete All";

--- a/Session/Meta/Translations/fi.lproj/Localizable.strings
+++ b/Session/Meta/Translations/fi.lproj/Localizable.strings
@@ -549,3 +549,4 @@
 "vc_conversation_settings_notify_for_mentions_only_title" = "Notify for Mentions Only";
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
+"message_deleted" = "This message has been deleted";

--- a/Session/Meta/Translations/fr.lproj/Localizable.strings
+++ b/Session/Meta/Translations/fr.lproj/Localizable.strings
@@ -550,3 +550,6 @@
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
 "message_deleted" = "This message has been deleted";
+"delete_message_for_me" = "Delete just for me";
+"delete_message_for_everyone" = "Delete for everyone";
+"delete_message_for_me_and_recipient" = "Delete for me and %@";

--- a/Session/Meta/Translations/fr.lproj/Localizable.strings
+++ b/Session/Meta/Translations/fr.lproj/Localizable.strings
@@ -553,3 +553,7 @@
 "delete_message_for_me" = "Delete just for me";
 "delete_message_for_everyone" = "Delete for everyone";
 "delete_message_for_me_and_recipient" = "Delete for me and %@";
+"context_menu_reply" = "Reply";
+"context_menu_save" = "Save";
+"context_menu_ban_user" = "Ban User";
+"context_menu_ban_and_delete_all" = "Ban and Delete All";

--- a/Session/Meta/Translations/fr.lproj/Localizable.strings
+++ b/Session/Meta/Translations/fr.lproj/Localizable.strings
@@ -549,3 +549,4 @@
 "vc_conversation_settings_notify_for_mentions_only_title" = "Notify for Mentions Only";
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
+"message_deleted" = "This message has been deleted";

--- a/Session/Meta/Translations/hi.lproj/Localizable.strings
+++ b/Session/Meta/Translations/hi.lproj/Localizable.strings
@@ -550,3 +550,6 @@
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
 "message_deleted" = "This message has been deleted";
+"delete_message_for_me" = "Delete just for me";
+"delete_message_for_everyone" = "Delete for everyone";
+"delete_message_for_me_and_recipient" = "Delete for me and %@";

--- a/Session/Meta/Translations/hi.lproj/Localizable.strings
+++ b/Session/Meta/Translations/hi.lproj/Localizable.strings
@@ -553,3 +553,7 @@
 "delete_message_for_me" = "Delete just for me";
 "delete_message_for_everyone" = "Delete for everyone";
 "delete_message_for_me_and_recipient" = "Delete for me and %@";
+"context_menu_reply" = "Reply";
+"context_menu_save" = "Save";
+"context_menu_ban_user" = "Ban User";
+"context_menu_ban_and_delete_all" = "Ban and Delete All";

--- a/Session/Meta/Translations/hi.lproj/Localizable.strings
+++ b/Session/Meta/Translations/hi.lproj/Localizable.strings
@@ -549,3 +549,4 @@
 "vc_conversation_settings_notify_for_mentions_only_title" = "Notify for Mentions Only";
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
+"message_deleted" = "This message has been deleted";

--- a/Session/Meta/Translations/hr.lproj/Localizable.strings
+++ b/Session/Meta/Translations/hr.lproj/Localizable.strings
@@ -550,3 +550,6 @@
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
 "message_deleted" = "This message has been deleted";
+"delete_message_for_me" = "Delete just for me";
+"delete_message_for_everyone" = "Delete for everyone";
+"delete_message_for_me_and_recipient" = "Delete for me and %@";

--- a/Session/Meta/Translations/hr.lproj/Localizable.strings
+++ b/Session/Meta/Translations/hr.lproj/Localizable.strings
@@ -553,3 +553,7 @@
 "delete_message_for_me" = "Delete just for me";
 "delete_message_for_everyone" = "Delete for everyone";
 "delete_message_for_me_and_recipient" = "Delete for me and %@";
+"context_menu_reply" = "Reply";
+"context_menu_save" = "Save";
+"context_menu_ban_user" = "Ban User";
+"context_menu_ban_and_delete_all" = "Ban and Delete All";

--- a/Session/Meta/Translations/hr.lproj/Localizable.strings
+++ b/Session/Meta/Translations/hr.lproj/Localizable.strings
@@ -549,3 +549,4 @@
 "vc_conversation_settings_notify_for_mentions_only_title" = "Notify for Mentions Only";
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
+"message_deleted" = "This message has been deleted";

--- a/Session/Meta/Translations/id-ID.lproj/Localizable.strings
+++ b/Session/Meta/Translations/id-ID.lproj/Localizable.strings
@@ -550,3 +550,6 @@
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
 "message_deleted" = "This message has been deleted";
+"delete_message_for_me" = "Delete just for me";
+"delete_message_for_everyone" = "Delete for everyone";
+"delete_message_for_me_and_recipient" = "Delete for me and %@";

--- a/Session/Meta/Translations/id-ID.lproj/Localizable.strings
+++ b/Session/Meta/Translations/id-ID.lproj/Localizable.strings
@@ -553,3 +553,7 @@
 "delete_message_for_me" = "Delete just for me";
 "delete_message_for_everyone" = "Delete for everyone";
 "delete_message_for_me_and_recipient" = "Delete for me and %@";
+"context_menu_reply" = "Reply";
+"context_menu_save" = "Save";
+"context_menu_ban_user" = "Ban User";
+"context_menu_ban_and_delete_all" = "Ban and Delete All";

--- a/Session/Meta/Translations/id-ID.lproj/Localizable.strings
+++ b/Session/Meta/Translations/id-ID.lproj/Localizable.strings
@@ -549,3 +549,4 @@
 "vc_conversation_settings_notify_for_mentions_only_title" = "Notify for Mentions Only";
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
+"message_deleted" = "This message has been deleted";

--- a/Session/Meta/Translations/it.lproj/Localizable.strings
+++ b/Session/Meta/Translations/it.lproj/Localizable.strings
@@ -550,3 +550,6 @@
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
 "message_deleted" = "This message has been deleted";
+"delete_message_for_me" = "Delete just for me";
+"delete_message_for_everyone" = "Delete for everyone";
+"delete_message_for_me_and_recipient" = "Delete for me and %@";

--- a/Session/Meta/Translations/it.lproj/Localizable.strings
+++ b/Session/Meta/Translations/it.lproj/Localizable.strings
@@ -553,3 +553,7 @@
 "delete_message_for_me" = "Delete just for me";
 "delete_message_for_everyone" = "Delete for everyone";
 "delete_message_for_me_and_recipient" = "Delete for me and %@";
+"context_menu_reply" = "Reply";
+"context_menu_save" = "Save";
+"context_menu_ban_user" = "Ban User";
+"context_menu_ban_and_delete_all" = "Ban and Delete All";

--- a/Session/Meta/Translations/it.lproj/Localizable.strings
+++ b/Session/Meta/Translations/it.lproj/Localizable.strings
@@ -549,3 +549,4 @@
 "vc_conversation_settings_notify_for_mentions_only_title" = "Notify for Mentions Only";
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
+"message_deleted" = "This message has been deleted";

--- a/Session/Meta/Translations/ja.lproj/Localizable.strings
+++ b/Session/Meta/Translations/ja.lproj/Localizable.strings
@@ -550,3 +550,6 @@
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
 "message_deleted" = "This message has been deleted";
+"delete_message_for_me" = "Delete just for me";
+"delete_message_for_everyone" = "Delete for everyone";
+"delete_message_for_me_and_recipient" = "Delete for me and %@";

--- a/Session/Meta/Translations/ja.lproj/Localizable.strings
+++ b/Session/Meta/Translations/ja.lproj/Localizable.strings
@@ -553,3 +553,7 @@
 "delete_message_for_me" = "Delete just for me";
 "delete_message_for_everyone" = "Delete for everyone";
 "delete_message_for_me_and_recipient" = "Delete for me and %@";
+"context_menu_reply" = "Reply";
+"context_menu_save" = "Save";
+"context_menu_ban_user" = "Ban User";
+"context_menu_ban_and_delete_all" = "Ban and Delete All";

--- a/Session/Meta/Translations/ja.lproj/Localizable.strings
+++ b/Session/Meta/Translations/ja.lproj/Localizable.strings
@@ -549,3 +549,4 @@
 "vc_conversation_settings_notify_for_mentions_only_title" = "Notify for Mentions Only";
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
+"message_deleted" = "This message has been deleted";

--- a/Session/Meta/Translations/nl.lproj/Localizable.strings
+++ b/Session/Meta/Translations/nl.lproj/Localizable.strings
@@ -550,3 +550,6 @@
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
 "message_deleted" = "This message has been deleted";
+"delete_message_for_me" = "Delete just for me";
+"delete_message_for_everyone" = "Delete for everyone";
+"delete_message_for_me_and_recipient" = "Delete for me and %@";

--- a/Session/Meta/Translations/nl.lproj/Localizable.strings
+++ b/Session/Meta/Translations/nl.lproj/Localizable.strings
@@ -553,3 +553,7 @@
 "delete_message_for_me" = "Delete just for me";
 "delete_message_for_everyone" = "Delete for everyone";
 "delete_message_for_me_and_recipient" = "Delete for me and %@";
+"context_menu_reply" = "Reply";
+"context_menu_save" = "Save";
+"context_menu_ban_user" = "Ban User";
+"context_menu_ban_and_delete_all" = "Ban and Delete All";

--- a/Session/Meta/Translations/nl.lproj/Localizable.strings
+++ b/Session/Meta/Translations/nl.lproj/Localizable.strings
@@ -549,3 +549,4 @@
 "vc_conversation_settings_notify_for_mentions_only_title" = "Notify for Mentions Only";
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
+"message_deleted" = "This message has been deleted";

--- a/Session/Meta/Translations/pl.lproj/Localizable.strings
+++ b/Session/Meta/Translations/pl.lproj/Localizable.strings
@@ -550,3 +550,6 @@
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
 "message_deleted" = "This message has been deleted";
+"delete_message_for_me" = "Delete just for me";
+"delete_message_for_everyone" = "Delete for everyone";
+"delete_message_for_me_and_recipient" = "Delete for me and %@";

--- a/Session/Meta/Translations/pl.lproj/Localizable.strings
+++ b/Session/Meta/Translations/pl.lproj/Localizable.strings
@@ -553,3 +553,7 @@
 "delete_message_for_me" = "Delete just for me";
 "delete_message_for_everyone" = "Delete for everyone";
 "delete_message_for_me_and_recipient" = "Delete for me and %@";
+"context_menu_reply" = "Reply";
+"context_menu_save" = "Save";
+"context_menu_ban_user" = "Ban User";
+"context_menu_ban_and_delete_all" = "Ban and Delete All";

--- a/Session/Meta/Translations/pl.lproj/Localizable.strings
+++ b/Session/Meta/Translations/pl.lproj/Localizable.strings
@@ -549,3 +549,4 @@
 "vc_conversation_settings_notify_for_mentions_only_title" = "Notify for Mentions Only";
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
+"message_deleted" = "This message has been deleted";

--- a/Session/Meta/Translations/pt_BR.lproj/Localizable.strings
+++ b/Session/Meta/Translations/pt_BR.lproj/Localizable.strings
@@ -550,3 +550,6 @@
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
 "message_deleted" = "This message has been deleted";
+"delete_message_for_me" = "Delete just for me";
+"delete_message_for_everyone" = "Delete for everyone";
+"delete_message_for_me_and_recipient" = "Delete for me and %@";

--- a/Session/Meta/Translations/pt_BR.lproj/Localizable.strings
+++ b/Session/Meta/Translations/pt_BR.lproj/Localizable.strings
@@ -553,3 +553,7 @@
 "delete_message_for_me" = "Delete just for me";
 "delete_message_for_everyone" = "Delete for everyone";
 "delete_message_for_me_and_recipient" = "Delete for me and %@";
+"context_menu_reply" = "Reply";
+"context_menu_save" = "Save";
+"context_menu_ban_user" = "Ban User";
+"context_menu_ban_and_delete_all" = "Ban and Delete All";

--- a/Session/Meta/Translations/pt_BR.lproj/Localizable.strings
+++ b/Session/Meta/Translations/pt_BR.lproj/Localizable.strings
@@ -549,3 +549,4 @@
 "vc_conversation_settings_notify_for_mentions_only_title" = "Notify for Mentions Only";
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
+"message_deleted" = "This message has been deleted";

--- a/Session/Meta/Translations/ru.lproj/Localizable.strings
+++ b/Session/Meta/Translations/ru.lproj/Localizable.strings
@@ -550,3 +550,6 @@
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
 "message_deleted" = "This message has been deleted";
+"delete_message_for_me" = "Delete just for me";
+"delete_message_for_everyone" = "Delete for everyone";
+"delete_message_for_me_and_recipient" = "Delete for me and %@";

--- a/Session/Meta/Translations/ru.lproj/Localizable.strings
+++ b/Session/Meta/Translations/ru.lproj/Localizable.strings
@@ -553,3 +553,7 @@
 "delete_message_for_me" = "Delete just for me";
 "delete_message_for_everyone" = "Delete for everyone";
 "delete_message_for_me_and_recipient" = "Delete for me and %@";
+"context_menu_reply" = "Reply";
+"context_menu_save" = "Save";
+"context_menu_ban_user" = "Ban User";
+"context_menu_ban_and_delete_all" = "Ban and Delete All";

--- a/Session/Meta/Translations/ru.lproj/Localizable.strings
+++ b/Session/Meta/Translations/ru.lproj/Localizable.strings
@@ -549,3 +549,4 @@
 "vc_conversation_settings_notify_for_mentions_only_title" = "Notify for Mentions Only";
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
+"message_deleted" = "This message has been deleted";

--- a/Session/Meta/Translations/sk.lproj/Localizable.strings
+++ b/Session/Meta/Translations/sk.lproj/Localizable.strings
@@ -550,3 +550,6 @@
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
 "message_deleted" = "This message has been deleted";
+"delete_message_for_me" = "Delete just for me";
+"delete_message_for_everyone" = "Delete for everyone";
+"delete_message_for_me_and_recipient" = "Delete for me and %@";

--- a/Session/Meta/Translations/sk.lproj/Localizable.strings
+++ b/Session/Meta/Translations/sk.lproj/Localizable.strings
@@ -553,3 +553,7 @@
 "delete_message_for_me" = "Delete just for me";
 "delete_message_for_everyone" = "Delete for everyone";
 "delete_message_for_me_and_recipient" = "Delete for me and %@";
+"context_menu_reply" = "Reply";
+"context_menu_save" = "Save";
+"context_menu_ban_user" = "Ban User";
+"context_menu_ban_and_delete_all" = "Ban and Delete All";

--- a/Session/Meta/Translations/sk.lproj/Localizable.strings
+++ b/Session/Meta/Translations/sk.lproj/Localizable.strings
@@ -549,3 +549,4 @@
 "vc_conversation_settings_notify_for_mentions_only_title" = "Notify for Mentions Only";
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
+"message_deleted" = "This message has been deleted";

--- a/Session/Meta/Translations/sv.lproj/Localizable.strings
+++ b/Session/Meta/Translations/sv.lproj/Localizable.strings
@@ -550,3 +550,6 @@
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
 "message_deleted" = "This message has been deleted";
+"delete_message_for_me" = "Delete just for me";
+"delete_message_for_everyone" = "Delete for everyone";
+"delete_message_for_me_and_recipient" = "Delete for me and %@";

--- a/Session/Meta/Translations/sv.lproj/Localizable.strings
+++ b/Session/Meta/Translations/sv.lproj/Localizable.strings
@@ -553,3 +553,7 @@
 "delete_message_for_me" = "Delete just for me";
 "delete_message_for_everyone" = "Delete for everyone";
 "delete_message_for_me_and_recipient" = "Delete for me and %@";
+"context_menu_reply" = "Reply";
+"context_menu_save" = "Save";
+"context_menu_ban_user" = "Ban User";
+"context_menu_ban_and_delete_all" = "Ban and Delete All";

--- a/Session/Meta/Translations/sv.lproj/Localizable.strings
+++ b/Session/Meta/Translations/sv.lproj/Localizable.strings
@@ -549,3 +549,4 @@
 "vc_conversation_settings_notify_for_mentions_only_title" = "Notify for Mentions Only";
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
+"message_deleted" = "This message has been deleted";

--- a/Session/Meta/Translations/th.lproj/Localizable.strings
+++ b/Session/Meta/Translations/th.lproj/Localizable.strings
@@ -550,3 +550,6 @@
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
 "message_deleted" = "This message has been deleted";
+"delete_message_for_me" = "Delete just for me";
+"delete_message_for_everyone" = "Delete for everyone";
+"delete_message_for_me_and_recipient" = "Delete for me and %@";

--- a/Session/Meta/Translations/th.lproj/Localizable.strings
+++ b/Session/Meta/Translations/th.lproj/Localizable.strings
@@ -553,3 +553,7 @@
 "delete_message_for_me" = "Delete just for me";
 "delete_message_for_everyone" = "Delete for everyone";
 "delete_message_for_me_and_recipient" = "Delete for me and %@";
+"context_menu_reply" = "Reply";
+"context_menu_save" = "Save";
+"context_menu_ban_user" = "Ban User";
+"context_menu_ban_and_delete_all" = "Ban and Delete All";

--- a/Session/Meta/Translations/th.lproj/Localizable.strings
+++ b/Session/Meta/Translations/th.lproj/Localizable.strings
@@ -549,3 +549,4 @@
 "vc_conversation_settings_notify_for_mentions_only_title" = "Notify for Mentions Only";
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
+"message_deleted" = "This message has been deleted";

--- a/Session/Meta/Translations/vi-VN.lproj/Localizable.strings
+++ b/Session/Meta/Translations/vi-VN.lproj/Localizable.strings
@@ -550,3 +550,6 @@
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
 "message_deleted" = "This message has been deleted";
+"delete_message_for_me" = "Delete just for me";
+"delete_message_for_everyone" = "Delete for everyone";
+"delete_message_for_me_and_recipient" = "Delete for me and %@";

--- a/Session/Meta/Translations/vi-VN.lproj/Localizable.strings
+++ b/Session/Meta/Translations/vi-VN.lproj/Localizable.strings
@@ -553,3 +553,7 @@
 "delete_message_for_me" = "Delete just for me";
 "delete_message_for_everyone" = "Delete for everyone";
 "delete_message_for_me_and_recipient" = "Delete for me and %@";
+"context_menu_reply" = "Reply";
+"context_menu_save" = "Save";
+"context_menu_ban_user" = "Ban User";
+"context_menu_ban_and_delete_all" = "Ban and Delete All";

--- a/Session/Meta/Translations/vi-VN.lproj/Localizable.strings
+++ b/Session/Meta/Translations/vi-VN.lproj/Localizable.strings
@@ -549,3 +549,4 @@
 "vc_conversation_settings_notify_for_mentions_only_title" = "Notify for Mentions Only";
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
+"message_deleted" = "This message has been deleted";

--- a/Session/Meta/Translations/zh-Hant.lproj/Localizable.strings
+++ b/Session/Meta/Translations/zh-Hant.lproj/Localizable.strings
@@ -550,3 +550,6 @@
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
 "message_deleted" = "This message has been deleted";
+"delete_message_for_me" = "Delete just for me";
+"delete_message_for_everyone" = "Delete for everyone";
+"delete_message_for_me_and_recipient" = "Delete for me and %@";

--- a/Session/Meta/Translations/zh-Hant.lproj/Localizable.strings
+++ b/Session/Meta/Translations/zh-Hant.lproj/Localizable.strings
@@ -553,3 +553,7 @@
 "delete_message_for_me" = "Delete just for me";
 "delete_message_for_everyone" = "Delete for everyone";
 "delete_message_for_me_and_recipient" = "Delete for me and %@";
+"context_menu_reply" = "Reply";
+"context_menu_save" = "Save";
+"context_menu_ban_user" = "Ban User";
+"context_menu_ban_and_delete_all" = "Ban and Delete All";

--- a/Session/Meta/Translations/zh-Hant.lproj/Localizable.strings
+++ b/Session/Meta/Translations/zh-Hant.lproj/Localizable.strings
@@ -549,3 +549,4 @@
 "vc_conversation_settings_notify_for_mentions_only_title" = "Notify for Mentions Only";
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
+"message_deleted" = "This message has been deleted";

--- a/Session/Meta/Translations/zh_CN.lproj/Localizable.strings
+++ b/Session/Meta/Translations/zh_CN.lproj/Localizable.strings
@@ -550,3 +550,6 @@
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
 "message_deleted" = "This message has been deleted";
+"delete_message_for_me" = "Delete just for me";
+"delete_message_for_everyone" = "Delete for everyone";
+"delete_message_for_me_and_recipient" = "Delete for me and %@";

--- a/Session/Meta/Translations/zh_CN.lproj/Localizable.strings
+++ b/Session/Meta/Translations/zh_CN.lproj/Localizable.strings
@@ -553,3 +553,7 @@
 "delete_message_for_me" = "Delete just for me";
 "delete_message_for_everyone" = "Delete for everyone";
 "delete_message_for_me_and_recipient" = "Delete for me and %@";
+"context_menu_reply" = "Reply";
+"context_menu_save" = "Save";
+"context_menu_ban_user" = "Ban User";
+"context_menu_ban_and_delete_all" = "Ban and Delete All";

--- a/Session/Meta/Translations/zh_CN.lproj/Localizable.strings
+++ b/Session/Meta/Translations/zh_CN.lproj/Localizable.strings
@@ -549,3 +549,4 @@
 "vc_conversation_settings_notify_for_mentions_only_title" = "Notify for Mentions Only";
 "vc_conversation_settings_notify_for_mentions_only_explanation" = "When enabled, you'll only be notified for messages mentioning you.";
 "view_conversation_title_notify_for_mentions_only" = "Notifying for Mentions Only";
+"message_deleted" = "This message has been deleted";

--- a/Session/Notifications/AppNotifications.swift
+++ b/Session/Notifications/AppNotifications.swift
@@ -95,6 +95,7 @@ protocol NotificationPresenterAdaptee: class {
     func notify(category: AppNotificationCategory, title: String?, body: String, userInfo: [AnyHashable: Any], sound: OWSSound?, replacingIdentifier: String?)
 
     func cancelNotifications(threadId: String)
+    func cancelNotification(identifier: String)
     func clearAllNotifications()
 }
 
@@ -219,6 +220,10 @@ public class NotificationPresenter: NSObject, NotificationsProtocol {
         let userInfo = [
             AppNotificationUserInfoKey.threadId: threadId
         ]
+        
+        let transaction = transaction as! YapDatabaseReadWriteTransaction
+        let identifier: String = UUID().uuidString
+        incomingMessage.setNotificationIdentifier(identifier, transaction: transaction)
 
         DispatchQueue.main.async {
             notificationBody = MentionUtilities.highlightMentions(in: notificationBody!, threadID: thread.uniqueId!)
@@ -227,7 +232,8 @@ public class NotificationPresenter: NSObject, NotificationsProtocol {
                                 title: notificationTitle,
                                 body: notificationBody ?? "",
                                 userInfo: userInfo,
-                                sound: sound)
+                                sound: sound,
+                                replacingIdentifier: identifier)
         }
     }
 
@@ -259,6 +265,11 @@ public class NotificationPresenter: NSObject, NotificationsProtocol {
                                 userInfo: userInfo,
                                 sound: sound)
         }
+    }
+    
+    @objc
+    public func cancelNotification(_ identifier: String) {
+        self.adaptee.cancelNotification(identifier: identifier)
     }
 
     @objc

--- a/Session/Notifications/AppNotifications.swift
+++ b/Session/Notifications/AppNotifications.swift
@@ -221,9 +221,7 @@ public class NotificationPresenter: NSObject, NotificationsProtocol {
             AppNotificationUserInfoKey.threadId: threadId
         ]
         
-        let transaction = transaction as! YapDatabaseReadWriteTransaction
-        let identifier: String = UUID().uuidString
-        incomingMessage.setNotificationIdentifier(identifier, transaction: transaction)
+        let identifier: String = incomingMessage.notificationIdentifier ?? UUID().uuidString
 
         DispatchQueue.main.async {
             notificationBody = MentionUtilities.highlightMentions(in: notificationBody!, threadID: thread.uniqueId!)

--- a/Session/Notifications/AppNotifications.swift
+++ b/Session/Notifications/AppNotifications.swift
@@ -269,7 +269,9 @@ public class NotificationPresenter: NSObject, NotificationsProtocol {
     
     @objc
     public func cancelNotification(_ identifier: String) {
-        self.adaptee.cancelNotification(identifier: identifier)
+        DispatchQueue.main.async {
+            self.adaptee.cancelNotification(identifier: identifier)
+        }
     }
 
     @objc

--- a/Session/Utilities/BackgroundPoller.swift
+++ b/Session/Utilities/BackgroundPoller.swift
@@ -48,7 +48,7 @@ public final class BackgroundPoller : NSObject {
                         // messages failed to parse.
                         guard let envelope = SNProtoEnvelope.from(json),
                             let data = try? envelope.serializedData() else { return nil }
-                        let job = MessageReceiveJob(data: data, isBackgroundPoll: true)
+                        let job = MessageReceiveJob(data: data, serverHash: json["hash"] as? String, isBackgroundPoll: true)
                         return job.execute()
                     }
                     return when(fulfilled: promises) // The promise returned by MessageReceiveJob never rejects

--- a/SessionMessagingKit/Messages/Control Messages/UnsendRequest.swift
+++ b/SessionMessagingKit/Messages/Control Messages/UnsendRequest.swift
@@ -1,0 +1,69 @@
+import SessionUtilitiesKit
+
+@objc(SNUnsendRequest)
+public final class UnsendRequest: ControlMessage {
+    public var timestamp: UInt64?
+    public var author: String?
+    
+    // MARK: Validation
+    public override var isValid: Bool {
+        guard super.isValid else { return false }
+        return timestamp != nil && author != nil
+    }
+    
+    // MARK: Initialization
+    public override init() { super.init() }
+
+    internal init(timestamp: UInt64, author: String) {
+        super.init()
+        self.timestamp = timestamp
+        self.author = author
+    }
+
+    // MARK: Coding
+    public required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        if let timestamp = coder.decodeObject(forKey: "timestamp") as! UInt64? { self.timestamp = timestamp }
+        if let author = coder.decodeObject(forKey: "author") as! String? { self.author = author }
+    }
+
+    public override func encode(with coder: NSCoder) {
+        super.encode(with: coder)
+        coder.encode(timestamp, forKey: "timestamp")
+        coder.encode(author, forKey: "author")
+    }
+    
+    // MARK: Proto Conversion
+    public override class func fromProto(_ proto: SNProtoContent) -> UnsendRequest? {
+        guard let unsendRequestProto = proto.unsendRequest else { return nil }
+        let timestamp = unsendRequestProto.timestamp
+        let author = unsendRequestProto.author
+        return UnsendRequest(timestamp: timestamp, author: author)
+    }
+
+    public override func toProto(using transaction: YapDatabaseReadWriteTransaction) -> SNProtoContent? {
+        guard let timestamp = timestamp, let author = author else {
+            SNLog("Couldn't construct unsend request proto from: \(self).")
+            return nil
+        }
+        let unsendRequestProto = SNProtoUnsendRequest.builder(timestamp: timestamp, author: author)
+        let contentProto = SNProtoContent.builder()
+        do {
+            contentProto.setUnsendRequest(try unsendRequestProto.build())
+            return try contentProto.build()
+        } catch {
+            SNLog("Couldn't construct unsend request proto from: \(self).")
+            return nil
+        }
+    }
+    
+    // MARK: Description
+    public override var description: String {
+        """
+        UnsendRequest(
+            timestamp: \(timestamp?.description ?? "null")
+            author: \(author?.description ?? "null")
+        )
+        """
+    }
+}

--- a/SessionMessagingKit/Messages/Control Messages/UnsendRequest.swift
+++ b/SessionMessagingKit/Messages/Control Messages/UnsendRequest.swift
@@ -5,6 +5,8 @@ public final class UnsendRequest: ControlMessage {
     public var timestamp: UInt64?
     public var author: String?
     
+    public override var isSelfSendValid: Bool { true }
+    
     // MARK: Validation
     public override var isValid: Bool {
         guard super.isValid else { return false }

--- a/SessionMessagingKit/Messages/Message.swift
+++ b/SessionMessagingKit/Messages/Message.swift
@@ -11,6 +11,7 @@ public class Message : NSObject, NSCoding { // NSObject/NSCoding conformance is 
     public var groupPublicKey: String?
     public var openGroupServerMessageID: UInt64?
     public var openGroupServerTimestamp: UInt64?
+    public var serverHash: String?
 
     public var ttl: UInt64 { 14 * 24 * 60 * 60 * 1000 }
     public var isSelfSendValid: Bool { false }
@@ -35,6 +36,7 @@ public class Message : NSObject, NSCoding { // NSObject/NSCoding conformance is 
         if let groupPublicKey = coder.decodeObject(forKey: "groupPublicKey") as! String? { self.groupPublicKey = groupPublicKey }
         if let openGroupServerMessageID = coder.decodeObject(forKey: "openGroupServerMessageID") as! UInt64? { self.openGroupServerMessageID = openGroupServerMessageID }
         if let openGroupServerTimestamp = coder.decodeObject(forKey: "openGroupServerTimestamp") as! UInt64? { self.openGroupServerTimestamp = openGroupServerTimestamp }
+        if let serverHash = coder.decodeObject(forKey: "serverHash") as! String? { self.serverHash = serverHash }
     }
 
     public func encode(with coder: NSCoder) {
@@ -47,6 +49,7 @@ public class Message : NSObject, NSCoding { // NSObject/NSCoding conformance is 
         coder.encode(groupPublicKey, forKey: "groupPublicKey")
         coder.encode(openGroupServerMessageID, forKey: "openGroupServerMessageID")
         coder.encode(openGroupServerTimestamp, forKey: "openGroupServerTimestamp")
+        coder.encode(serverHash, forKey: "serverHash")
     }
 
     // MARK: Proto Conversion

--- a/SessionMessagingKit/Messages/Signal/TSIncomingMessage+Conversion.swift
+++ b/SessionMessagingKit/Messages/Signal/TSIncomingMessage+Conversion.swift
@@ -22,7 +22,8 @@ public extension TSIncomingMessage {
             serverTimestamp: visibleMessage.openGroupServerTimestamp as NSNumber?,
             wasReceivedByUD: true,
             openGroupInvitationName: visibleMessage.openGroupInvitation?.name,
-            openGroupInvitationURL: visibleMessage.openGroupInvitation?.url
+            openGroupInvitationURL: visibleMessage.openGroupInvitation?.url,
+            serverHash: visibleMessage.serverHash
         )
         result.openGroupServerMessageID = openGroupServerMessageID
         return result

--- a/SessionMessagingKit/Messages/Signal/TSIncomingMessage.h
+++ b/SessionMessagingKit/Messages/Signal/TSIncomingMessage.h
@@ -18,6 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) BOOL isUserMentioned;
 
+@property (nonatomic, readonly, nullable) NSString *notificationIdentifier;
+
 - (instancetype)initMessageWithTimestamp:(uint64_t)timestamp
                                 inThread:(nullable TSThread *)thread
                              messageBody:(nullable NSString *)body
@@ -87,6 +89,9 @@ NS_ASSUME_NONNULL_BEGIN
 // convenience method for expiring a message which was just read
 - (void)markAsReadNowWithSendReadReceipt:(BOOL)sendReadReceipt
                              transaction:(YapDatabaseReadWriteTransaction *)transaction;
+
+- (void)setNotificationIdentifier:(NSString * _Nullable)notificationIdentifier
+                      transaction:(YapDatabaseReadWriteTransaction *)transaction;
 
 @end
 

--- a/SessionMessagingKit/Messages/Signal/TSIncomingMessage.h
+++ b/SessionMessagingKit/Messages/Signal/TSIncomingMessage.h
@@ -64,7 +64,8 @@ NS_ASSUME_NONNULL_BEGIN
                   serverTimestamp:(nullable NSNumber *)serverTimestamp
                   wasReceivedByUD:(BOOL)wasReceivedByUD
           openGroupInvitationName:(nullable NSString *)openGroupInvitationName
-           openGroupInvitationURL:(nullable NSString *)openGroupInvitationURL NS_DESIGNATED_INITIALIZER;
+           openGroupInvitationURL:(nullable NSString *)openGroupInvitationURL
+                       serverHash:(nullable NSString*)serverHash NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)initWithCoder:(NSCoder *)coder NS_DESIGNATED_INITIALIZER;
 

--- a/SessionMessagingKit/Messages/Signal/TSIncomingMessage.m
+++ b/SessionMessagingKit/Messages/Signal/TSIncomingMessage.m
@@ -77,6 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
     _read = NO;
     _serverTimestamp = serverTimestamp;
     _wasReceivedByUD = wasReceivedByUD;
+    _notificationIdentifier = nil;
 
     return self;
 }
@@ -126,6 +127,12 @@ NS_ASSUME_NONNULL_BEGIN
 {
     NSString *userPublicKey = [SNGeneralUtilities getUserPublicKey];
     return (self.body != nil && [self.body containsString:[NSString stringWithFormat:@"@%@", userPublicKey]]) || (self.quotedMessage != nil && [self.quotedMessage.authorId isEqualToString:userPublicKey]);
+}
+
+- (void)setNotificationIdentifier:(NSString * _Nullable)notificationIdentifier transaction:(nonnull YapDatabaseReadWriteTransaction *)transaction
+{
+    _notificationIdentifier = notificationIdentifier;
+    [self saveWithTransaction:transaction];
 }
 
 #pragma mark - OWSReadTracking

--- a/SessionMessagingKit/Messages/Signal/TSIncomingMessage.m
+++ b/SessionMessagingKit/Messages/Signal/TSIncomingMessage.m
@@ -56,6 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
                   wasReceivedByUD:(BOOL)wasReceivedByUD
           openGroupInvitationName:(nullable NSString *)openGroupInvitationName
            openGroupInvitationURL:(nullable NSString *)openGroupInvitationURL
+                       serverHash:(nullable NSString *)serverHash
 {
     self = [super initMessageWithTimestamp:timestamp
                                   inThread:thread
@@ -66,7 +67,8 @@ NS_ASSUME_NONNULL_BEGIN
                              quotedMessage:quotedMessage
                                linkPreview:linkPreview
                    openGroupInvitationName:openGroupInvitationName
-                    openGroupInvitationURL:openGroupInvitationURL];
+                    openGroupInvitationURL:openGroupInvitationURL
+                                serverHash:serverHash];
 
     if (!self) {
         return self;

--- a/SessionMessagingKit/Messages/Signal/TSInfoMessage.m
+++ b/SessionMessagingKit/Messages/Signal/TSInfoMessage.m
@@ -57,7 +57,8 @@ NSUInteger TSInfoMessageSchemaVersion = 1;
                              quotedMessage:nil
                                linkPreview:nil
                    openGroupInvitationName:nil
-                    openGroupInvitationURL:nil];
+                    openGroupInvitationURL:nil
+                                serverHash:nil];
 
     if (!self) {
         return self;

--- a/SessionMessagingKit/Messages/Signal/TSMessage.h
+++ b/SessionMessagingKit/Messages/Signal/TSMessage.h
@@ -39,6 +39,7 @@ extern const NSUInteger kOversizeTextMessageSizeThreshold;
 @property (nonatomic, readonly, nullable) NSString *openGroupInvitationName;
 @property (nonatomic, readonly, nullable) NSString *openGroupInvitationURL;
 @property (nonatomic, nullable) NSString *serverHash;
+@property (nonatomic) BOOL isDeleted;
 
 - (instancetype)initInteractionWithTimestamp:(uint64_t)timestamp inThread:(TSThread *)thread NS_UNAVAILABLE;
 
@@ -81,6 +82,8 @@ extern const NSUInteger kOversizeTextMessageSizeThreshold;
 - (void)updateWithExpireStartedAt:(uint64_t)expireStartedAt transaction:(YapDatabaseReadWriteTransaction *)transaction;
 
 - (void)updateWithLinkPreview:(OWSLinkPreview *)linkPreview transaction:(YapDatabaseReadWriteTransaction *)transaction;
+
+- (void)updateForDeletionWithTransaction:(YapDatabaseReadWriteTransaction *)transaction;
 
 @end
 

--- a/SessionMessagingKit/Messages/Signal/TSMessage.h
+++ b/SessionMessagingKit/Messages/Signal/TSMessage.h
@@ -38,6 +38,7 @@ extern const NSUInteger kOversizeTextMessageSizeThreshold;
 @property (nonatomic, readonly) BOOL isOpenGroupMessage;
 @property (nonatomic, readonly, nullable) NSString *openGroupInvitationName;
 @property (nonatomic, readonly, nullable) NSString *openGroupInvitationURL;
+@property (nonatomic, nullable) NSString *serverHash;
 
 - (instancetype)initInteractionWithTimestamp:(uint64_t)timestamp inThread:(TSThread *)thread NS_UNAVAILABLE;
 

--- a/SessionMessagingKit/Messages/Signal/TSMessage.h
+++ b/SessionMessagingKit/Messages/Signal/TSMessage.h
@@ -51,7 +51,8 @@ extern const NSUInteger kOversizeTextMessageSizeThreshold;
                            quotedMessage:(nullable TSQuotedMessage *)quotedMessage
                              linkPreview:(nullable OWSLinkPreview *)linkPreview
                  openGroupInvitationName:(nullable NSString *)openGroupInvitationName
-                  openGroupInvitationURL:(nullable NSString *)openGroupInvitationURL NS_DESIGNATED_INITIALIZER;
+                  openGroupInvitationURL:(nullable NSString *)openGroupInvitationURL
+                              serverHash:(nullable NSString *)serverHash NS_DESIGNATED_INITIALIZER;
 
 - (nullable instancetype)initWithCoder:(NSCoder *)coder NS_DESIGNATED_INITIALIZER;
 

--- a/SessionMessagingKit/Messages/Signal/TSMessage.m
+++ b/SessionMessagingKit/Messages/Signal/TSMessage.m
@@ -84,6 +84,7 @@ const NSUInteger kOversizeTextMessageSizeThreshold = 2 * 1024;
     _openGroupServerMessageID = 0;
     _openGroupInvitationName = openGroupInvitationName;
     _openGroupInvitationURL = openGroupInvitationURL;
+    _serverHash = nil;
 
     return self;
 }

--- a/SessionMessagingKit/Messages/Signal/TSMessage.m
+++ b/SessionMessagingKit/Messages/Signal/TSMessage.m
@@ -65,6 +65,7 @@ const NSUInteger kOversizeTextMessageSizeThreshold = 2 * 1024;
                              linkPreview:(nullable OWSLinkPreview *)linkPreview
                  openGroupInvitationName:(nullable NSString *)openGroupInvitationName
                   openGroupInvitationURL:(nullable NSString *)openGroupInvitationURL
+                              serverHash:(nullable NSString *)serverHash
 {
     self = [super initInteractionWithTimestamp:timestamp inThread:thread];
 
@@ -84,7 +85,7 @@ const NSUInteger kOversizeTextMessageSizeThreshold = 2 * 1024;
     _openGroupServerMessageID = 0;
     _openGroupInvitationName = openGroupInvitationName;
     _openGroupInvitationURL = openGroupInvitationURL;
-    _serverHash = nil;
+    _serverHash = serverHash;
 
     return self;
 }

--- a/SessionMessagingKit/Messages/Signal/TSOutgoingMessage+Conversion.swift
+++ b/SessionMessagingKit/Messages/Signal/TSOutgoingMessage+Conversion.swift
@@ -30,7 +30,8 @@ import SessionUtilitiesKit
             quotedMessage: TSQuotedMessage.from(visibleMessage.quote),
             linkPreview: OWSLinkPreview.from(visibleMessage.linkPreview),
             openGroupInvitationName: visibleMessage.openGroupInvitation?.name,
-            openGroupInvitationURL: visibleMessage.openGroupInvitation?.url
+            openGroupInvitationURL: visibleMessage.openGroupInvitation?.url,
+            serverHash: visibleMessage.serverHash
         )
     }
 }

--- a/SessionMessagingKit/Messages/Signal/TSOutgoingMessage.h
+++ b/SessionMessagingKit/Messages/Signal/TSOutgoingMessage.h
@@ -94,7 +94,8 @@ typedef NS_ENUM(NSInteger, TSGroupMetaMessage) {
                                    quotedMessage:(nullable TSQuotedMessage *)quotedMessage
                                      linkPreview:(nullable OWSLinkPreview *)linkPreview
                          openGroupInvitationName:(nullable NSString *)openGroupInvitationName
-                          openGroupInvitationURL:(nullable NSString *)openGroupInvitationURL NS_DESIGNATED_INITIALIZER;
+                          openGroupInvitationURL:(nullable NSString *)openGroupInvitationURL
+                                      serverHash:(nullable NSString *)serverHash NS_DESIGNATED_INITIALIZER;
 
 - (nullable instancetype)initWithCoder:(NSCoder *)coder NS_DESIGNATED_INITIALIZER;
 

--- a/SessionMessagingKit/Messages/Signal/TSOutgoingMessage.h
+++ b/SessionMessagingKit/Messages/Signal/TSOutgoingMessage.h
@@ -133,6 +133,8 @@ typedef NS_ENUM(NSInteger, TSGroupMetaMessage) {
 
 @property (nonatomic, readonly) BOOL isVoiceMessage;
 
+@property (nonatomic, nullable) NSString *syncMessageServerHash;
+
 + (nullable instancetype)findMessageWithTimestamp:(uint64_t)timestamp;
 
 - (BOOL)shouldBeSaved;

--- a/SessionMessagingKit/Messages/Signal/TSOutgoingMessage.h
+++ b/SessionMessagingKit/Messages/Signal/TSOutgoingMessage.h
@@ -133,8 +133,6 @@ typedef NS_ENUM(NSInteger, TSGroupMetaMessage) {
 
 @property (nonatomic, readonly) BOOL isVoiceMessage;
 
-@property (nonatomic, nullable) NSString *syncMessageServerHash;
-
 + (nullable instancetype)findMessageWithTimestamp:(uint64_t)timestamp;
 
 - (BOOL)shouldBeSaved;

--- a/SessionMessagingKit/Messages/Signal/TSOutgoingMessage.m
+++ b/SessionMessagingKit/Messages/Signal/TSOutgoingMessage.m
@@ -206,8 +206,6 @@ NSString *NSStringForOutgoingMessageRecipientState(OWSOutgoingMessageRecipientSt
     if (!self) {
         return self;
     }
-    
-    _syncMessageServerHash = nil;
 
     _hasSyncedTranscript = NO;
 

--- a/SessionMessagingKit/Messages/Signal/TSOutgoingMessage.m
+++ b/SessionMessagingKit/Messages/Signal/TSOutgoingMessage.m
@@ -154,7 +154,8 @@ NSString *NSStringForOutgoingMessageRecipientState(OWSOutgoingMessageRecipientSt
                                                          quotedMessage:quotedMessage
                                                            linkPreview:linkPreview
                                                openGroupInvitationName:nil
-                                                openGroupInvitationURL:nil];
+                                                openGroupInvitationURL:nil
+                                                            serverHash:nil];
 }
 
 + (instancetype)outgoingMessageInThread:(nullable TSThread *)thread
@@ -173,7 +174,8 @@ NSString *NSStringForOutgoingMessageRecipientState(OWSOutgoingMessageRecipientSt
                                                          quotedMessage:nil
                                                            linkPreview:nil
                                                openGroupInvitationName:nil
-                                                openGroupInvitationURL:nil];
+                                                openGroupInvitationURL:nil
+                                                            serverHash:nil];
 }
 
 - (instancetype)initOutgoingMessageWithTimestamp:(uint64_t)timestamp
@@ -188,6 +190,7 @@ NSString *NSStringForOutgoingMessageRecipientState(OWSOutgoingMessageRecipientSt
                                      linkPreview:(nullable OWSLinkPreview *)linkPreview
                          openGroupInvitationName:(nullable NSString *)openGroupInvitationName
                           openGroupInvitationURL:(nullable NSString *)openGroupInvitationURL
+                                      serverHash:(nullable NSString *)serverHash
 {
     self = [super initMessageWithTimestamp:timestamp
                                   inThread:thread
@@ -198,7 +201,8 @@ NSString *NSStringForOutgoingMessageRecipientState(OWSOutgoingMessageRecipientSt
                              quotedMessage:quotedMessage
                                linkPreview:linkPreview
                    openGroupInvitationName:openGroupInvitationName
-                    openGroupInvitationURL:openGroupInvitationURL];
+                    openGroupInvitationURL:openGroupInvitationURL
+                                serverHash:serverHash];
     if (!self) {
         return self;
     }

--- a/SessionMessagingKit/Messages/Signal/TSOutgoingMessage.m
+++ b/SessionMessagingKit/Messages/Signal/TSOutgoingMessage.m
@@ -563,6 +563,14 @@ NSString *NSStringForOutgoingMessageRecipientState(OWSOutgoingMessageRecipientSt
                              }];
 }
 
+#pragma mark - Delete
+
+- (void)updateForDeletionWithTransaction:(YapDatabaseReadWriteTransaction *)transaction
+{
+    [super updateForDeletionWithTransaction:transaction];
+    [self removeWithTransaction:transaction];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SessionMessagingKit/Messages/Signal/TSOutgoingMessage.m
+++ b/SessionMessagingKit/Messages/Signal/TSOutgoingMessage.m
@@ -206,6 +206,8 @@ NSString *NSStringForOutgoingMessageRecipientState(OWSOutgoingMessageRecipientSt
     if (!self) {
         return self;
     }
+    
+    _syncMessageServerHash = nil;
 
     _hasSyncedTranscript = NO;
 

--- a/SessionMessagingKit/Protos/Generated/SNProto.swift
+++ b/SessionMessagingKit/Protos/Generated/SNProto.swift
@@ -338,6 +338,118 @@ extension SNProtoTypingMessage.SNProtoTypingMessageBuilder {
 
 #endif
 
+// MARK: - SNProtoUnsendRequest
+
+@objc public class SNProtoUnsendRequest: NSObject {
+
+    // MARK: - SNProtoUnsendRequestBuilder
+
+    @objc public class func builder(timestamp: UInt64, author: String) -> SNProtoUnsendRequestBuilder {
+        return SNProtoUnsendRequestBuilder(timestamp: timestamp, author: author)
+    }
+
+    // asBuilder() constructs a builder that reflects the proto's contents.
+    @objc public func asBuilder() -> SNProtoUnsendRequestBuilder {
+        let builder = SNProtoUnsendRequestBuilder(timestamp: timestamp, author: author)
+        return builder
+    }
+
+    @objc public class SNProtoUnsendRequestBuilder: NSObject {
+
+        private var proto = SessionProtos_UnsendRequest()
+
+        @objc fileprivate override init() {}
+
+        @objc fileprivate init(timestamp: UInt64, author: String) {
+            super.init()
+
+            setTimestamp(timestamp)
+            setAuthor(author)
+        }
+
+        @objc public func setTimestamp(_ valueParam: UInt64) {
+            proto.timestamp = valueParam
+        }
+
+        @objc public func setAuthor(_ valueParam: String) {
+            proto.author = valueParam
+        }
+
+        @objc public func build() throws -> SNProtoUnsendRequest {
+            return try SNProtoUnsendRequest.parseProto(proto)
+        }
+
+        @objc public func buildSerializedData() throws -> Data {
+            return try SNProtoUnsendRequest.parseProto(proto).serializedData()
+        }
+    }
+
+    fileprivate let proto: SessionProtos_UnsendRequest
+
+    @objc public let timestamp: UInt64
+
+    @objc public let author: String
+
+    private init(proto: SessionProtos_UnsendRequest,
+                 timestamp: UInt64,
+                 author: String) {
+        self.proto = proto
+        self.timestamp = timestamp
+        self.author = author
+    }
+
+    @objc
+    public func serializedData() throws -> Data {
+        return try self.proto.serializedData()
+    }
+
+    @objc public class func parseData(_ serializedData: Data) throws -> SNProtoUnsendRequest {
+        let proto = try SessionProtos_UnsendRequest(serializedData: serializedData)
+        return try parseProto(proto)
+    }
+
+    fileprivate class func parseProto(_ proto: SessionProtos_UnsendRequest) throws -> SNProtoUnsendRequest {
+        guard proto.hasTimestamp else {
+            throw SNProtoError.invalidProtobuf(description: "\(logTag) missing required field: timestamp")
+        }
+        let timestamp = proto.timestamp
+
+        guard proto.hasAuthor else {
+            throw SNProtoError.invalidProtobuf(description: "\(logTag) missing required field: author")
+        }
+        let author = proto.author
+
+        // MARK: - Begin Validation Logic for SNProtoUnsendRequest -
+
+        // MARK: - End Validation Logic for SNProtoUnsendRequest -
+
+        let result = SNProtoUnsendRequest(proto: proto,
+                                          timestamp: timestamp,
+                                          author: author)
+        return result
+    }
+
+    @objc public override var debugDescription: String {
+        return "\(proto)"
+    }
+}
+
+#if DEBUG
+
+extension SNProtoUnsendRequest {
+    @objc public func serializedDataIgnoringErrors() -> Data? {
+        return try! self.serializedData()
+    }
+}
+
+extension SNProtoUnsendRequest.SNProtoUnsendRequestBuilder {
+    @objc public func buildIgnoringErrors() -> SNProtoUnsendRequest? {
+        return try! self.build()
+    }
+}
+
+#endif
+
 // MARK: - SNProtoContent
 
 @objc public class SNProtoContent: NSObject {
@@ -365,6 +477,9 @@ extension SNProtoTypingMessage.SNProtoTypingMessageBuilder {
         }
         if let _value = dataExtractionNotification {
             builder.setDataExtractionNotification(_value)
+        }
+        if let _value = unsendRequest {
+            builder.setUnsendRequest(_value)
         }
         return builder
     }
@@ -395,6 +510,10 @@ extension SNProtoTypingMessage.SNProtoTypingMessageBuilder {
             proto.dataExtractionNotification = valueParam.proto
         }
 
+        @objc public func setUnsendRequest(_ valueParam: SNProtoUnsendRequest) {
+            proto.unsendRequest = valueParam.proto
+        }
+
         @objc public func build() throws -> SNProtoContent {
             return try SNProtoContent.parseProto(proto)
         }
@@ -416,18 +535,22 @@ extension SNProtoTypingMessage.SNProtoTypingMessageBuilder {
 
     @objc public let dataExtractionNotification: SNProtoDataExtractionNotification?
 
+    @objc public let unsendRequest: SNProtoUnsendRequest?
+
     private init(proto: SessionProtos_Content,
                  dataMessage: SNProtoDataMessage?,
                  receiptMessage: SNProtoReceiptMessage?,
                  typingMessage: SNProtoTypingMessage?,
                  configurationMessage: SNProtoConfigurationMessage?,
-                 dataExtractionNotification: SNProtoDataExtractionNotification?) {
+                 dataExtractionNotification: SNProtoDataExtractionNotification?,
+                 unsendRequest: SNProtoUnsendRequest?) {
         self.proto = proto
         self.dataMessage = dataMessage
         self.receiptMessage = receiptMessage
         self.typingMessage = typingMessage
         self.configurationMessage = configurationMessage
         self.dataExtractionNotification = dataExtractionNotification
+        self.unsendRequest = unsendRequest
     }
 
     @objc
@@ -466,6 +589,11 @@ extension SNProtoTypingMessage.SNProtoTypingMessageBuilder {
             dataExtractionNotification = try SNProtoDataExtractionNotification.parseProto(proto.dataExtractionNotification)
         }
 
+        var unsendRequest: SNProtoUnsendRequest? = nil
+        if proto.hasUnsendRequest {
+            unsendRequest = try SNProtoUnsendRequest.parseProto(proto.unsendRequest)
+        }
+
         // MARK: - Begin Validation Logic for SNProtoContent -
 
         // MARK: - End Validation Logic for SNProtoContent -
@@ -475,7 +603,8 @@ extension SNProtoTypingMessage.SNProtoTypingMessageBuilder {
                                     receiptMessage: receiptMessage,
                                     typingMessage: typingMessage,
                                     configurationMessage: configurationMessage,
-                                    dataExtractionNotification: dataExtractionNotification)
+                                    dataExtractionNotification: dataExtractionNotification,
+                                    unsendRequest: unsendRequest)
         return result
     }
 

--- a/SessionMessagingKit/Protos/Generated/SessionProtos.pb.swift
+++ b/SessionMessagingKit/Protos/Generated/SessionProtos.pb.swift
@@ -196,6 +196,39 @@ extension SessionProtos_TypingMessage.Action: CaseIterable {
 
 #endif  // swift(>=4.2)
 
+struct SessionProtos_UnsendRequest {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// @required
+  var timestamp: UInt64 {
+    get {return _timestamp ?? 0}
+    set {_timestamp = newValue}
+  }
+  /// Returns true if `timestamp` has been explicitly set.
+  var hasTimestamp: Bool {return self._timestamp != nil}
+  /// Clears the value of `timestamp`. Subsequent reads from it will return its default value.
+  mutating func clearTimestamp() {self._timestamp = nil}
+
+  /// @required
+  var author: String {
+    get {return _author ?? String()}
+    set {_author = newValue}
+  }
+  /// Returns true if `author` has been explicitly set.
+  var hasAuthor: Bool {return self._author != nil}
+  /// Clears the value of `author`. Subsequent reads from it will return its default value.
+  mutating func clearAuthor() {self._author = nil}
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+
+  fileprivate var _timestamp: UInt64? = nil
+  fileprivate var _author: String? = nil
+}
+
 struct SessionProtos_Content {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -246,6 +279,15 @@ struct SessionProtos_Content {
   /// Clears the value of `dataExtractionNotification`. Subsequent reads from it will return its default value.
   mutating func clearDataExtractionNotification() {self._dataExtractionNotification = nil}
 
+  var unsendRequest: SessionProtos_UnsendRequest {
+    get {return _unsendRequest ?? SessionProtos_UnsendRequest()}
+    set {_unsendRequest = newValue}
+  }
+  /// Returns true if `unsendRequest` has been explicitly set.
+  var hasUnsendRequest: Bool {return self._unsendRequest != nil}
+  /// Clears the value of `unsendRequest`. Subsequent reads from it will return its default value.
+  mutating func clearUnsendRequest() {self._unsendRequest = nil}
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
@@ -255,6 +297,7 @@ struct SessionProtos_Content {
   fileprivate var _typingMessage: SessionProtos_TypingMessage? = nil
   fileprivate var _configurationMessage: SessionProtos_ConfigurationMessage? = nil
   fileprivate var _dataExtractionNotification: SessionProtos_DataExtractionNotification? = nil
+  fileprivate var _unsendRequest: SessionProtos_UnsendRequest? = nil
 }
 
 struct SessionProtos_KeyPair {
@@ -1504,6 +1547,50 @@ extension SessionProtos_TypingMessage.Action: SwiftProtobuf._ProtoNameProviding 
   ]
 }
 
+extension SessionProtos_UnsendRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".UnsendRequest"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "timestamp"),
+    2: .same(proto: "author"),
+  ]
+
+  public var isInitialized: Bool {
+    if self._timestamp == nil {return false}
+    if self._author == nil {return false}
+    return true
+  }
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularUInt64Field(value: &self._timestamp) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self._author) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if let v = self._timestamp {
+      try visitor.visitSingularUInt64Field(value: v, fieldNumber: 1)
+    }
+    if let v = self._author {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: SessionProtos_UnsendRequest, rhs: SessionProtos_UnsendRequest) -> Bool {
+    if lhs._timestamp != rhs._timestamp {return false}
+    if lhs._author != rhs._author {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
 extension SessionProtos_Content: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Content"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -1512,6 +1599,7 @@ extension SessionProtos_Content: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
     6: .same(proto: "typingMessage"),
     7: .same(proto: "configurationMessage"),
     8: .same(proto: "dataExtractionNotification"),
+    9: .same(proto: "unsendRequest"),
   ]
 
   public var isInitialized: Bool {
@@ -1520,6 +1608,7 @@ extension SessionProtos_Content: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
     if let v = self._typingMessage, !v.isInitialized {return false}
     if let v = self._configurationMessage, !v.isInitialized {return false}
     if let v = self._dataExtractionNotification, !v.isInitialized {return false}
+    if let v = self._unsendRequest, !v.isInitialized {return false}
     return true
   }
 
@@ -1534,6 +1623,7 @@ extension SessionProtos_Content: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
       case 6: try { try decoder.decodeSingularMessageField(value: &self._typingMessage) }()
       case 7: try { try decoder.decodeSingularMessageField(value: &self._configurationMessage) }()
       case 8: try { try decoder.decodeSingularMessageField(value: &self._dataExtractionNotification) }()
+      case 9: try { try decoder.decodeSingularMessageField(value: &self._unsendRequest) }()
       default: break
       }
     }
@@ -1555,6 +1645,9 @@ extension SessionProtos_Content: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
     if let v = self._dataExtractionNotification {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
     }
+    if let v = self._unsendRequest {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -1564,6 +1657,7 @@ extension SessionProtos_Content: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
     if lhs._typingMessage != rhs._typingMessage {return false}
     if lhs._configurationMessage != rhs._configurationMessage {return false}
     if lhs._dataExtractionNotification != rhs._dataExtractionNotification {return false}
+    if lhs._unsendRequest != rhs._unsendRequest {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/SessionMessagingKit/Protos/SessionProtos.proto
+++ b/SessionMessagingKit/Protos/SessionProtos.proto
@@ -34,12 +34,20 @@ message TypingMessage {
     required Action action    = 2;
 }
 
+message UnsendRequest {
+    // @required
+    required uint64 timestamp = 1;
+    // @required
+    required string author    = 2;
+} 
+
 message Content {
   optional DataMessage                dataMessage                = 1;
   optional ReceiptMessage             receiptMessage             = 5;
   optional TypingMessage              typingMessage              = 6;
   optional ConfigurationMessage       configurationMessage       = 7;
   optional DataExtractionNotification dataExtractionNotification = 8;
+  optional UnsendRequest              unsendRequest              = 9;	
 }
 
 message KeyPair {

--- a/SessionMessagingKit/Sending & Receiving/MessageReceiver+Handling.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageReceiver+Handling.swift
@@ -305,6 +305,7 @@ extension MessageReceiver {
         // Notify the user if needed
         guard (isMainAppAndActive || isBackgroundPoll), let tsIncomingMessage = TSMessage.fetch(uniqueId: tsMessageID, transaction: transaction) as? TSIncomingMessage,
             let thread = TSThread.fetch(uniqueId: threadID, transaction: transaction) else { return tsMessageID }
+        tsIncomingMessage.setNotificationIdentifier(UUID().uuidString, transaction: transaction)
         DispatchQueue.main.async {
             Storage.read { transaction in
                 SSKEnvironment.shared.notificationsManager!.notifyUser(for: tsIncomingMessage, in: thread, transaction: transaction)

--- a/SessionMessagingKit/Sending & Receiving/MessageReceiver+Handling.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageReceiver+Handling.swift
@@ -234,7 +234,7 @@ extension MessageReceiver {
             if let serverHash = messageToDelete.serverHash {
                 SnodeAPI.deleteMessage(publicKey: author, serverHashes: [serverHash]).retainUntilComplete()
             }
-            messageToDelete.remove(with: transaction)
+            messageToDelete.updateForDeletion(with: transaction)
         }
     }
     

--- a/SessionMessagingKit/Sending & Receiving/MessageReceiver+Handling.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageReceiver+Handling.swift
@@ -1,4 +1,5 @@
 import SignalCoreKit
+import SessionSnodeKit
 
 extension MessageReceiver {
 
@@ -229,6 +230,9 @@ extension MessageReceiver {
            let messageToDelete = userPublicKey == message.sender ? TSOutgoingMessage.find(withTimestamp: timestamp) : TSIncomingMessage.find(withAuthorId: author, timestamp: timestamp, transaction: transaction) {
             if let incomingMessage = messageToDelete as? TSIncomingMessage, let notificationIdentifier = incomingMessage.notificationIdentifier, !notificationIdentifier.isEmpty {
                 SSKEnvironment.shared.notificationsManager!.cancelNotification(notificationIdentifier)
+            }
+            if let serverHash = messageToDelete.serverHash {
+                SnodeAPI.deleteMessage(publicKey: author, serverHashes: [serverHash]).retainUntilComplete()
             }
             messageToDelete.remove(with: transaction)
         }

--- a/SessionMessagingKit/Sending & Receiving/MessageReceiver+Handling.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageReceiver+Handling.swift
@@ -227,6 +227,9 @@ extension MessageReceiver {
         let transaction = transaction as! YapDatabaseReadWriteTransaction
         if let author = message.author, let timestamp = message.timestamp,
            let messageToDelete = userPublicKey == message.sender ? TSOutgoingMessage.find(withTimestamp: timestamp) : TSIncomingMessage.find(withAuthorId: author, timestamp: timestamp, transaction: transaction) {
+            if let incomingMessage = messageToDelete as? TSIncomingMessage, let notificationIdentifier = incomingMessage.notificationIdentifier, !notificationIdentifier.isEmpty {
+                SSKEnvironment.shared.notificationsManager!.cancelNotification(notificationIdentifier)
+            }
             messageToDelete.remove(with: transaction)
         }
     }

--- a/SessionMessagingKit/Sending & Receiving/MessageReceiver+Handling.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageReceiver+Handling.swift
@@ -228,8 +228,11 @@ extension MessageReceiver {
         let transaction = transaction as! YapDatabaseReadWriteTransaction
         if let author = message.author, let timestamp = message.timestamp,
            let messageToDelete = userPublicKey == message.sender ? TSOutgoingMessage.find(withTimestamp: timestamp) : TSIncomingMessage.find(withAuthorId: author, timestamp: timestamp, transaction: transaction) {
-            if let incomingMessage = messageToDelete as? TSIncomingMessage, let notificationIdentifier = incomingMessage.notificationIdentifier, !notificationIdentifier.isEmpty {
-                SSKEnvironment.shared.notificationsManager!.cancelNotification(notificationIdentifier)
+            if let incomingMessage = messageToDelete as? TSIncomingMessage {
+                incomingMessage.markAsReadNow(withSendReadReceipt: false, transaction: transaction)
+                if let notificationIdentifier = incomingMessage.notificationIdentifier, !notificationIdentifier.isEmpty {
+                    SSKEnvironment.shared.notificationsManager!.cancelNotification(notificationIdentifier)
+                }
             }
             if let serverHash = messageToDelete.serverHash {
                 SnodeAPI.deleteMessage(publicKey: author, serverHashes: [serverHash]).retainUntilComplete()

--- a/SessionMessagingKit/Sending & Receiving/MessageReceiver+Handling.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageReceiver+Handling.swift
@@ -231,7 +231,9 @@ extension MessageReceiver {
             if let incomingMessage = messageToDelete as? TSIncomingMessage {
                 incomingMessage.markAsReadNow(withSendReadReceipt: false, transaction: transaction)
                 if let notificationIdentifier = incomingMessage.notificationIdentifier, !notificationIdentifier.isEmpty {
-                    SSKEnvironment.shared.notificationsManager!.cancelNotification(notificationIdentifier)
+                    UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [notificationIdentifier])
+                    UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [notificationIdentifier])
+                    
                 }
             }
             if let serverHash = messageToDelete.serverHash {

--- a/SessionMessagingKit/Sending & Receiving/MessageReceiver.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageReceiver.swift
@@ -124,6 +124,7 @@ public enum MessageReceiver {
             if let dataExtractionNotification = DataExtractionNotification.fromProto(proto) { return dataExtractionNotification }
             if let expirationTimerUpdate = ExpirationTimerUpdate.fromProto(proto) { return expirationTimerUpdate }
             if let configurationMessage = ConfigurationMessage.fromProto(proto) { return configurationMessage }
+            if let unsendRequest = UnsendRequest.fromProto(proto) { return unsendRequest }
             if let visibleMessage = VisibleMessage.fromProto(proto) { return visibleMessage }
             return nil
         }()

--- a/SessionMessagingKit/Sending & Receiving/MessageSender.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageSender.swift
@@ -332,6 +332,9 @@ public final class MessageSender : NSObject {
         Storage.shared.addReceivedMessageTimestamp(message.sentTimestamp!, using: transaction)
         // Get the visible message if possible
         if let tsMessage = TSOutgoingMessage.find(withTimestamp: message.sentTimestamp!) {
+            // When the sync message is successfully sent, the hash value of this TSOutgoingMessage
+            // will be replaced by the hash value of the sync message. Since the hash value of the
+            // real message has no use when we delete a message. It is OK to let it be.
             tsMessage.serverHash = message.serverHash
             // Track the open group server message ID
             tsMessage.openGroupServerMessageID = message.openGroupServerMessageID ?? 0

--- a/SessionMessagingKit/Sending & Receiving/MessageSender.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageSender.swift
@@ -332,8 +332,7 @@ public final class MessageSender : NSObject {
         Storage.shared.addReceivedMessageTimestamp(message.sentTimestamp!, using: transaction)
         // Get the visible message if possible
         if let tsMessage = TSOutgoingMessage.find(withTimestamp: message.sentTimestamp!) {
-            if (!isSyncMessage) { tsMessage.serverHash = message.serverHash }
-            else { tsMessage.syncMessageServerHash = message.serverHash }
+            tsMessage.serverHash = message.serverHash
             // Track the open group server message ID
             tsMessage.openGroupServerMessageID = message.openGroupServerMessageID ?? 0
             tsMessage.save(with: transaction)

--- a/SessionMessagingKit/Sending & Receiving/MessageSender.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageSender.swift
@@ -134,8 +134,9 @@ public final class MessageSender : NSObject {
         // • a configuration message
         // • a sync message
         // • a closed group control message of type `new`
+        // • an unsend request
         let isNewClosedGroupControlMessage = given(message as? ClosedGroupControlMessage) { if case .new = $0.kind { return true } else { return false } } ?? false
-        guard !isSelfSend || message is ConfigurationMessage || isSyncMessage || isNewClosedGroupControlMessage else {
+        guard !isSelfSend || message is ConfigurationMessage || isSyncMessage || isNewClosedGroupControlMessage || message is UnsendRequest else {
             storage.write(with: { transaction in
                 MessageSender.handleSuccessfulMessageSend(message, to: destination, using: transaction)
                 seal.fulfill(())

--- a/SessionMessagingKit/Sending & Receiving/MessageSender.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageSender.swift
@@ -332,7 +332,8 @@ public final class MessageSender : NSObject {
         Storage.shared.addReceivedMessageTimestamp(message.sentTimestamp!, using: transaction)
         // Get the visible message if possible
         if let tsMessage = TSOutgoingMessage.find(withTimestamp: message.sentTimestamp!) {
-            tsMessage.serverHash = message.serverHash
+            if (!isSyncMessage) { tsMessage.serverHash = message.serverHash }
+            else { tsMessage.syncMessageServerHash = message.serverHash }
             // Track the open group server message ID
             tsMessage.openGroupServerMessageID = message.openGroupServerMessageID ?? 0
             tsMessage.save(with: transaction)

--- a/SessionMessagingKit/Sending & Receiving/MessageSender.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageSender.swift
@@ -212,7 +212,7 @@ public final class MessageSender : NSObject {
                     isSuccess = true
                     storage.write(with: { transaction in
                         MessageSender.handleSuccessfulMessageSend(message, to: destination, isSyncMessage: isSyncMessage, using: transaction)
-                        var shouldNotify = (message is VisibleMessage && !isSyncMessage)
+                        var shouldNotify = ((message is VisibleMessage || message is UnsendRequest) && !isSyncMessage)
                         /*
                         if let closedGroupControlMessage = message as? ClosedGroupControlMessage, case .new = closedGroupControlMessage.kind {
                             shouldNotify = true

--- a/SessionMessagingKit/Sending & Receiving/Notifications/NotificationsProtocol.h
+++ b/SessionMessagingKit/Sending & Receiving/Notifications/NotificationsProtocol.h
@@ -20,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
                             inThread:(TSThread *)thread
                          transaction:(YapDatabaseReadTransaction *)transaction;
 
+- (void)cancelNotification:(NSString *)identifier;
 - (void)clearAllNotifications;
 
 @end

--- a/SessionMessagingKit/Sending & Receiving/Pollers/ClosedGroupPoller.swift
+++ b/SessionMessagingKit/Sending & Receiving/Pollers/ClosedGroupPoller.swift
@@ -117,7 +117,7 @@ public final class ClosedGroupPoller : NSObject {
                 guard let envelope = SNProtoEnvelope.from(json) else { return }
                 do {
                     let data = try envelope.serializedData()
-                    let job = MessageReceiveJob(data: data, isBackgroundPoll: false)
+                    let job = MessageReceiveJob(data: data, serverHash: json["hash"] as? String, isBackgroundPoll: false)
                     SNMessagingKitConfiguration.shared.storage.write { transaction in
                         SessionMessagingKit.JobQueue.shared.add(job, using: transaction)
                     }

--- a/SessionMessagingKit/Sending & Receiving/Pollers/Poller.swift
+++ b/SessionMessagingKit/Sending & Receiving/Pollers/Poller.swift
@@ -97,7 +97,7 @@ public final class Poller : NSObject {
                 guard let envelope = SNProtoEnvelope.from(json) else { return }
                 do {
                     let data = try envelope.serializedData()
-                    let job = MessageReceiveJob(data: data, isBackgroundPoll: false)
+                    let job = MessageReceiveJob(data: data, serverHash: json["hash"] as? String, isBackgroundPoll: false)
                     SNMessagingKitConfiguration.shared.storage.write { transaction in
                         SessionMessagingKit.JobQueue.shared.add(job, using: transaction)
                     }

--- a/SessionMessagingKit/Threads/TSThread.m
+++ b/SessionMessagingKit/Threads/TSThread.m
@@ -314,6 +314,13 @@ BOOL IsNoteToSelfEnabled(void)
     if (interaction.isDynamicInteraction) {
         return NO;
     }
+    
+    if ([interaction isKindOfClass:[TSMessage class]]) {
+        TSMessage *message = (TSMessage *)interaction;
+        if (message.isDeleted) {
+            return NO;
+        }
+    }
 
     return YES;
 }

--- a/SessionNotificationServiceExtension/NotificationServiceExtension.swift
+++ b/SessionNotificationServiceExtension/NotificationServiceExtension.swift
@@ -67,6 +67,11 @@ public final class NotificationServiceExtension : UNNotificationServiceExtension
                                 return self.completeSilenty()
                             }
                         }
+                        // Store the notification identifier for unsend request to cancel this notification
+                        tsIncomingMessage.setNotificationIdentifier(request.identifier, transaction: transaction)
+                    case let unsendRequest as UnsendRequest:
+                        MessageReceiver.handleUnsendRequest(unsendRequest, using: transaction)
+                        return self.completeSilenty()
                     case let closedGroupControlMessage as ClosedGroupControlMessage:
                         // TODO: We could consider actually handling the update here. Not sure if there's enough time though, seeing as though
                         // in some cases we need to send messages (e.g. our sender key) to a number of other users.

--- a/SessionSnodeKit/Snode.swift
+++ b/SessionSnodeKit/Snode.swift
@@ -14,6 +14,7 @@ public final class Snode : NSObject, NSCoding { // NSObject/NSCoding conformance
         case getSwarm = "get_snodes_for_pubkey"
         case getMessages = "retrieve"
         case sendMessage = "store"
+        case deleteMessage = "delete"
         case oxenDaemonRPCCall = "oxend_request"
         case getInfo = "info"
         case clearAllData = "delete_all"

--- a/SessionSnodeKit/SnodeAPI.swift
+++ b/SessionSnodeKit/SnodeAPI.swift
@@ -454,7 +454,53 @@ public final class SnodeAPI : NSObject {
         return promise
     }
     
-//    public static func deleteMessage() -> Promise
+    @objc(deleteMessageForPublickKey:serverHash:)
+    public static func objc_deleteMessage(publicKey: String, serverHash: String) -> AnyPromise {
+        AnyPromise.from(deleteMessage(publicKey: publicKey, serverHash: serverHash))
+    }
+    
+    public static func deleteMessage(publicKey: String, serverHash: String) -> Promise<RawResponsePromise> {
+        let storage = SNSnodeKitConfiguration.shared.storage
+        guard let userX25519PublicKey = storage.getUserPublicKey(),
+            let userED25519KeyPair = storage.getUserED25519KeyPair() else { return Promise(error: Error.noKeyPair) }
+        let publicKey = Features.useTestnet ? publicKey.removing05PrefixIfNeeded() : publicKey
+        let (promise, seal) = Promise<RawResponsePromise>.pending()
+        Threading.workQueue.async {
+            getTargetSnodes(for: publicKey).map2 { targetSnodes in
+                let snode = targetSnodes.first!
+                let verificationData = (Snode.Method.deleteMessage.rawValue + serverHash).data(using: String.Encoding.utf8)!
+                guard let signature = sodium.sign.signature(message: Bytes(verificationData), secretKey: userED25519KeyPair.secretKey) else { throw Error.signingFailed }
+                let parameters: JSON = [
+                    "pubkey" : userX25519PublicKey,
+                    "pubkey_ed25519" : userED25519KeyPair.publicKey.toHexString(),
+                    "messages": [serverHash],
+                    "signature": signature.toBase64()!
+                ]
+                return attempt(maxRetryCount: maxRetryCount, recoveringOn: Threading.workQueue) {
+                    invoke(.deleteMessage, on: snode, associatedWith: publicKey, parameters: parameters).map2{ rawResponse -> RawResponse in
+                        guard let json = rawResponse as? JSON else { throw HTTP.Error.invalidJSON }
+                        var result = false
+                        let isFailed = json["failed"] as? Bool ?? false
+                        if !isFailed {
+                            guard let hashes = json["deleted"] as? [String], let signature = json["signature"] as? String else { throw HTTP.Error.invalidJSON }
+                            // The signature format is ( PUBKEY_HEX || RMSG[0] || ... || RMSG[N] || DMSG[0] || ... || DMSG[M] )
+                            let verificationData = (publicKey + serverHash + hashes.joined(separator: "")).data(using: String.Encoding.utf8)!
+                            let isValid = sodium.sign.verify(message: Bytes(verificationData), publicKey: Bytes(Data(hex: snode.publicKeySet.ed25519Key)), signature: Bytes(Data(base64Encoded: signature)!))
+                            result = isValid
+                        } else {
+                            if let reason = json["reason"] as? String, let statusCode = json["code"] as? String {
+                                SNLog("Couldn't delete message with hash: \(serverHash) due to error: \(reason) (\(statusCode)).")
+                            } else {
+                                SNLog("Couldn't delete message with hash: \(serverHash).")
+                            }
+                        }
+                        return result
+                    }
+                }
+            }.done2 { seal.fulfill($0) }.catch2 { seal.reject($0) }
+        }
+        return promise
+    }
     
     /// Clears all the user's data from their swarm. Returns a dictionary of snode public key to deletion confirmation.
     public static func clearAllData() -> Promise<[String:Bool]> {

--- a/SessionSnodeKit/SnodeAPI.swift
+++ b/SessionSnodeKit/SnodeAPI.swift
@@ -454,6 +454,8 @@ public final class SnodeAPI : NSObject {
         return promise
     }
     
+//    public static func deleteMessage() -> Promise
+    
     /// Clears all the user's data from their swarm. Returns a dictionary of snode public key to deletion confirmation.
     public static func clearAllData() -> Promise<[String:Bool]> {
         let storage = SNSnodeKitConfiguration.shared.storage

--- a/SignalUtilitiesKit/Utilities/NoopNotificationsManager.swift
+++ b/SignalUtilitiesKit/Utilities/NoopNotificationsManager.swift
@@ -8,6 +8,10 @@ public class NoopNotificationsManager: NSObject, NotificationsProtocol {
     public func notifyUser(for incomingMessage: TSIncomingMessage, in thread: TSThread, transaction: YapDatabaseReadTransaction) {
         owsFailDebug("")
     }
+    
+    public func cancelNotification(_ identifier: String) {
+        owsFailDebug("")
+    }
 
     public func clearAllNotifications() {
         Logger.warn("clearAllNotifications")


### PR DESCRIPTION
- Use the `delete` endpoint to delete a specific message with the hash
- Send `UnsendRequest` to the recipient and linked devices to delete the message
- Dismiss the notification of a deleted message
- New action sheet UI for delete options
- New message bubble UI for deleted messages