### PR TITLE
Fixed unrecognised selector crash

### DIFF
--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -675,7 +675,7 @@
 		C3A7219A2558C1660043A11F /* AnyPromise+Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A721992558C1660043A11F /* AnyPromise+Conversion.swift */; };
 		C3A7225E2558C38D0043A11F /* Promise+Retaining.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A7225D2558C38D0043A11F /* Promise+Retaining.swift */; };
 		C3A76A8D25DB83F90074CB90 /* PermissionMissingModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A76A8C25DB83F90074CB90 /* PermissionMissingModal.swift */; };
-		C3AABDDF2553ECF00042FF4C /* Array+Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C2A5D12553860800C340D1 /* Array+Description.swift */; };
+		C3AABDDF2553ECF00042FF4C /* Array+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C2A5D12553860800C340D1 /* Array+Utilities.swift */; };
 		C3AAFFF225AE99710089E6DD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AAFFF125AE99710089E6DD /* AppDelegate.swift */; };
 		C3ADC66126426688005F1414 /* ShareVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3ADC66026426688005F1414 /* ShareVC.swift */; };
 		C3BBE0762554CDA60050F1E3 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3BBE0752554CDA60050F1E3 /* Configuration.swift */; };
@@ -1749,7 +1749,7 @@
 		C3C2A5CE2553860700C340D1 /* Logging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		C3C2A5CF2553860700C340D1 /* Promise+Hashing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Promise+Hashing.swift"; sourceTree = "<group>"; };
 		C3C2A5D02553860800C340D1 /* Promise+Threading.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Promise+Threading.swift"; sourceTree = "<group>"; };
-		C3C2A5D12553860800C340D1 /* Array+Description.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Description.swift"; sourceTree = "<group>"; };
+		C3C2A5D12553860800C340D1 /* Array+Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Utilities.swift"; sourceTree = "<group>"; };
 		C3C2A5D22553860900C340D1 /* String+Trimming.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Trimming.swift"; sourceTree = "<group>"; };
 		C3C2A5D32553860900C340D1 /* Promise+Delaying.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Promise+Delaying.swift"; sourceTree = "<group>"; };
 		C3C2A5D42553860A00C340D1 /* Threading.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Threading.swift; sourceTree = "<group>"; };
@@ -2349,7 +2349,7 @@
 			children = (
 				C33FDB8A255A581200E217F9 /* AppContext.h */,
 				C33FDB85255A581100E217F9 /* AppContext.m */,
-				C3C2A5D12553860800C340D1 /* Array+Description.swift */,
+				C3C2A5D12553860800C340D1 /* Array+Utilities.swift */,
 				C33FDAA8255A57FF00E217F9 /* BuildConfiguration.swift */,
 				B8F5F58225EC94A6003BF8D4 /* Collection+Subscripting.swift */,
 				B8AE75A325A6C6A6001A84D2 /* Data+Trimming.swift */,
@@ -4655,7 +4655,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C3AABDDF2553ECF00042FF4C /* Array+Description.swift in Sources */,
+				C3AABDDF2553ECF00042FF4C /* Array+Utilities.swift in Sources */,
 				C32C5A47256DB8F0003C73A2 /* ECKeyPair+Hexadecimal.swift in Sources */,
 				C3D9E41525676C320040E4F3 /* Storage.swift in Sources */,
 				C32C5D83256DD5B6003C73A2 /* SSKKeychainStorage.swift in Sources */,

--- a/Session/Utilities/ContactUtilities.swift
+++ b/Session/Utilities/ContactUtilities.swift
@@ -5,6 +5,7 @@ enum ContactUtilities {
         // Collect all contacts
         var result: [String] = []
         Storage.read { transaction in
+            // FIXME: If a user deletes a contact thread they will no longer appear in this list (ie. won't be an option for closed group conversations)
             TSContactThread.enumerateCollectionObjects(with: transaction) { object, _ in
                 guard
                     let thread: TSContactThread = object as? TSContactThread,

--- a/SessionMessagingKit/Messages/Signal/TSIncomingMessage.h
+++ b/SessionMessagingKit/Messages/Signal/TSIncomingMessage.h
@@ -85,7 +85,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSString *authorId;
 
 // convenience method for expiring a message which was just read
-- (void)markAsReadNowWithSendReadReceipt:(BOOL)sendReadReceipt
+- (void)markAsReadNowWithTrySendReadReceipt:(BOOL)trySendReadReceipt
                              transaction:(YapDatabaseReadWriteTransaction *)transaction;
 
 - (void)setNotificationIdentifier:(NSString * _Nullable)notificationIdentifier

--- a/SessionMessagingKit/Sending & Receiving/MessageReceiver+Handling.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageReceiver+Handling.swift
@@ -238,12 +238,6 @@ extension MessageReceiver {
                         thread.remove(with: transaction)
                     }
                 }
-                else {
-                    // Otherwise create and save the thread
-                    let thread = TSContactThread.getOrCreateThread(withContactSessionID: sessionID, transaction: transaction)
-                    thread.shouldBeVisible = true
-                    thread.save(with: transaction)
-                }
             }
             
             // FIXME: 'OWSBlockingManager' manages it's own dbConnection and transactions so we have to dispatch this to prevent deadlocks

--- a/SessionMessagingKit/Sending & Receiving/MessageReceiver+Handling.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageReceiver+Handling.swift
@@ -296,7 +296,7 @@ extension MessageReceiver {
             }
             if let messageToDelete = localMessage {
                 if let incomingMessage = messageToDelete as? TSIncomingMessage {
-                    incomingMessage.markAsReadNow(withSendReadReceipt: false, transaction: transaction)
+                    incomingMessage.markAsReadNow(withTrySendReadReceipt: false, transaction: transaction)
                     if let notificationIdentifier = incomingMessage.notificationIdentifier, !notificationIdentifier.isEmpty {
                         UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [notificationIdentifier])
                         UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [notificationIdentifier])

--- a/SessionUtilitiesKit/General/Array+Utilities.swift
+++ b/SessionUtilitiesKit/General/Array+Utilities.swift
@@ -5,3 +5,9 @@ public extension Array where Element : CustomStringConvertible {
         return "[ " + map { $0.description }.joined(separator: ", ") + " ]"
     }
 }
+
+public extension Array where Element: Hashable {
+    func asSet() -> Set<Element> {
+        return Set(self)
+    }
+}


### PR DESCRIPTION
@RyanRory Sorry I missed this in #568, looks like there is no compile time validation between Swift files and Objective C implementation files (as long as the header matches the Swift) - this fixes a crash that occurs when restoring a device if you have an unsend request in your message history