### PR TITLE
Potentially fix closed groups sometimes not receiving messages

### DIFF
--- a/SessionMessagingKit/Sending & Receiving/Pollers/ClosedGroupPoller.swift
+++ b/SessionMessagingKit/Sending & Receiving/Pollers/ClosedGroupPoller.swift
@@ -40,8 +40,11 @@ public final class ClosedGroupPoller : NSObject {
 
     public func startPolling(for groupPublicKey: String) {
         guard !isPolling(for: groupPublicKey) else { return }
-        setUpPolling(for: groupPublicKey)
+        // Might be a race condition that the setUpPolling finishes too soon,
+        // and the timer is not created, if we mark the group as is polling
+        // after setUpPolling. So the poller may not work, thus misses messages.
         isPolling[groupPublicKey] = true
+        setUpPolling(for: groupPublicKey)
     }
 
     @objc public func stop() {
@@ -51,8 +54,8 @@ public final class ClosedGroupPoller : NSObject {
     }
 
     public func stopPolling(for groupPublicKey: String) {
-        timers[groupPublicKey]?.invalidate()
         isPolling[groupPublicKey] = false
+        timers[groupPublicKey]?.invalidate()
     }
 
     // MARK: Private API


### PR DESCRIPTION
This is also a race condition where `setUpPolling` finishes too soon before the group is marked as `isPolling`.
In this situation the timer for polling won't be created, so the poller will never have a chance to start unless restart the app.