### PR TITLE
Increased the file upload size to 10Mb

### DIFF
--- a/SessionMessagingKit/Database/Models/Attachment.swift
+++ b/SessionMessagingKit/Database/Models/Attachment.swift
@@ -1062,7 +1062,7 @@ extension Attachment {
         
         // Check the file size
         SNLog("File size: \(data.count) bytes.")
-        if Double(data.count) > Double(FileServerAPI.maxFileSize) / FileServerAPI.fileSizeORMultiplier {
+        if data.count > FileServerAPI.maxFileSize {
             failure?(HTTP.Error.maxFileSizeExceeded)
             return
         }

--- a/SessionMessagingKit/File Server/FileServerAPI.swift
+++ b/SessionMessagingKit/File Server/FileServerAPI.swift
@@ -15,13 +15,9 @@ public final class FileServerAPI: NSObject {
     @objc public static let server = "http://filev2.getsession.org"
     public static let serverPublicKey = "da21e1d886c6fbaea313f75298bd64aab03a97ce985b46bb2dad9f2089c8ee59"
     public static let maxFileSize = (10 * 1024 * 1024) // 10 MB
-    /// The file server has a file size limit of `maxFileSize`, which the Service Nodes try to enforce as well. However, the limit applied by the Service Nodes
-    /// is on the **HTTP request** and not the actual file size. Because the file server expects the file data to be base 64 encoded, the size of the HTTP
-    /// request for a given file will be at least `ceil(n / 3) * 4` bytes, where n is the file size in bytes. This is the minimum size because there might also
-    /// be other parameters in the request. On average the multiplier appears to be about 1.5, so when checking whether the file will exceed the file size limit when
-    /// uploading a file we just divide the size of the file by this number. The alternative would be to actually check the size of the HTTP request but that's only
-    /// possible after proof of work has been calculated and the onion request encryption has happened, which takes several seconds.
-    public static let fileSizeORMultiplier: Double = 2
+    
+    /// Standard timeout is 10 seconds which is a little too short fir file upload/download with slightly larger files
+    public static let fileTimeout: TimeInterval = 30
     
     // MARK: - File Storage
     
@@ -77,7 +73,7 @@ public final class FileServerAPI: NSObject {
             return Promise(error: error)
         }
         
-        return OnionRequestAPI.sendOnionRequest(urlRequest, to: request.server, with: serverPublicKey)
+        return OnionRequestAPI.sendOnionRequest(urlRequest, to: request.server, with: serverPublicKey, timeout: FileServerAPI.fileTimeout)
             .map2 { _, response in
                 guard let response: Data = response else { throw HTTP.Error.parsingFailed }
                 

--- a/SessionMessagingKit/Open Groups/OpenGroupAPI.swift
+++ b/SessionMessagingKit/Open Groups/OpenGroupAPI.swift
@@ -871,6 +871,7 @@ public enum OpenGroupAPI {
                     ],
                     body: bytes
                 ),
+                timeout: FileServerAPI.fileTimeout,
                 using: dependencies
             )
             .decoded(as: FileUploadResponse.self, on: OpenGroupAPI.workQueue, using: dependencies)
@@ -890,6 +891,7 @@ public enum OpenGroupAPI {
                     server: server,
                     endpoint: .roomFileIndividual(roomToken, fileId)
                 ),
+                timeout: FileServerAPI.fileTimeout,
                 using: dependencies
             )
             .map { responseInfo, maybeData in
@@ -1391,6 +1393,7 @@ public enum OpenGroupAPI {
         _ db: Database,
         request: Request<T, Endpoint>,
         forceBlinded: Bool = false,
+        timeout: TimeInterval = HTTP.timeout,
         using dependencies: SMKDependencies = SMKDependencies()
     ) -> Promise<(OnionRequestResponseInfoType, Data?)> {
         let urlRequest: URLRequest
@@ -1415,6 +1418,6 @@ public enum OpenGroupAPI {
             return Promise(error: OpenGroupAPIError.signingFailed)
         }
         
-        return dependencies.onionApi.sendOnionRequest(signedRequest, to: request.server, with: publicKey)
+        return dependencies.onionApi.sendOnionRequest(signedRequest, to: request.server, with: publicKey, timeout: timeout)
     }
 }

--- a/SessionSnodeKit/OnionRequestAPI.swift
+++ b/SessionSnodeKit/OnionRequestAPI.swift
@@ -7,13 +7,17 @@ import PromiseKit
 import SessionUtilitiesKit
 
 public protocol OnionRequestAPIType {
-    static func sendOnionRequest(to snode: Snode, invoking method: SnodeAPIEndpoint, with parameters: JSON, associatedWith publicKey: String?) -> Promise<Data>
-    static func sendOnionRequest(_ request: URLRequest, to server: String, using version: OnionRequestAPIVersion, with x25519PublicKey: String) -> Promise<(OnionRequestResponseInfoType, Data?)>
+    static func sendOnionRequest(to snode: Snode, invoking method: SnodeAPIEndpoint, with parameters: JSON, associatedWith publicKey: String?, timeout: TimeInterval) -> Promise<Data>
+    static func sendOnionRequest(_ request: URLRequest, to server: String, using version: OnionRequestAPIVersion, with x25519PublicKey: String, timeout: TimeInterval) -> Promise<(OnionRequestResponseInfoType, Data?)>
 }
 
 public extension OnionRequestAPIType {
-    static func sendOnionRequest(_ request: URLRequest, to server: String, with x25519PublicKey: String) -> Promise<(OnionRequestResponseInfoType, Data?)> {
-        sendOnionRequest(request, to: server, using: .v4, with: x25519PublicKey)
+    static func sendOnionRequest(to snode: Snode, invoking method: SnodeAPIEndpoint, with parameters: JSON, associatedWith publicKey: String?) -> Promise<Data> {
+        sendOnionRequest(to: snode, invoking: method, with: parameters, associatedWith: publicKey, timeout: HTTP.timeout)
+    }
+    
+    static func sendOnionRequest(_ request: URLRequest, to server: String, with x25519PublicKey: String, timeout: TimeInterval = HTTP.timeout) -> Promise<(OnionRequestResponseInfoType, Data?)> {
+        sendOnionRequest(request, to: server, using: .v4, with: x25519PublicKey, timeout: timeout)
     }
 }
 
@@ -369,7 +373,7 @@ public enum OnionRequestAPI: OnionRequestAPIType {
     // MARK: - Public API
     
     /// Sends an onion request to `snode`. Builds new paths as needed.
-    public static func sendOnionRequest(to snode: Snode, invoking method: SnodeAPIEndpoint, with parameters: JSON, associatedWith publicKey: String? = nil) -> Promise<Data> {
+    public static func sendOnionRequest(to snode: Snode, invoking method: SnodeAPIEndpoint, with parameters: JSON, associatedWith publicKey: String? = nil, timeout: TimeInterval = HTTP.timeout) -> Promise<Data> {
         let payloadJson: JSON = [ "method" : method.rawValue, "params" : parameters ]
         
         guard let payload: Data = try? JSONSerialization.data(withJSONObject: payloadJson, options: []) else {
@@ -377,7 +381,7 @@ public enum OnionRequestAPI: OnionRequestAPIType {
         }
         
         /// **Note:** Currently the service nodes only support V3 Onion Requests
-        return sendOnionRequest(with: payload, to: OnionRequestAPIDestination.snode(snode), version: .v3)
+        return sendOnionRequest(with: payload, to: OnionRequestAPIDestination.snode(snode), version: .v3, timeout: timeout)
             .map { _, maybeData in
                 guard let data: Data = maybeData else { throw HTTP.Error.invalidResponse }
                 
@@ -393,7 +397,7 @@ public enum OnionRequestAPI: OnionRequestAPIType {
     }
 
     /// Sends an onion request to `server`. Builds new paths as needed.
-    public static func sendOnionRequest(_ request: URLRequest, to server: String, using version: OnionRequestAPIVersion = .v4, with x25519PublicKey: String) -> Promise<(OnionRequestResponseInfoType, Data?)> {
+    public static func sendOnionRequest(_ request: URLRequest, to server: String, using version: OnionRequestAPIVersion = .v4, with x25519PublicKey: String, timeout: TimeInterval = HTTP.timeout) -> Promise<(OnionRequestResponseInfoType, Data?)> {
         guard let url = request.url, let host = request.url?.host else {
             return Promise(error: OnionRequestAPIError.invalidURL)
         }
@@ -412,14 +416,14 @@ public enum OnionRequestAPI: OnionRequestAPIType {
             scheme: scheme,
             port: port
         )
-        let promise = sendOnionRequest(with: payload, to: destination, version: version)
+        let promise = sendOnionRequest(with: payload, to: destination, version: version, timeout: timeout)
         promise.catch2 { error in
             SNLog("Couldn't reach server: \(url) due to error: \(error).")
         }
         return promise
     }
 
-    public static func sendOnionRequest(with payload: Data, to destination: OnionRequestAPIDestination, version: OnionRequestAPIVersion) -> Promise<(OnionRequestResponseInfoType, Data?)> {
+    public static func sendOnionRequest(with payload: Data, to destination: OnionRequestAPIDestination, version: OnionRequestAPIVersion, timeout: TimeInterval = HTTP.timeout) -> Promise<(OnionRequestResponseInfoType, Data?)> {
         let (promise, seal) = Promise<(OnionRequestResponseInfoType, Data?)>.pending()
         var guardSnode: Snode?
         
@@ -444,7 +448,7 @@ public enum OnionRequestAPI: OnionRequestAPIType {
                     }
                     let destinationSymmetricKey = intermediate.destinationSymmetricKey
                     
-                    HTTP.execute(.post, url, body: body)
+                    HTTP.execute(.post, url, body: body, timeout: timeout)
                         .done2 { responseData in
                             handleResponse(
                                 responseData: responseData,

--- a/SignalUtilitiesKit/Configuration.swift
+++ b/SignalUtilitiesKit/Configuration.swift
@@ -8,10 +8,7 @@ import SessionMessagingKit
 public enum Configuration {
     public static func performMainSetup() {
         // Need to do this first to ensure the legacy database exists
-        SNUtilitiesKit.configure(
-            maxFileSize: UInt(Double(FileServerAPI.maxFileSize) / FileServerAPI.fileSizeORMultiplier)
-        )
-        
+        SNUtilitiesKit.configure(maxFileSize: UInt(FileServerAPI.maxFileSize))
         SNMessagingKit.configure()
         SNSnodeKit.configure()
         SNUIKit.configure()


### PR DESCRIPTION
- Removed the 'fileSizeORMultiplier' that was dealing with the b64 encoding (no longer exists)
- Increased the request timeout for file upload/download to 30 seconds (up from 10 seconds)