### PR TITLE
Default link previews to use HTTPS

### DIFF
--- a/SessionMessagingKit/Sending & Receiving/Link Previews/OWSLinkPreview.swift
+++ b/SessionMessagingKit/Sending & Receiving/Link Previews/OWSLinkPreview.swift
@@ -385,10 +385,16 @@ public class OWSLinkPreview: MTLModel {
         var urlMatches: [URLMatchResult] = []
         let matches = detector.matches(in: body, options: [], range: NSRange(location: 0, length: body.count))
         for match in matches {
-            guard let matchURL = match.url else {
-                continue
-            }
-            let urlString = matchURL.absoluteString
+            guard let matchURL = match.url else { continue }
+            
+            // If the URL entered didn't have a scheme it will default to 'http', we want to catch this and
+            // set the scheme to 'https' instead as we don't load previews for 'http' so this will result
+            // in more previews actually getting loaded without forcing the user to enter 'https://' before
+            // every URL they enter
+            let urlString: String = (matchURL.absoluteString == "http://\(body)" ?
+                "https://\(body)" :
+                matchURL.absoluteString
+            )
             if isValidLinkUrl(urlString) {
                 let matchResult = URLMatchResult(urlString: urlString, matchRange: match.range)
                 urlMatches.append(matchResult)


### PR DESCRIPTION
Updated the code to use HTTPS when generating a link preview when a url scheme isn't provided (would previously default to HTTP which the code intentionally avoids loading)