### PR TITLE
Fixed a number of bugs

### DIFF
--- a/Session/Calls/Call Management/SessionCall.swift
+++ b/Session/Calls/Call Management/SessionCall.swift
@@ -318,12 +318,20 @@ public final class SessionCall: CurrentCallProtocol, WebRTCSessionDelegate {
                     }
                 }()
                 
-                guard shouldMarkAsRead else { return }
+                guard
+                    shouldMarkAsRead,
+                    let threadVariant: SessionThread.Variant = try? SessionThread
+                        .filter(id: interaction.threadId)
+                        .select(.variant)
+                        .asRequest(of: SessionThread.Variant.self)
+                        .fetchOne(db)
+                else { return }
                 
                 try Interaction.markAsRead(
                     db,
                     interactionId: interaction.id,
                     threadId: interaction.threadId,
+                    threadVariant: threadVariant,
                     includingOlder: false,
                     trySendReadReceipt: false
                 )

--- a/Session/Conversations/Context Menu/ContextMenuVC+Action.swift
+++ b/Session/Conversations/Context Menu/ContextMenuVC+Action.swift
@@ -110,6 +110,7 @@ extension ContextMenuVC {
     static func actions(
         for cellViewModel: MessageViewModel,
         recentEmojis: [EmojiWithSkinTones],
+        currentUserPublicKey: String,
         currentUserIsOpenGroupModerator: Bool,
         currentThreadIsMessageRequest: Bool,
         delegate: ContextMenuActionDelegate?
@@ -163,6 +164,7 @@ extension ContextMenuVC {
         let canDelete: Bool = (
             cellViewModel.threadVariant != .openGroup ||
             currentUserIsOpenGroupModerator ||
+            cellViewModel.authorId == currentUserPublicKey ||
             cellViewModel.state == .failed
         )
         let canBan: Bool = (

--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -777,6 +777,7 @@ extension ConversationVC:
             let actions: [ContextMenuVC.Action] = ContextMenuVC.actions(
                 for: cellViewModel,
                 recentEmojis: (self.viewModel.threadData.recentReactionEmoji ?? []).compactMap { EmojiWithSkinTones(rawValue: $0) },
+                currentUserPublicKey: self.viewModel.threadData.currentUserPublicKey,
                 currentUserIsOpenGroupModerator: OpenGroupManager.isUserModeratorOrAdmin(
                     self.viewModel.threadData.currentUserPublicKey,
                     for: self.viewModel.threadData.openGroupRoomToken,

--- a/Session/Conversations/ConversationVC.swift
+++ b/Session/Conversations/ConversationVC.swift
@@ -737,11 +737,17 @@ final class ConversationVC: BaseVC, ConversationSearchControllerDelegate, UITabl
         
         // Store the 'sentMessageBeforeUpdate' state locally
         let didSendMessageBeforeUpdate: Bool = self.viewModel.sentMessageBeforeUpdate
+        let wasOnlyUpdates: Bool = (
+            changeset.count == 1 &&
+            changeset[0].elementUpdated.count == changeset[0].changeCount
+        )
         self.viewModel.sentMessageBeforeUpdate = false
         
-        // When sending a message we want to reload the UI instantly (with any form of animation the message
-        // sending feels somewhat unresponsive but an instant update feels snappy)
-        guard !didSendMessageBeforeUpdate else {
+        // When sending a message, or if there were only cell updates (ie. read status changes) we want to
+        // reload the UI instantly (with any form of animation the message sending feels somewhat unresponsive
+        // but an instant update feels snappy and without the instant update there is some overlap of the read
+        // status text change even though there shouldn't be any animations)
+        guard !didSendMessageBeforeUpdate && !wasOnlyUpdates else {
             self.viewModel.updateInteractionData(updatedData)
             self.tableView.reloadData()
             

--- a/Session/Conversations/ConversationViewModel.swift
+++ b/Session/Conversations/ConversationViewModel.swift
@@ -197,7 +197,17 @@ public class ConversationViewModel: OWSAudioPlayerDelegate {
                         
                         return SQL("LEFT JOIN \(Profile.self) ON \(profile[.id]) = \(interaction[.authorId])")
                     }()
-                )
+                ),
+                PagedData.ObservedChanges(
+                    table: RecipientState.self,
+                    columns: [.state, .mostRecentFailureText],
+                    joinToPagedType: {
+                        let interaction: TypedTableAlias<Interaction> = TypedTableAlias()
+                        let recipientState: TypedTableAlias<RecipientState> = TypedTableAlias()
+                        
+                        return SQL("LEFT JOIN \(RecipientState.self) ON \(recipientState[.interactionId]) = \(interaction[.id])")
+                    }()
+                ),
             ],
             filterSQL: MessageViewModel.filterSQL(threadId: threadId),
             groupSQL: MessageViewModel.groupSQL,
@@ -405,6 +415,7 @@ public class ConversationViewModel: OWSAudioPlayerDelegate {
         else { return }
         
         let threadId: String = self.threadData.threadId
+        let threadVariant: SessionThread.Variant = self.threadData.threadVariant
         let trySendReadReceipt: Bool = (self.threadData.threadIsMessageRequest == false)
         self.lastInteractionIdMarkedAsRead = targetInteractionId
         
@@ -413,6 +424,7 @@ public class ConversationViewModel: OWSAudioPlayerDelegate {
                 db,
                 interactionId: targetInteractionId,
                 threadId: threadId,
+                threadVariant: threadVariant,
                 includingOlder: true,
                 trySendReadReceipt: trySendReadReceipt
             )

--- a/Session/Conversations/Message Cells/VisibleMessageCell.swift
+++ b/Session/Conversations/Message Cells/VisibleMessageCell.swift
@@ -1121,11 +1121,15 @@ final class VisibleMessageCell: MessageCell, TappableLabelDelegate {
                     return [:]
                 }
                 
+                // Note: The 'String.count' value is based on actual character counts whereas
+                // NSAttributedString and NSRange are both based on UTF-16 encoded lengths, so
+                // in order to avoid strings which contain emojis breaking strings which end
+                // with URLs we need to use the 'String.utf16.count' value when creating the range
                 return detector
                     .matches(
                         in: attributedText.string,
                         options: [],
-                        range: NSRange(location: 0, length: attributedText.string.count)
+                        range: NSRange(location: 0, length: attributedText.string.utf16.count)
                     )
                     .reduce(into: [:]) { result, match in
                         guard

--- a/Session/Conversations/Message Cells/VisibleMessageCell.swift
+++ b/Session/Conversations/Message Cells/VisibleMessageCell.swift
@@ -165,6 +165,8 @@ final class VisibleMessageCell: MessageCell, TappableLabelDelegate {
         
         return result
     }()
+    
+    internal lazy var messageStatusLabelPaddingView: UIView = UIView()
 
     // MARK: - Settings
     
@@ -252,6 +254,7 @@ final class VisibleMessageCell: MessageCell, TappableLabelDelegate {
         
         underBubbleStackView.addArrangedSubview(reactionContainerView)
         underBubbleStackView.addArrangedSubview(messageStatusContainerView)
+        underBubbleStackView.addArrangedSubview(messageStatusLabelPaddingView)
         
         messageStatusContainerView.addSubview(messageStatusLabel)
         messageStatusContainerView.addSubview(messageStatusImageView)
@@ -267,6 +270,8 @@ final class VisibleMessageCell: MessageCell, TappableLabelDelegate {
         messageStatusLabel.center(.vertical, in: messageStatusContainerView)
         messageStatusLabel.pin(.leading, to: .leading, of: messageStatusContainerView)
         messageStatusLabel.pin(.trailing, to: .leading, of: messageStatusImageView, withInset: -2)
+        messageStatusLabelPaddingView.pin(.leading, to: .leading, of: messageStatusContainerView)
+        messageStatusLabelPaddingView.pin(.trailing, to: .trailing, of: messageStatusContainerView)
     }
 
     override func setUpGestureRecognizers() {
@@ -428,6 +433,10 @@ final class VisibleMessageCell: MessageCell, TappableLabelDelegate {
                 cellViewModel.state == .sent &&
                 !cellViewModel.isLast
             )
+        )
+        messageStatusLabelPaddingView.isHidden = (
+            messageStatusContainerView.isHidden ||
+            cellViewModel.isLast
         )
         
         // Set the height of the underBubbleStackView to 0 if it has no content (need to do this

--- a/Session/Notifications/AppNotifications.swift
+++ b/Session/Notifications/AppNotifications.swift
@@ -546,6 +546,7 @@ class NotificationActionHandler {
                 db,
                 interactionId: interaction.id,
                 threadId: thread.id,
+                threadVariant: thread.variant,
                 includingOlder: true,
                 trySendReadReceipt: true
             )
@@ -600,6 +601,7 @@ class NotificationActionHandler {
                         .asRequest(of: Int64.self)
                         .fetchOne(db),
                     threadId: thread.id,
+                    threadVariant: thread.variant,
                     includingOlder: true,
                     trySendReadReceipt: true
                 )

--- a/Session/Path/PathStatusView.swift
+++ b/Session/Path/PathStatusView.swift
@@ -1,6 +1,7 @@
 // Copyright © 2022 Rangeproof Pty Ltd. All rights reserved.
 
 import UIKit
+import Reachability
 import SessionUIKit
 
 final class PathStatusView: UIView {
@@ -42,6 +43,7 @@ final class PathStatusView: UIView {
     // MARK: - Initialization
     
     private let size: Size
+    private let reachability: Reachability = Reachability.forInternetConnection()
     
     init(size: Size = .small) {
         self.size = size
@@ -73,15 +75,34 @@ final class PathStatusView: UIView {
         self.set(.width, to: self.size.pointSize)
         self.set(.height, to: self.size.pointSize)
         
-        setStatus(to: (!OnionRequestAPI.paths.isEmpty ? .connected : .connecting))
+        switch (reachability.isReachable(), OnionRequestAPI.paths.isEmpty) {
+            case (false, _): setStatus(to: .error)
+            case (true, true): setStatus(to: .connecting)
+            case (true, false): setStatus(to: .connected)
+        }
     }
     
     // MARK: - Functions
 
     private func registerObservers() {
-        let notificationCenter = NotificationCenter.default
-        notificationCenter.addObserver(self, selector: #selector(handleBuildingPathsNotification), name: .buildingPaths, object: nil)
-        notificationCenter.addObserver(self, selector: #selector(handlePathsBuiltNotification), name: .pathsBuilt, object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleBuildingPathsNotification),
+            name: .buildingPaths,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handlePathsBuiltNotification),
+            name: .pathsBuilt,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(reachabilityChanged),
+            name: .reachabilityChanged,
+            object: nil
+        )
     }
 
     private func setStatus(to status: Status) {
@@ -102,10 +123,34 @@ final class PathStatusView: UIView {
     }
 
     @objc private func handleBuildingPathsNotification() {
+        guard reachability.isReachable() else {
+            setStatus(to: .error)
+            return
+        }
+        
         setStatus(to: .connecting)
     }
 
     @objc private func handlePathsBuiltNotification() {
+        guard reachability.isReachable() else {
+            setStatus(to: .error)
+            return
+        }
+        
         setStatus(to: .connected)
+    }
+    
+    @objc private func reachabilityChanged() {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [weak self] in self?.reachabilityChanged() }
+            return
+        }
+        
+        guard reachability.isReachable() else {
+            setStatus(to: .error)
+            return
+        }
+        
+        setStatus(to: (!OnionRequestAPI.paths.isEmpty ? .connected : .connecting))
     }
 }

--- a/SessionMessagingKit/Database/Models/Interaction.swift
+++ b/SessionMessagingKit/Database/Models/Interaction.swift
@@ -445,6 +445,7 @@ public extension Interaction {
         _ db: Database,
         interactionId: Int64?,
         threadId: String,
+        threadVariant: SessionThread.Variant,
         includingOlder: Bool,
         trySendReadReceipt: Bool
     ) throws {
@@ -480,8 +481,9 @@ public extension Interaction {
                     ))
             )
             
-            // If we want to send read receipts then try to add the 'SendReadReceiptsJob'
-            if trySendReadReceipt {
+            // If we want to send read receipts and it's a contact thread then try to add the
+            // 'SendReadReceiptsJob'
+            if trySendReadReceipt && threadVariant == .contact {
                 JobRunner.upsert(
                     db,
                     job: SendReadReceiptsJob.createOrUpdateIfNeeded(

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+UnsendRequests.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+UnsendRequests.swift
@@ -19,7 +19,12 @@ extension MessageReceiver {
         
         guard
             let interactionId: Int64 = maybeInteraction?.id,
-            let interaction: Interaction = maybeInteraction
+            let interaction: Interaction = maybeInteraction,
+            let threadVariant: SessionThread.Variant = try SessionThread
+                .filter(id: interaction.threadId)
+                .select(.variant)
+                .asRequest(of: SessionThread.Variant.self)
+                .fetchOne(db)
         else { return }
         
         // Mark incoming messages as read and remove any of their notifications
@@ -28,6 +33,7 @@ extension MessageReceiver {
                 db,
                 interactionId: interactionId,
                 threadId: interaction.threadId,
+                threadVariant: threadVariant,
                 includingOlder: false,
                 trySendReadReceipt: false
             )

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+VisibleMessages.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+VisibleMessages.swift
@@ -405,6 +405,7 @@ extension MessageReceiver {
             db,
             interactionId: interactionId,
             threadId: thread.id,
+            threadVariant: thread.variant,
             includingOlder: true,
             trySendReadReceipt: true
         )


### PR DESCRIPTION
- Updated the PathStatusView to take Reachability into account for it's status indicator
- Fixed a bug where including emojis in a message that ended with a URL would result in incorrect URL detection
- Fixed an odd UI glitch which could occur when message cells updated (delivery/read state could overlap temporarily)
- Fixed an issue where a user couldn't delete their own messages sent to a community
- Fixed an issue where the app didn't require a passcode to be set to use screen lock
- Fixed an issue where the delivery status on a sending message might not update when on the conversation screen
- Fixed an issue where read receipts weren't working

Fixes #770 
Fixes #643 
Fixes #774
Fixes #755
Fixes #717