### PR TITLE
Use service node offset time where possible

### DIFF
--- a/Session/Calls/Call Management/SessionCall.swift
+++ b/Session/Calls/Call Management/SessionCall.swift
@@ -206,7 +206,7 @@ public final class SessionCall: CurrentCallProtocol, WebRTCSessionDelegate {
             let thread: SessionThread = try? SessionThread.fetchOne(db, id: sessionId)
         else { return }
         
-        let timestampMs: Int64 = Int64(floor(Date().timeIntervalSince1970 * 1000))
+        let timestampMs: Int64 = SnodeAPI.currentOffsetTimestampMs()
         let message: CallMessage = CallMessage(
             uuid: self.uuid,
             kind: .preOffer,

--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -409,7 +409,7 @@ extension ConversationVC:
         // flags appropriately
         let threadId: String = self.viewModel.threadData.threadId
         let oldThreadShouldBeVisible: Bool = (self.viewModel.threadData.threadShouldBeVisible == true)
-        let sentTimestampMs: Int64 = Int64(floor((Date().timeIntervalSince1970 * 1000)))
+        let sentTimestampMs: Int64 = SnodeAPI.currentOffsetTimestampMs()
         let linkPreviewDraft: LinkPreviewDraft? = snInputView.linkPreviewInfo?.draft
         let quoteModel: QuotedReplyModel? = snInputView.quoteDraftInfo?.model
         
@@ -534,7 +534,7 @@ extension ConversationVC:
         // flags appropriately
         let threadId: String = self.viewModel.threadData.threadId
         let oldThreadShouldBeVisible: Bool = (self.viewModel.threadData.threadShouldBeVisible == true)
-        let sentTimestampMs: Int64 = Int64(floor((Date().timeIntervalSince1970 * 1000)))
+        let sentTimestampMs: Int64 = SnodeAPI.currentOffsetTimestampMs()
 
         // If this was a message request then approve it
         approveMessageRequestIfNeeded(
@@ -640,7 +640,7 @@ extension ConversationVC:
                 threadVariant: threadVariant,
                 threadIsMessageRequest: threadIsMessageRequest,
                 direction: .outgoing,
-                timestampMs: Int64(floor(Date().timeIntervalSince1970 * 1000))
+                timestampMs: SnodeAPI.currentOffsetTimestampMs()
             )
             
             if needsToStartTypingIndicator {
@@ -1219,7 +1219,7 @@ extension ConversationVC:
         guard !threadIsMessageRequest else { return }
         
         // Perform local rate limiting (don't allow more than 20 reactions within 60 seconds)
-        let sentTimestamp: Int64 = Int64(floor(Date().timeIntervalSince1970 * 1000))
+        let sentTimestamp: Int64 = SnodeAPI.currentOffsetTimestampMs()
         let recentReactionTimestamps: [Int64] = General.cache.wrappedValue.recentReactionTimestamps
         
         guard
@@ -2044,7 +2044,7 @@ extension ConversationVC:
         
         // Create URL
         let directory: String = OWSTemporaryDirectory()
-        let fileName: String = "\(Int64(floor(Date().timeIntervalSince1970 * 1000))).m4a"
+        let fileName: String = "\(SnodeAPI.currentOffsetTimestampMs()).m4a"
         let url: URL = URL(fileURLWithPath: directory).appendingPathComponent(fileName)
         
         // Set up audio session
@@ -2285,7 +2285,7 @@ extension ConversationVC {
             for: self.viewModel.threadData.threadId,
             threadVariant: self.viewModel.threadData.threadVariant,
             isNewThread: false,
-            timestampMs: Int64(floor(Date().timeIntervalSince1970 * 1000))
+            timestampMs: SnodeAPI.currentOffsetTimestampMs()
         )
     }
 

--- a/Session/Conversations/Settings/OWSMessageTimerView.m
+++ b/Session/Conversations/Settings/OWSMessageTimerView.m
@@ -8,6 +8,7 @@
 #import <QuartzCore/QuartzCore.h>
 #import <SignalCoreKit/NSDate+OWS.h>
 #import <SessionUtilitiesKit/NSTimer+Proxying.h>
+#import <SessionSnodeKit/SessionSnodeKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -75,7 +76,7 @@ const CGFloat kDisappearingMessageIconSize = 12.f;
         return;
     }
 
-    uint64_t nowTimestamp = [NSDate ows_millisecondTimeStamp];
+    uint64_t nowTimestamp = [SNSnodeAPI currentOffsetTimestampMs];
     CGFloat secondsLeft
         = (self.expirationTimestamp > nowTimestamp ? (self.expirationTimestamp - nowTimestamp) / 1000.f : 0.f);
     CGFloat progress = 0.f;

--- a/Session/Conversations/Settings/ThreadDisappearingMessagesViewModel.swift
+++ b/Session/Conversations/Settings/ThreadDisappearingMessagesViewModel.swift
@@ -168,7 +168,7 @@ class ThreadDisappearingMessagesViewModel: SessionTableViewModel<ThreadDisappear
                 authorId: getUserHexEncodedPublicKey(db),
                 variant: .infoDisappearingMessagesUpdate,
                 body: config.messageInfoString(with: nil),
-                timestampMs: Int64(floor(Date().timeIntervalSince1970 * 1000))
+                timestampMs: SnodeAPI.currentOffsetTimestampMs()
             )
             .inserted(db)
             

--- a/Session/Conversations/Settings/ThreadSettingsViewModel.swift
+++ b/Session/Conversations/Settings/ThreadSettingsViewModel.swift
@@ -622,7 +622,7 @@ class ThreadSettingsViewModel: SessionTableViewModel<ThreadSettingsViewModel.Nav
                     threadId: thread.id,
                     authorId: userId,
                     variant: .standardOutgoing,
-                    timestampMs: Int64(floor(Date().timeIntervalSince1970 * 1000)),
+                    timestampMs: SnodeAPI.currentOffsetTimestampMs(),
                     expiresInSeconds: try? DisappearingMessagesConfiguration
                         .select(.durationSeconds)
                         .filter(id: userId)

--- a/Session/Notifications/AppNotifications.swift
+++ b/Session/Notifications/AppNotifications.swift
@@ -532,7 +532,7 @@ class NotificationActionHandler {
                 authorId: getUserHexEncodedPublicKey(db),
                 variant: .standardOutgoing,
                 body: replyText,
-                timestampMs: Int64(floor(Date().timeIntervalSince1970 * 1000)),
+                timestampMs: SnodeAPI.currentOffsetTimestampMs(),
                 hasMention: Interaction.isUserMentioned(db, threadId: threadId, body: replyText),
                 expiresInSeconds: try? DisappearingMessagesConfiguration
                     .select(.durationSeconds)

--- a/SessionMessagingKit/Calls/WebRTCSession.swift
+++ b/SessionMessagingKit/Calls/WebRTCSession.swift
@@ -5,6 +5,7 @@ import GRDB
 import PromiseKit
 import WebRTC
 import SessionUtilitiesKit
+import SessionSnodeKit
 
 public protocol WebRTCSessionDelegate: AnyObject {
     var videoCapturer: RTCVideoCapturer { get }
@@ -179,7 +180,7 @@ public final class WebRTCSession : NSObject, RTCPeerConnectionDelegate {
                                 uuid: uuid,
                                 kind: .offer,
                                 sdps: [ sdp.sdp ],
-                                sentTimestampMs: UInt64(floor(Date().timeIntervalSince1970 * 1000))
+                                sentTimestampMs: SnodeAPI.currentTimestampMs()
                             ),
                             interactionId: nil,
                             in: thread

--- a/SessionMessagingKit/Calls/WebRTCSession.swift
+++ b/SessionMessagingKit/Calls/WebRTCSession.swift
@@ -180,7 +180,7 @@ public final class WebRTCSession : NSObject, RTCPeerConnectionDelegate {
                                 uuid: uuid,
                                 kind: .offer,
                                 sdps: [ sdp.sdp ],
-                                sentTimestampMs: SnodeAPI.currentTimestampMs()
+                                sentTimestampMs: UInt64(SnodeAPI.currentOffsetTimestampMs())
                             ),
                             interactionId: nil,
                             in: thread

--- a/SessionMessagingKit/Database/Migrations/_003_YDBToGRDBMigration.swift
+++ b/SessionMessagingKit/Database/Migrations/_003_YDBToGRDBMigration.swift
@@ -1286,7 +1286,7 @@ enum _003_YDBToGRDBMigration: Migration {
                     // so we can reverse-engineer an approximate timestamp by extracting it from
                     // the id (this value is unlikely to match exactly though)
                     let fallbackTimestamp: UInt64 = legacyJob.id
-                        .map { UInt64($0.prefix("\(Int(Date().timeIntervalSince1970 * 1000))".count)) }
+                        .map { UInt64($0.prefix("\(SnodeAPI.currentOffsetTimestampMs())".count)) }
                         .defaulting(to: 0)
                     let legacyIdentifier: String = identifier(
                         for: threadId,
@@ -1657,7 +1657,7 @@ enum _003_YDBToGRDBMigration: Migration {
             state: .invalid,
             contentType: "",
             byteCount: 0,
-            creationTimestamp: Date().timeIntervalSince1970,
+            creationTimestamp: (TimeInterval(SnodeAPI.currentOffsetTimestampMs()) / 1000),
             sourceFilename: nil,
             downloadUrl: nil,
             localRelativeFilePath: nil,

--- a/SessionMessagingKit/Database/Models/Attachment.swift
+++ b/SessionMessagingKit/Database/Models/Attachment.swift
@@ -1,12 +1,13 @@
 // Copyright © 2022 Rangeproof Pty Ltd. All rights reserved.
 
 import Foundation
+import AVFAudio
+import AVFoundation
 import GRDB
 import PromiseKit
 import SignalCoreKit
 import SessionUtilitiesKit
-import AVFAudio
-import AVFoundation
+import SessionSnodeKit
 
 public struct Attachment: Codable, Identifiable, Equatable, Hashable, FetchableRecord, PersistableRecord, TableRecord, ColumnExpressible {
     public static var databaseTableName: String { "attachment" }
@@ -1114,7 +1115,7 @@ extension Attachment {
                             state: .uploaded,
                             creationTimestamp: (
                                 updatedAttachment?.creationTimestamp ??
-                                Date().timeIntervalSince1970
+                                (TimeInterval(SnodeAPI.currentOffsetTimestampMs()) / 1000)
                             ),
                             downloadUrl: "\(FileServerAPI.server)/files/\(fileId)"
                         )

--- a/SessionMessagingKit/Database/Models/DisappearingMessageConfiguration.swift
+++ b/SessionMessagingKit/Database/Models/DisappearingMessageConfiguration.swift
@@ -3,6 +3,7 @@
 import Foundation
 import GRDB
 import SessionUtilitiesKit
+import SessionSnodeKit
 
 public struct DisappearingMessagesConfiguration: Codable, Identifiable, Equatable, FetchableRecord, PersistableRecord, TableRecord, ColumnExpressible {
     public static var databaseTableName: String { "disappearingMessagesConfiguration" }
@@ -206,7 +207,7 @@ public class SMKDisappearingMessagesConfiguration: NSObject {
                 authorId: getUserHexEncodedPublicKey(db),
                 variant: .infoDisappearingMessagesUpdate,
                 body: config.messageInfoString(with: nil),
-                timestampMs: Int64(floor(Date().timeIntervalSince1970 * 1000))
+                timestampMs: SnodeAPI.currentOffsetTimestampMs()
             )
             .inserted(db)
             

--- a/SessionMessagingKit/Database/Models/Interaction.swift
+++ b/SessionMessagingKit/Database/Models/Interaction.swift
@@ -4,6 +4,7 @@ import Foundation
 import GRDB
 import Sodium
 import SessionUtilitiesKit
+import SessionSnodeKit
 
 public struct Interaction: Codable, Identifiable, Equatable, FetchableRecord, MutablePersistableRecord, TableRecord, ColumnExpressible {
     public static var databaseTableName: String { "interaction" }
@@ -298,7 +299,7 @@ public struct Interaction: Codable, Identifiable, Equatable, FetchableRecord, Mu
         self.timestampMs = timestampMs
         self.receivedAtTimestampMs = {
             switch variant {
-                case .standardIncoming, .standardOutgoing: return Int64(Date().timeIntervalSince1970 * 1000)
+                case .standardIncoming, .standardOutgoing: return SnodeAPI.currentOffsetTimestampMs()
 
                 /// For TSInteractions which are not `standardIncoming` and `standardOutgoing` use the `timestampMs` value
                 default: return timestampMs
@@ -458,7 +459,7 @@ public extension Interaction {
                 job: DisappearingMessagesJob.updateNextRunIfNeeded(
                     db,
                     interactionIds: interactionIds,
-                    startedAtMs: (Date().timeIntervalSince1970 * 1000)
+                    startedAtMs: TimeInterval(SnodeAPI.currentOffsetTimestampMs())
                 )
             )
             

--- a/SessionMessagingKit/Database/Models/LinkPreview.swift
+++ b/SessionMessagingKit/Database/Models/LinkPreview.swift
@@ -6,6 +6,7 @@ import PromiseKit
 import AFNetworking
 import SignalCoreKit
 import SessionUtilitiesKit
+import SessionSnodeKit
 
 public struct LinkPreview: Codable, Equatable, Hashable, FetchableRecord, PersistableRecord, TableRecord, ColumnExpressible {
     public static var databaseTableName: String { "linkPreview" }
@@ -60,7 +61,7 @@ public struct LinkPreview: Codable, Equatable, Hashable, FetchableRecord, Persis
     public init(
         url: String,
         timestamp: TimeInterval = LinkPreview.timestampFor(
-            sentTimestampMs: (Date().timeIntervalSince1970 * 1000)  // Default to now
+            sentTimestampMs: TimeInterval(SnodeAPI.currentOffsetTimestampMs())  // Default to now
         ),
         variant: Variant = .standard,
         title: String?,

--- a/SessionMessagingKit/Database/Models/SessionThread.swift
+++ b/SessionMessagingKit/Database/Models/SessionThread.swift
@@ -4,6 +4,7 @@ import Foundation
 import GRDB
 import Sodium
 import SessionUtilitiesKit
+import SessionSnodeKit
 
 public struct SessionThread: Codable, Identifiable, Equatable, FetchableRecord, PersistableRecord, TableRecord, ColumnExpressible {
     public static var databaseTableName: String { "thread" }
@@ -104,7 +105,7 @@ public struct SessionThread: Codable, Identifiable, Equatable, FetchableRecord, 
     public init(
         id: String,
         variant: Variant,
-        creationDateTimestamp: TimeInterval = Date().timeIntervalSince1970,
+        creationDateTimestamp: TimeInterval = (TimeInterval(SnodeAPI.currentOffsetTimestampMs()) / 1000),
         shouldBeVisible: Bool = false,
         isPinned: Bool = false,
         messageDraft: String? = nil,

--- a/SessionMessagingKit/Jobs/Types/AttachmentDownloadJob.swift
+++ b/SessionMessagingKit/Jobs/Types/AttachmentDownloadJob.swift
@@ -145,7 +145,7 @@ public enum AttachmentDownloadJob: JobExecutor {
                     _ = try attachment
                         .with(
                             state: .downloaded,
-                            creationTimestamp: Date().timeIntervalSince1970,
+                            creationTimestamp: (TimeInterval(SnodeAPI.currentOffsetTimestampMs()) / 1000),
                             localRelativeFilePath: (
                                 attachment.localRelativeFilePath ??
                                 Attachment.localRelativeFilePath(from: attachment.originalFilePath)

--- a/SessionMessagingKit/Jobs/Types/DisappearingMessagesJob.swift
+++ b/SessionMessagingKit/Jobs/Types/DisappearingMessagesJob.swift
@@ -60,10 +60,14 @@ public extension DisappearingMessagesJob {
         
         guard let nextExpirationTimestampMs: Double = nextExpirationTimestampMs else { return nil }
         
+        /// The `expiresStartedAtMs` timestamp is now based on the `SnodeAPI.currentOffsetTimestampMs()` value
+        /// so we need to make sure offset the `nextRunTimestamp` accordingly to ensure it runs at the correct local time
+        let clockOffsetMs: Int64 = SnodeAPI.clockOffsetMs.wrappedValue
+        
         return try? Job
             .filter(Job.Columns.variant == Job.Variant.disappearingMessages)
             .fetchOne(db)?
-            .with(nextRunTimestamp: ceil(nextExpirationTimestampMs / 1000))
+            .with(nextRunTimestamp: ceil((nextExpirationTimestampMs - Double(clockOffsetMs)) / 1000))
             .saved(db)
     }
     

--- a/SessionMessagingKit/Jobs/Types/DisappearingMessagesJob.swift
+++ b/SessionMessagingKit/Jobs/Types/DisappearingMessagesJob.swift
@@ -3,6 +3,7 @@
 import Foundation
 import GRDB
 import SessionUtilitiesKit
+import SessionSnodeKit
 
 public enum DisappearingMessagesJob: JobExecutor {
     public static let maxFailureCount: Int = -1
@@ -17,7 +18,7 @@ public enum DisappearingMessagesJob: JobExecutor {
         deferred: @escaping (Job) -> ()
     ) {
         // The 'backgroundTask' gets captured and cleared within the 'completion' block
-        let timestampNowMs: TimeInterval = ceil(Date().timeIntervalSince1970 * 1000)
+        let timestampNowMs: TimeInterval = TimeInterval(SnodeAPI.currentOffsetTimestampMs())
         var backgroundTask: OWSBackgroundTask? = OWSBackgroundTask(label: #function)
         
         let updatedJob: Job? = Storage.shared.write { db in

--- a/SessionMessagingKit/Messages/Message.swift
+++ b/SessionMessagingKit/Messages/Message.swift
@@ -259,7 +259,10 @@ public extension Message {
         return try processRawReceivedMessage(
             db,
             envelope: envelope,
-            serverExpirationTimestamp: (Date().timeIntervalSince1970 + ControlMessageProcessRecord.defaultExpirationSeconds),
+            serverExpirationTimestamp: (
+                (TimeInterval(SnodeAPI.currentOffsetTimestampMs()) / 1000) +
+                ControlMessageProcessRecord.defaultExpirationSeconds
+            ),
             serverHash: serverHash,
             handleClosedGroupKeyUpdateMessages: true
         )
@@ -275,7 +278,10 @@ public extension Message {
         let processedMessage: ProcessedMessage? = try processRawReceivedMessage(
             db,
             envelope: envelope,
-            serverExpirationTimestamp: (Date().timeIntervalSince1970 + ControlMessageProcessRecord.defaultExpirationSeconds),
+            serverExpirationTimestamp: (
+                (TimeInterval(SnodeAPI.currentOffsetTimestampMs()) / 1000) +
+                ControlMessageProcessRecord.defaultExpirationSeconds
+            ),
             serverHash: nil,
             handleClosedGroupKeyUpdateMessages: false
         )
@@ -407,7 +413,7 @@ public extension Message {
                 
                 let count: Int64 = rawReaction.you ? rawReaction.count - 1 : rawReaction.count
                 
-                let timestampMs: Int64 = Int64(floor((Date().timeIntervalSince1970 * 1000)))
+                let timestampMs: Int64 = SnodeAPI.currentOffsetTimestampMs()
                 let maxLength: Int = shouldAddSelfReaction ? 4 : 5
                 let desiredReactorIds: [String] = reactors
                     .filter { $0 != blindedUserPublicKey && $0 != userPublicKey } // Remove current user for now, will add back if needed

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+Calls.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+Calls.swift
@@ -4,6 +4,7 @@ import Foundation
 import GRDB
 import WebRTC
 import SessionUtilitiesKit
+import SessionSnodeKit
 
 extension MessageReceiver {
     public static func handleCallMessage(_ db: Database, message: CallMessage) throws {
@@ -189,7 +190,7 @@ extension MessageReceiver {
             body: String(data: messageInfoData, encoding: .utf8),
             timestampMs: (
                 message.sentTimestamp.map { Int64($0) } ??
-                Int64(floor(Date().timeIntervalSince1970 * 1000))
+                SnodeAPI.currentOffsetTimestampMs()
             )
         )
         .inserted(db)
@@ -235,7 +236,7 @@ extension MessageReceiver {
         )
         let timestampMs: Int64 = (
             message.sentTimestamp.map { Int64($0) } ??
-            Int64(floor(Date().timeIntervalSince1970 * 1000))
+            SnodeAPI.currentOffsetTimestampMs()
         )
         
         guard let messageInfoData: Data = try? JSONEncoder().encode(messageInfo) else { return nil }

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+ClosedGroups.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+ClosedGroups.swift
@@ -4,6 +4,7 @@ import Foundation
 import GRDB
 import Sodium
 import SessionUtilitiesKit
+import SessionSnodeKit
 
 extension MessageReceiver {
     public static func handleClosedGroupControlMessage(_ db: Database, _ message: ClosedGroupControlMessage) throws {
@@ -135,7 +136,7 @@ extension MessageReceiver {
             threadId: groupPublicKey,
             publicKey: Data(encryptionKeyPair.publicKey),
             secretKey: Data(encryptionKeyPair.secretKey),
-            receivedTimestamp: Date().timeIntervalSince1970
+            receivedTimestamp: (TimeInterval(SnodeAPI.currentOffsetTimestampMs()) / 1000)
         ).insert(db)
         
         // Start polling
@@ -196,7 +197,7 @@ extension MessageReceiver {
                 threadId: groupPublicKey,
                 publicKey: proto.publicKey.removingIdPrefixIfNeeded(),
                 secretKey: proto.privateKey,
-                receivedTimestamp: Date().timeIntervalSince1970
+                receivedTimestamp: (TimeInterval(SnodeAPI.currentOffsetTimestampMs()) / 1000)
             ).insert(db)
         }
         catch {
@@ -231,7 +232,7 @@ extension MessageReceiver {
                     .infoMessage(db, sender: sender),
                 timestampMs: (
                     message.sentTimestamp.map { Int64($0) } ??
-                    Int64(floor(Date().timeIntervalSince1970 * 1000))
+                    SnodeAPI.currentOffsetTimestampMs()
                 )
             ).inserted(db)
         }
@@ -307,7 +308,7 @@ extension MessageReceiver {
                     .infoMessage(db, sender: sender),
                 timestampMs: (
                     message.sentTimestamp.map { Int64($0) } ??
-                    Int64(floor(Date().timeIntervalSince1970 * 1000))
+                    SnodeAPI.currentOffsetTimestampMs()
                 )
             ).inserted(db)
         }
@@ -383,7 +384,7 @@ extension MessageReceiver {
                     .infoMessage(db, sender: sender),
                 timestampMs: (
                     message.sentTimestamp.map { Int64($0) } ??
-                    Int64(floor(Date().timeIntervalSince1970 * 1000))
+                    SnodeAPI.currentOffsetTimestampMs()
                 )
             ).inserted(db)
         }
@@ -461,7 +462,7 @@ extension MessageReceiver {
                     .infoMessage(db, sender: sender),
                 timestampMs: (
                     message.sentTimestamp.map { Int64($0) } ??
-                    Int64(floor(Date().timeIntervalSince1970 * 1000))
+                    SnodeAPI.currentOffsetTimestampMs()
                 )
             ).inserted(db)
         }

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+DataExtractionNotification.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+DataExtractionNotification.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import GRDB
+import SessionSnodeKit
 
 extension MessageReceiver {
     internal static func handleDataExtractionNotification(_ db: Database, message: DataExtractionNotification) throws {
@@ -24,7 +25,7 @@ extension MessageReceiver {
             }(),
             timestampMs: (
                 message.sentTimestamp.map { Int64($0) } ??
-                Int64(floor(Date().timeIntervalSince1970 * 1000))
+                SnodeAPI.currentOffsetTimestampMs()
             )
         ).inserted(db)
     }

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+MessageRequests.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+MessageRequests.swift
@@ -4,6 +4,7 @@ import Foundation
 import GRDB
 import SignalCoreKit
 import SessionUtilitiesKit
+import SessionSnodeKit
 
 extension MessageReceiver {
     internal static func handleMessageRequestResponse(
@@ -123,7 +124,7 @@ extension MessageReceiver {
             variant: .infoMessageRequestAccepted,
             timestampMs: (
                 message.sentTimestamp.map { Int64($0) } ??
-                Int64(floor(Date().timeIntervalSince1970 * 1000))
+                SnodeAPI.currentOffsetTimestampMs()
             )
         ).inserted(db)
     }

--- a/SessionMessagingKit/Sending & Receiving/MessageReceiver.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageReceiver.swift
@@ -5,6 +5,7 @@ import GRDB
 import Sodium
 import SignalCoreKit
 import SessionUtilitiesKit
+import SessionSnodeKit
 
 public enum MessageReceiver {
     private static var lastEncryptionKeyPairRequest: [String: Date] = [:]
@@ -144,7 +145,7 @@ public enum MessageReceiver {
         message.sender = sender
         message.recipient = userPublicKey
         message.sentTimestamp = envelope.timestamp
-        message.receivedTimestamp = UInt64((Date().timeIntervalSince1970) * 1000)
+        message.receivedTimestamp = SnodeAPI.currentTimestampMs()
         message.groupPublicKey = groupPublicKey
         message.openGroupServerMessageId = openGroupMessageServerId.map { UInt64($0) }
         

--- a/SessionMessagingKit/Sending & Receiving/MessageReceiver.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageReceiver.swift
@@ -145,7 +145,7 @@ public enum MessageReceiver {
         message.sender = sender
         message.recipient = userPublicKey
         message.sentTimestamp = envelope.timestamp
-        message.receivedTimestamp = SnodeAPI.currentTimestampMs()
+        message.receivedTimestamp = UInt64(SnodeAPI.currentOffsetTimestampMs())
         message.groupPublicKey = groupPublicKey
         message.openGroupServerMessageId = openGroupMessageServerId.map { UInt64($0) }
         

--- a/SessionMessagingKit/Sending & Receiving/MessageSender.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageSender.swift
@@ -202,7 +202,7 @@ public final class MessageSender {
             recipient: message.recipient!,
             data: base64EncodedData,
             ttl: message.ttl,
-            timestampMs: UInt64(messageSendTimestamp + SnodeAPI.clockOffset.wrappedValue)
+            timestampMs: UInt64(messageSendTimestamp)
         )
         
         SnodeAPI
@@ -322,7 +322,7 @@ public final class MessageSender {
         
         // Set the timestamp, sender and recipient
         if message.sentTimestamp == nil { // Visible messages will already have their sent timestamp set
-            message.sentTimestamp = SnodeAPI.currentTimestampMs()
+            message.sentTimestamp = UInt64(SnodeAPI.currentOffsetTimestampMs())
         }
         
         switch destination {
@@ -472,7 +472,7 @@ public final class MessageSender {
         
         // Set the timestamp, sender and recipient
         if message.sentTimestamp == nil { // Visible messages will already have their sent timestamp set
-            message.sentTimestamp = SnodeAPI.currentTimestampMs()
+            message.sentTimestamp = UInt64(SnodeAPI.currentOffsetTimestampMs())
         }
         
         message.sender = userPublicKey

--- a/SessionMessagingKit/Sending & Receiving/MessageSender.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageSender.swift
@@ -67,7 +67,7 @@ public final class MessageSender {
         let (promise, seal) = Promise<Void>.pending()
         let userPublicKey: String = getUserHexEncodedPublicKey(db)
         let isMainAppActive: Bool = (UserDefaults.sharedLokiProject?[.isMainAppActive]).defaulting(to: false)
-        let messageSendTimestamp: Int64 = Int64(floor(Date().timeIntervalSince1970 * 1000))
+        let messageSendTimestamp: Int64 = SnodeAPI.currentOffsetTimestampMs()
         
         // Set the timestamp, sender and recipient
         message.sentTimestamp = (
@@ -322,7 +322,7 @@ public final class MessageSender {
         
         // Set the timestamp, sender and recipient
         if message.sentTimestamp == nil { // Visible messages will already have their sent timestamp set
-            message.sentTimestamp = UInt64(floor(Date().timeIntervalSince1970 * 1000))
+            message.sentTimestamp = SnodeAPI.currentTimestampMs()
         }
         
         switch destination {
@@ -472,7 +472,7 @@ public final class MessageSender {
         
         // Set the timestamp, sender and recipient
         if message.sentTimestamp == nil { // Visible messages will already have their sent timestamp set
-            message.sentTimestamp = UInt64(floor(Date().timeIntervalSince1970 * 1000))
+            message.sentTimestamp = SnodeAPI.currentTimestampMs()
         }
         
         message.sender = userPublicKey
@@ -617,7 +617,7 @@ public final class MessageSender {
                     job: DisappearingMessagesJob.updateNextRunIfNeeded(
                         db,
                         interaction: interaction,
-                        startedAtMs: (Date().timeIntervalSince1970 * 1000)
+                        startedAtMs: TimeInterval(SnodeAPI.currentOffsetTimestampMs())
                     )
                 )
             }
@@ -636,7 +636,10 @@ public final class MessageSender {
                 }
             }(),
             message: message,
-            serverExpirationTimestamp: (Date().timeIntervalSince1970 + ControlMessageProcessRecord.defaultExpirationSeconds)
+            serverExpirationTimestamp: (
+                (TimeInterval(SnodeAPI.currentOffsetTimestampMs()) / 1000) +
+                ControlMessageProcessRecord.defaultExpirationSeconds
+            )
         )?.insert(db)
         
         // Sync the message if:

--- a/SessionMessagingKit/Sending & Receiving/Typing Indicators/TypingIndicators.swift
+++ b/SessionMessagingKit/Sending & Receiving/Typing Indicators/TypingIndicators.swift
@@ -3,6 +3,7 @@
 import Foundation
 import GRDB
 import SessionUtilitiesKit
+import SessionSnodeKit
 
 public class TypingIndicators {
     // MARK: - Direction
@@ -41,7 +42,7 @@ public class TypingIndicators {
             
             self.threadId = threadId
             self.direction = direction
-            self.timestampMs = (timestampMs ?? Int64(floor(Date().timeIntervalSince1970 * 1000)))
+            self.timestampMs = (timestampMs ?? SnodeAPI.currentOffsetTimestampMs())
         }
         
         fileprivate func start(_ db: Database) {

--- a/SessionShareExtension/ThreadPickerVC.swift
+++ b/SessionShareExtension/ThreadPickerVC.swift
@@ -196,7 +196,7 @@ final class ThreadPickerVC: UIViewController, UITableViewDataSource, UITableView
                         authorId: getUserHexEncodedPublicKey(db),
                         variant: .standardOutgoing,
                         body: body,
-                        timestampMs: Int64(floor(Date().timeIntervalSince1970 * 1000)),
+                        timestampMs: SnodeAPI.currentOffsetTimestampMs(),
                         hasMention: Interaction.isUserMentioned(db, threadId: threadId, body: body),
                         expiresInSeconds: try? DisappearingMessagesConfiguration
                             .select(.durationSeconds)

--- a/SessionSnodeKit/Database/Models/SnodeReceivedMessageInfo.swift
+++ b/SessionSnodeKit/Database/Models/SnodeReceivedMessageInfo.swift
@@ -93,7 +93,7 @@ public extension SnodeReceivedMessageInfo {
                 return try SnodeReceivedMessageInfo
                     .select(Column.rowID)
                     .filter(SnodeReceivedMessageInfo.Columns.key == key(for: snode, publicKey: publicKey, namespace: namespace))
-                    .filter(SnodeReceivedMessageInfo.Columns.expirationDateMs <= (Date().timeIntervalSince1970 * 1000))
+                    .filter(SnodeReceivedMessageInfo.Columns.expirationDateMs <= SnodeAPI.currentOffsetTimestampMs())
                     .asRequest(of: Int64.self)
                     .fetchAll(db)
             }
@@ -122,7 +122,7 @@ public extension SnodeReceivedMessageInfo {
                     SnodeReceivedMessageInfo.Columns.wasDeletedOrInvalid == false
                 )
                 .filter(SnodeReceivedMessageInfo.Columns.key == key(for: snode, publicKey: publicKey, namespace: namespace))
-                .filter(SnodeReceivedMessageInfo.Columns.expirationDateMs > (Date().timeIntervalSince1970 * 1000))
+                .filter(SnodeReceivedMessageInfo.Columns.expirationDateMs > SnodeAPI.currentOffsetTimestampMs())
                 .order(SnodeReceivedMessageInfo.Columns.id.desc)
                 .fetchOne(db)
             

--- a/SessionSnodeKit/OnionRequestAPI.swift
+++ b/SessionSnodeKit/OnionRequestAPI.swift
@@ -672,7 +672,7 @@ public enum OnionRequestAPI: OnionRequestAPIType {
                         
                         if let timestamp = body["t"] as? Int64 {
                             let offset = timestamp - Int64(floor(Date().timeIntervalSince1970 * 1000))
-                            SnodeAPI.clockOffset.mutate { $0 = offset }
+                            SnodeAPI.clockOffsetMs.mutate { $0 = offset }
                         }
                         
                         guard 200...299 ~= statusCode else {

--- a/SessionSnodeKit/SnodeAPI.swift
+++ b/SessionSnodeKit/SnodeAPI.swift
@@ -23,6 +23,14 @@ public final class SnodeAPI {
     ///
     /// - Note: Should only be accessed from `Threading.workQueue` to avoid race conditions.
     public static var clockOffset: Atomic<Int64> = Atomic(0)
+    
+    public static func currentOffsetTimestampMs() -> Int64 {
+        return (
+            Int64(floor(Date().timeIntervalSince1970 * 1000)) +
+            SnodeAPI.clockOffset.wrappedValue
+        )
+    }
+    
     /// - Note: Should only be accessed from `Threading.workQueue` to avoid race conditions.
     public static var swarmCache: Atomic<[String: Set<Snode>]> = Atomic([:])
     
@@ -546,7 +554,7 @@ public final class SnodeAPI {
         let lastHash = SnodeReceivedMessageInfo.fetchLastNotExpired(for: snode, namespace: namespace, associatedWith: publicKey)?.hash ?? ""
 
         // Construct signature
-        let timestamp = UInt64(Int64(floor(Date().timeIntervalSince1970 * 1000)) + SnodeAPI.clockOffset.wrappedValue)
+        let timestamp = UInt64(SnodeAPI.currentOffsetTimestampMs())
         let ed25519PublicKey = userED25519KeyPair.publicKey.toHexString()
         let namespaceVerificationString = (namespace == defaultNamespace ? "" : String(namespace))
         
@@ -647,7 +655,7 @@ public final class SnodeAPI {
         }
         
         // Construct signature
-        let timestamp = UInt64(Int64(floor(Date().timeIntervalSince1970 * 1000)) + SnodeAPI.clockOffset.wrappedValue)
+        let timestamp = UInt64(SnodeAPI.currentOffsetTimestampMs())
         let ed25519PublicKey = userED25519KeyPair.publicKey.toHexString()
         
         guard

--- a/SessionSnodeKit/SnodeAPI.swift
+++ b/SessionSnodeKit/SnodeAPI.swift
@@ -19,15 +19,13 @@ public final class SnodeAPI {
     internal static var snodePool: Atomic<Set<Snode>> = Atomic([])
 
     /// The offset between the user's clock and the Service Node's clock. Used in cases where the
-    /// user's clock is incorrect.
-    ///
-    /// - Note: Should only be accessed from `Threading.workQueue` to avoid race conditions.
-    public static var clockOffset: Atomic<Int64> = Atomic(0)
+    /// user's clock is incorrect
+    public static var clockOffsetMs: Atomic<Int64> = Atomic(0)
     
     public static func currentOffsetTimestampMs() -> Int64 {
         return (
             Int64(floor(Date().timeIntervalSince1970 * 1000)) +
-            SnodeAPI.clockOffset.wrappedValue
+            SnodeAPI.clockOffsetMs.wrappedValue
         )
     }
     
@@ -1108,5 +1106,13 @@ public final class SnodeAPI {
         }
         
         return nil
+    }
+}
+
+@objc(SNSnodeAPI)
+public final class SNSnodeAPI: NSObject {
+    @objc(currentOffsetTimestampMs)
+    public static func currentOffsetTimestampMs() -> UInt64 {
+        return UInt64(SnodeAPI.currentOffsetTimestampMs())
     }
 }


### PR DESCRIPTION
In order to improve the synchronised behaviours between devices we are looking to update the logic to offset times based on the difference between the device timestamp and the service node timestamp. This allows us to better ensure message ordering, read status syncing and disappearing message syncing all works more consistently