### PR TITLE
Fix for a UI call running on background thread

### DIFF
--- a/Session/Home/HomeVC.swift
+++ b/Session/Home/HomeVC.swift
@@ -84,6 +84,12 @@ final class HomeVC : BaseVC, UITableViewDataSource, UITableViewDelegate, NewConv
     // MARK: Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        // Note: This is a hack to ensure `isRTL` is initially gets run on the main thread so the value is cached (it gets
+        // called on background threads and if it hasn't cached the value then it can cause odd performance issues since
+        // it accesses UIKit)
+        _ = CurrentAppContext().isRTL
+        
         // Threads (part 1)
         dbConnection.beginLongLivedReadTransaction() // Freeze the connection for use on the main thread (this gives us a stable data source that doesn't change until we tell it to)
         // Preparation

--- a/Session/Meta/MainAppContext.m
+++ b/Session/Meta/MainAppContext.m
@@ -166,6 +166,7 @@ NSString *const ReportedApplicationStateDidChangeNotification = @"ReportedApplic
 
 - (BOOL)isRTL
 {
+    // FIXME: We should try to remove this as we've had to add a hack to ensure the first call to this runs on the main thread
     static BOOL isRTL = NO;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{


### PR DESCRIPTION
- Added an initial call to `isRTL` on the main thread to prevent a background thread calling it first