### PR TITLE
Fix replying outgoing message in open groups

### DIFF
--- a/Session/Conversations/ConversationViewModel.m
+++ b/Session/Conversations/ConversationViewModel.m
@@ -1158,7 +1158,7 @@ NS_ASSUME_NONNULL_BEGIN
                 break;
         }
 
-        uint64_t viewItemTimestamp = viewItem.interaction.timestampForUI;
+        uint64_t viewItemTimestamp = viewItem.interaction.timestamp;
         OWSAssertDebug(viewItemTimestamp > 0);
 
         BOOL shouldShowDate = NO;
@@ -1225,7 +1225,7 @@ NS_ASSUME_NONNULL_BEGIN
         NSAttributedString *_Nullable senderName = nil;
 
         OWSInteractionType interactionType = viewItem.interaction.interactionType;
-        NSString *timestampText = [DateUtil formatTimestampShort:viewItem.interaction.timestampForUI];
+        NSString *timestampText = [DateUtil formatTimestampShort:viewItem.interaction.timestamp];
 
         if (interactionType == OWSInteractionType_OutgoingMessage) {
             TSOutgoingMessage *outgoingMessage = (TSOutgoingMessage *)viewItem.interaction;

--- a/SessionMessagingKit/Messages/Signal/TSIncomingMessage+Conversion.swift
+++ b/SessionMessagingKit/Messages/Signal/TSIncomingMessage+Conversion.swift
@@ -19,7 +19,6 @@ public extension TSIncomingMessage {
             expiresInSeconds: !isOpenGroupMessage ? expiration : 0, // Ensure we don't ever expire open group messages
             quotedMessage: quotedMessage,
             linkPreview: linkPreview,
-            serverTimestamp: visibleMessage.openGroupServerTimestamp as NSNumber?,
             wasReceivedByUD: true,
             openGroupInvitationName: visibleMessage.openGroupInvitation?.name,
             openGroupInvitationURL: visibleMessage.openGroupInvitation?.url,

--- a/SessionMessagingKit/Messages/Signal/TSIncomingMessage.h
+++ b/SessionMessagingKit/Messages/Signal/TSIncomingMessage.h
@@ -59,7 +59,6 @@ NS_ASSUME_NONNULL_BEGIN
                  expiresInSeconds:(uint32_t)expiresInSeconds
                     quotedMessage:(nullable TSQuotedMessage *)quotedMessage
                       linkPreview:(nullable OWSLinkPreview *)linkPreview
-                  serverTimestamp:(nullable NSNumber *)serverTimestamp
                   wasReceivedByUD:(BOOL)wasReceivedByUD
           openGroupInvitationName:(nullable NSString *)openGroupInvitationName
            openGroupInvitationURL:(nullable NSString *)openGroupInvitationURL

--- a/SessionMessagingKit/Messages/Signal/TSIncomingMessage.h
+++ b/SessionMessagingKit/Messages/Signal/TSIncomingMessage.h
@@ -12,8 +12,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface TSIncomingMessage : TSMessage <OWSReadTracking>
 
-@property (nonatomic, readonly, nullable) NSNumber *serverTimestamp;
-
 @property (nonatomic, readonly) BOOL wasReceivedByUD;
 
 @property (nonatomic, readonly) BOOL isUserMentioned;

--- a/SessionMessagingKit/Messages/Signal/TSIncomingMessage.m
+++ b/SessionMessagingKit/Messages/Signal/TSIncomingMessage.m
@@ -21,8 +21,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, getter=wasRead) BOOL read;
 
-@property (nonatomic, nullable) NSNumber *serverTimestamp;
-
 @end
 
 #pragma mark -
@@ -52,7 +50,6 @@ NS_ASSUME_NONNULL_BEGIN
                  expiresInSeconds:(uint32_t)expiresInSeconds
                     quotedMessage:(nullable TSQuotedMessage *)quotedMessage
                       linkPreview:(nullable OWSLinkPreview *)linkPreview
-                  serverTimestamp:(nullable NSNumber *)serverTimestamp
                   wasReceivedByUD:(BOOL)wasReceivedByUD
           openGroupInvitationName:(nullable NSString *)openGroupInvitationName
            openGroupInvitationURL:(nullable NSString *)openGroupInvitationURL
@@ -77,7 +74,6 @@ NS_ASSUME_NONNULL_BEGIN
     _authorId = authorId;
     _sourceDeviceId = sourceDeviceId;
     _read = NO;
-    _serverTimestamp = serverTimestamp;
     _wasReceivedByUD = wasReceivedByUD;
     _notificationIdentifier = nil;
 

--- a/SessionMessagingKit/Messages/Signal/TSInteraction.h
+++ b/SessionMessagingKit/Messages/Signal/TSInteraction.h
@@ -38,9 +38,6 @@ NSString *NSStringFromOWSInteractionType(OWSInteractionType value);
 @property (nonatomic, readonly) uint64_t timestamp;
 @property (nonatomic, readonly) uint64_t sortId;
 @property (nonatomic, readonly) uint64_t receivedAtTimestamp;
-@property (nonatomic, readonly) BOOL shouldUseServerTime;
-
-- (uint64_t)timestampForUI;
 
 - (NSDate *)dateForUI;
 
@@ -79,6 +76,8 @@ NSString *NSStringFromOWSInteractionType(OWSInteractionType value);
 
 - (void)saveNextSortIdWithTransaction:(YapDatabaseReadWriteTransaction *)transaction
     NS_SWIFT_NAME(saveNextSortId(transaction:));
+
+- (void)updateTimestamp:(uint64_t)timestamp;
 
 @end
 

--- a/SessionMessagingKit/Messages/Signal/TSInteraction.m
+++ b/SessionMessagingKit/Messages/Signal/TSInteraction.m
@@ -165,17 +165,6 @@ NSString *NSStringFromOWSInteractionType(OWSInteractionType value)
 
 #pragma mark Date operations
 
-- (uint64_t)timestampForUI
-{
-    // We always want to show the sent timestamp. In the case of one-on-one, closed group and V2 open group messages we get
-    // this from the protobuf. In the case of V1 open group messages we get it from the envelope in which the message is
-    // wrapped, which gets parsed to `serverTimestamp` in that case.
-    if ([self isKindOfClass:TSIncomingMessage.class] && ((TSIncomingMessage *)self).isOpenGroupMessage && ((TSIncomingMessage *)self).serverTimestamp != nil) {
-        return ((TSIncomingMessage *)self).serverTimestamp.unsignedLongLongValue;
-    }
-    return _timestamp;
-}
-
 - (uint64_t)timestampForLegacySorting
 {
     return self.timestamp;
@@ -183,7 +172,7 @@ NSString *NSStringFromOWSInteractionType(OWSInteractionType value)
 
 - (NSDate *)dateForUI
 {
-    return [NSDate ows_dateWithMillisecondsSince1970:self.timestampForUI];
+    return [NSDate ows_dateWithMillisecondsSince1970:self.timestamp];
 }
 
 - (NSDate *)receivedAtDate
@@ -229,12 +218,6 @@ NSString *NSStringFromOWSInteractionType(OWSInteractionType value)
 
 - (uint64_t)sortId
 {
-    // We always want to sort on the sent timestamp. In the case of one-on-one, closed group and V2 open group messages we get
-    // this from the protobuf. In the case of V1 open group messages we get it from the envelope in which the message is
-    // wrapped, which gets parsed to `serverTimestamp` in that case.
-    if ([self isKindOfClass:TSIncomingMessage.class] && ((TSIncomingMessage *)self).isOpenGroupMessage && ((TSIncomingMessage *)self).serverTimestamp != nil) {
-        return ((TSIncomingMessage *)self).serverTimestamp.unsignedLongLongValue;
-    }
     return self.timestamp;
 }
 
@@ -279,6 +262,12 @@ NSString *NSStringFromOWSInteractionType(OWSInteractionType value)
     }
     [self saveWithTransaction:transaction];
 }
+
+- (void)updateTimestamp:(uint64_t)timestamp
+{
+    _timestamp = timestamp;
+}
+
 
 @end
 

--- a/SessionMessagingKit/Messages/Signal/TSOutgoingMessage.h
+++ b/SessionMessagingKit/Messages/Signal/TSOutgoingMessage.h
@@ -159,6 +159,9 @@ typedef NS_ENUM(NSInteger, TSGroupMetaMessage) {
 
 #pragma mark - Update With... Methods
 
+- (void)updateOpenGroupServerID:(uint64_t)openGroupServerID
+                serverTimeStamp:(uint64_t)timestamp;
+
 // This method is used to record a successful send to one recipient.
 - (void)updateWithSentRecipient:(NSString *)recipientId
                     wasSentByUD:(BOOL)wasSentByUD

--- a/SessionMessagingKit/Messages/Signal/TSOutgoingMessage.m
+++ b/SessionMessagingKit/Messages/Signal/TSOutgoingMessage.m
@@ -450,6 +450,12 @@ NSString *NSStringForOutgoingMessageRecipientState(OWSOutgoingMessageRecipientSt
 
 #pragma mark - Update With... Methods
 
+- (void)updateOpenGroupServerID:(uint64_t)openGroupServerID serverTimeStamp:(uint64_t)timestamp
+{
+    self.openGroupServerMessageID = openGroupServerID;
+    [super updateTimestamp:timestamp];
+}
+
 - (void)updateWithSendingError:(NSError *)error transaction:(YapDatabaseReadWriteTransaction *)transaction
 {
     [self applyChangeToSelfAndLatestCopy:transaction

--- a/SessionMessagingKit/Sending & Receiving/Pollers/OpenGroupPollerV2.swift
+++ b/SessionMessagingKit/Sending & Receiving/Pollers/OpenGroupPollerV2.swift
@@ -73,7 +73,6 @@ public final class OpenGroupPollerV2 : NSObject {
                 let envelope = SNProtoEnvelope.builder(type: .sessionMessage, timestamp: message.sentTimestamp)
                 envelope.setContent(data)
                 envelope.setSource(message.sender!) // Safe because messages with a nil sender are filtered out
-                envelope.setServerTimestamp(message.sentTimestamp)
                 do {
                     let data = try envelope.buildSerializedData()
                     let (message, proto) = try MessageReceiver.parse(data, openGroupMessageServerID: UInt64(message.serverID!), isRetry: false, using: transaction)


### PR DESCRIPTION
- Fixes the issue that Android and desktop can't find the original quote when an iOS user replies to their own message in an open group.
- Clean the unused server timestamp we introduced before for open groups messages