### PR TITLE
JobRunner Tweaks

### DIFF
--- a/SessionMessagingKit/Sending & Receiving/MessageSender.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageSender.swift
@@ -66,7 +66,6 @@ public final class MessageSender {
     ) throws -> Promise<Void> {
         let (promise, seal) = Promise<Void>.pending()
         let userPublicKey: String = getUserHexEncodedPublicKey(db)
-        let isMainAppActive: Bool = (UserDefaults.sharedLokiProject?[.isMainAppActive]).defaulting(to: false)
         let messageSendTimestamp: Int64 = SnodeAPI.currentOffsetTimestampMs()
         
         // Set the timestamp, sender and recipient
@@ -261,6 +260,8 @@ public final class MessageSender {
                                 behaviour: .runOnce,
                                 details: NotifyPushServerJob.Details(message: snodeMessage)
                             )
+                            let isMainAppActive: Bool = (UserDefaults.sharedLokiProject?[.isMainAppActive])
+                                .defaulting(to: false)
                             
                             if isMainAppActive {
                                 JobRunner.add(db, job: job)


### PR DESCRIPTION
- Added a new `canStartQueues` flag to the `JobRunner` in an effort to prevent job queues from restarting themselves due to race conditions or previously scheduled start times when the app goes into the background
- Fixed a bug where a stale flag was used to determine how to send a push notification
- Fixed an issue where the `upsert` function might not respect a `canStartJob: false` parameter
- Fixed an issue where the `insert` function could start queues which weren't currently running (shouldn't do this)
- Fixed an issue where jobs that permanently failed weren't doing proper cleanup
- Fixed an issue where failed job dependencies could be given the wrong `failureCount`