### PR TITLE
Fixed a couple of reachability oddities and bugs

### DIFF
--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -651,6 +651,8 @@
 		FD3C907127E445E500CD579F /* MessageReceiverDecryptionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3C907027E445E500CD579F /* MessageReceiverDecryptionSpec.swift */; };
 		FD3E0C84283B5835002A425C /* SessionThreadViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3E0C83283B5835002A425C /* SessionThreadViewModel.swift */; };
 		FD42F9A8285064B800A0C77D /* PushNotificationAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33FDBDE255A581900E217F9 /* PushNotificationAPI.swift */; };
+		FD432432299C6933008A0213 /* _011_AddPendingReadReceipts.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD432431299C6933008A0213 /* _011_AddPendingReadReceipts.swift */; };
+		FD432434299C6985008A0213 /* PendingReadReceipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD432433299C6985008A0213 /* PendingReadReceipt.swift */; };
 		FD4B200E283492210034334B /* InsetLockableTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD4B200D283492210034334B /* InsetLockableTableView.swift */; };
 		FD52090028AF6153006098F6 /* OWSBackgroundTask.m in Sources */ = {isa = PBXBuildFile; fileRef = C33FDC1B255A581F00E217F9 /* OWSBackgroundTask.m */; };
 		FD52090128AF61BA006098F6 /* OWSBackgroundTask.h in Headers */ = {isa = PBXBuildFile; fileRef = C33FDB38255A580B00E217F9 /* OWSBackgroundTask.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1735,6 +1737,8 @@
 		FD3C907027E445E500CD579F /* MessageReceiverDecryptionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReceiverDecryptionSpec.swift; sourceTree = "<group>"; };
 		FD3C907427E83AC200CD579F /* OpenGroupServerIdLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenGroupServerIdLookup.swift; sourceTree = "<group>"; };
 		FD3E0C83283B5835002A425C /* SessionThreadViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionThreadViewModel.swift; sourceTree = "<group>"; };
+		FD432431299C6933008A0213 /* _011_AddPendingReadReceipts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _011_AddPendingReadReceipts.swift; sourceTree = "<group>"; };
+		FD432433299C6985008A0213 /* PendingReadReceipt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingReadReceipt.swift; sourceTree = "<group>"; };
 		FD4B200D283492210034334B /* InsetLockableTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsetLockableTableView.swift; sourceTree = "<group>"; };
 		FD52090228B4680F006098F6 /* RadioButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioButton.swift; sourceTree = "<group>"; };
 		FD52090428B4915F006098F6 /* PrivacySettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySettingsViewModel.swift; sourceTree = "<group>"; };
@@ -3524,6 +3528,7 @@
 				FDE77F6A280FEB28002CFC5D /* ControlMessageProcessRecord.swift */,
 				FD5C7308285007920029977D /* BlindedIdLookup.swift */,
 				FD09B7E6288670FD00ED0B66 /* Reaction.swift */,
+				FD432433299C6985008A0213 /* PendingReadReceipt.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -3541,6 +3546,7 @@
 				FD09B7E4288670BB00ED0B66 /* _008_EmojiReacts.swift */,
 				7BAA7B6528D2DE4700AE1489 /* _009_OpenGroupPermission.swift */,
 				FD7115F128C6CB3900B47552 /* _010_AddThreadIdToFTS.swift */,
+				FD432431299C6933008A0213 /* _011_AddPendingReadReceipts.swift */,
 			);
 			path = Migrations;
 			sourceTree = "<group>";
@@ -5490,6 +5496,7 @@
 				FD716E6428502DDD00C96BF4 /* CallManagerProtocol.swift in Sources */,
 				FDC438C727BB6DF000C60D73 /* DirectMessage.swift in Sources */,
 				FDC4384F27B4804F00C60D73 /* Header.swift in Sources */,
+				FD432434299C6985008A0213 /* PendingReadReceipt.swift in Sources */,
 				FDC4381727B32EC700C60D73 /* Personalization.swift in Sources */,
 				FD245C51285065CC00B966DD /* MessageReceiver.swift in Sources */,
 				FD245C652850665400B966DD /* ClosedGroupControlMessage.swift in Sources */,
@@ -5551,6 +5558,7 @@
 				FDC438C127BB4E6800C60D73 /* SMKDependencies.swift in Sources */,
 				FDC4383827B3863200C60D73 /* VersionResponse.swift in Sources */,
 				B806ECA126C4A7E4008BDA44 /* WebRTCSession+UI.swift in Sources */,
+				FD432432299C6933008A0213 /* _011_AddPendingReadReceipts.swift in Sources */,
 				7BCD116C27016062006330F1 /* WebRTCSession+DataChannel.swift in Sources */,
 				FD5C72F9284F0E880029977D /* MessageReceiver+TypingIndicators.swift in Sources */,
 				FD5C7303284F0FA50029977D /* MessageReceiver+Calls.swift in Sources */,

--- a/Session/Conversations/Context Menu/ContextMenuVC+Action.swift
+++ b/Session/Conversations/Context Menu/ContextMenuVC+Action.swift
@@ -34,6 +34,17 @@ extension ContextMenuVC {
         }
         
         // MARK: - Actions
+        
+        static func retry(_ cellViewModel: MessageViewModel, _ delegate: ContextMenuActionDelegate?) -> Action {
+            return Action(
+                icon: UIImage(systemName: "arrow.triangle.2.circlepath"),
+                title: (cellViewModel.state == .failedToSync ?
+                    "context_menu_resync".localized() :
+                    "context_menu_resend".localized()
+                ),
+                accessibilityLabel: (cellViewModel.state == .failedToSync ? "Resync message" : "Resend message")
+            ) { delegate?.retry(cellViewModel) }
+        }
 
         static func reply(_ cellViewModel: MessageViewModel, _ delegate: ContextMenuActionDelegate?) -> Action {
             return Action(
@@ -126,6 +137,14 @@ extension ContextMenuVC {
             case .standardOutgoing, .standardIncoming: break
         }
         
+        let canRetry: Bool = (
+            cellViewModel.variant == .standardOutgoing && (
+                cellViewModel.state == .failed || (
+                    cellViewModel.threadVariant == .contact &&
+                    cellViewModel.state == .failedToSync
+                )
+            )
+        )
         let canReply: Bool = (
             cellViewModel.variant != .standardOutgoing || (
                 cellViewModel.state != .failed &&
@@ -180,6 +199,7 @@ extension ContextMenuVC {
         }()
         
         let generatedActions: [Action] = [
+            (canRetry ? Action.retry(cellViewModel, delegate) : nil),
             (canReply ? Action.reply(cellViewModel, delegate) : nil),
             (canCopy ? Action.copy(cellViewModel, delegate) : nil),
             (canSave ? Action.save(cellViewModel, delegate) : nil),
@@ -201,6 +221,7 @@ extension ContextMenuVC {
 // MARK: - Delegate
 
 protocol ContextMenuActionDelegate {
+    func retry(_ cellViewModel: MessageViewModel)
     func reply(_ cellViewModel: MessageViewModel)
     func copy(_ cellViewModel: MessageViewModel)
     func copySessionID(_ cellViewModel: MessageViewModel)

--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -1826,10 +1826,16 @@ extension ConversationVC:
                 })
                 
                 actionSheet.addAction(UIAlertAction(
-                    title: (cellViewModel.threadVariant == .closedGroup ?
-                        "delete_message_for_everyone".localized() :
-                        String(format: "delete_message_for_me_and_recipient".localized(), threadName)
-                    ),
+                    title: {
+                        switch cellViewModel.threadVariant {
+                            case .closedGroup: return "delete_message_for_everyone".localized()
+                            default:
+                                return (cellViewModel.threadId == userPublicKey ?
+                                    "delete_message_for_me_and_my_devices".localized() :
+                                    String(format: "delete_message_for_me_and_recipient".localized(), threadName)
+                                )
+                        }
+                    }(),
                     style: .destructive
                 ) { [weak self] _ in
                     deleteRemotely(

--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -7,6 +7,7 @@ import PhotosUI
 import Sodium
 import PromiseKit
 import GRDB
+import SessionUIKit
 import SessionMessagingKit
 import SessionUtilitiesKit
 import SignalUtilitiesKit
@@ -828,7 +829,7 @@ extension ConversationVC:
     }
 
     func handleItemTapped(_ cellViewModel: MessageViewModel, gestureRecognizer: UITapGestureRecognizer) {
-        guard cellViewModel.variant != .standardOutgoing || cellViewModel.state != .failed else {
+        guard cellViewModel.variant != .standardOutgoing || (cellViewModel.state != .failed && cellViewModel.state != .failedToSync) else {
             // Show the failed message sheet
             showFailedMessageSheet(for: cellViewModel)
             return
@@ -1450,30 +1451,34 @@ extension ConversationVC:
     // MARK: --action handling
     
     func showFailedMessageSheet(for cellViewModel: MessageViewModel) {
-        let sheet = UIAlertController(title: cellViewModel.mostRecentFailureText, message: nil, preferredStyle: .actionSheet)
-        sheet.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
-        sheet.addAction(UIAlertAction(title: "Delete", style: .destructive, handler: { _ in
-            Storage.shared.writeAsync { db in
-                try Interaction
-                    .filter(id: cellViewModel.id)
-                    .deleteAll(db)
-            }
-        }))
-        sheet.addAction(UIAlertAction(title: "Resend", style: .default, handler: { _ in
-            Storage.shared.writeAsync { [weak self] db in
-                guard
-                    let threadId: String = self?.viewModel.threadData.threadId,
-                    let interaction: Interaction = try? Interaction.fetchOne(db, id: cellViewModel.id),
-                    let thread: SessionThread = try SessionThread.fetchOne(db, id: threadId)
-                else { return }
-                
-                try MessageSender.send(
-                    db,
-                    interaction: interaction,
-                    in: thread
-                )
-            }
-        }))
+        let sheet = UIAlertController(
+            title: (cellViewModel.state == .failedToSync ?
+                "MESSAGE_DELIVERY_FAILED_SYNC_TITLE".localized() :
+                "MESSAGE_DELIVERY_FAILED_TITLE".localized()
+            ),
+            message: cellViewModel.mostRecentFailureText,
+            preferredStyle: .actionSheet
+        )
+        sheet.addAction(UIAlertAction(title: "TXT_CANCEL_TITLE".localized(), style: .cancel, handler: nil))
+        
+        if cellViewModel.state != .failedToSync {
+            sheet.addAction(UIAlertAction(title: "TXT_DELETE_TITLE".localized(), style: .destructive, handler: { _ in
+                Storage.shared.writeAsync { db in
+                    try Interaction
+                        .filter(id: cellViewModel.id)
+                        .deleteAll(db)
+                }
+            }))
+        }
+        
+        sheet.addAction(UIAlertAction(
+            title: (cellViewModel.state == .failedToSync ?
+                "context_menu_resync".localized() :
+                "context_menu_resend".localized()
+            ),
+            style: .default,
+            handler: { [weak self] _ in self?.retry(cellViewModel) }
+        ))
         
         // HACK: Extracting this info from the error string is pretty dodgy
         let prefix: String = "HTTP request failed at destination (Service node "
@@ -1557,6 +1562,23 @@ extension ConversationVC:
     }
     
     // MARK: - ContextMenuActionDelegate
+    
+    func retry(_ cellViewModel: MessageViewModel) {
+        Storage.shared.writeAsync { [weak self] db in
+            guard
+                let threadId: String = self?.viewModel.threadData.threadId,
+                let interaction: Interaction = try? Interaction.fetchOne(db, id: cellViewModel.id),
+                let thread: SessionThread = try SessionThread.fetchOne(db, id: threadId)
+            else { return }
+            
+            try MessageSender.send(
+                db,
+                interaction: interaction,
+                in: thread,
+                isSyncMessage: (cellViewModel.state == .failedToSync)
+            )
+        }
+    }
 
     func reply(_ cellViewModel: MessageViewModel) {
         let maybeQuoteDraft: QuotedReplyModel? = QuotedReplyModel.quotedReplyForSending(

--- a/Session/Conversations/ConversationViewModel.swift
+++ b/Session/Conversations/ConversationViewModel.swift
@@ -298,6 +298,15 @@ public class ConversationViewModel: OWSAudioPlayerDelegate {
                                     index == (sortedData.count - 1) &&
                                     pageInfo.pageOffset == 0
                                 ),
+                                isLastOutgoing: (
+                                    cellViewModel.id == sortedData
+                                        .filter {
+                                            $0.authorId == threadData.currentUserPublicKey ||
+                                            $0.authorId == threadData.currentUserBlindedPublicKey
+                                        }
+                                        .last?
+                                        .id
+                                ),
                                 currentUserBlindedPublicKey: threadData.currentUserBlindedPublicKey
                             )
                         }

--- a/Session/Conversations/ConversationViewModel.swift
+++ b/Session/Conversations/ConversationViewModel.swift
@@ -200,7 +200,7 @@ public class ConversationViewModel: OWSAudioPlayerDelegate {
                 ),
                 PagedData.ObservedChanges(
                     table: RecipientState.self,
-                    columns: [.state, .mostRecentFailureText],
+                    columns: [.state, .readTimestampMs, .mostRecentFailureText],
                     joinToPagedType: {
                         let interaction: TypedTableAlias<Interaction> = TypedTableAlias()
                         let recipientState: TypedTableAlias<RecipientState> = TypedTableAlias()

--- a/Session/Conversations/Input View/InputView.swift
+++ b/Session/Conversations/Input View/InputView.swift
@@ -3,6 +3,7 @@
 import UIKit
 import SessionUIKit
 import SessionMessagingKit
+import SessionUtilitiesKit
 
 final class InputView: UIView, InputViewButtonDelegate, InputTextViewDelegate, MentionSelectionViewDelegate {
     // MARK: - Variables

--- a/Session/Conversations/Message Cells/VisibleMessageCell.swift
+++ b/Session/Conversations/Message Cells/VisibleMessageCell.swift
@@ -431,7 +431,7 @@ final class VisibleMessageCell: MessageCell, TappableLabelDelegate {
             cellViewModel.variant == .infoCall ||
             (
                 cellViewModel.state == .sent &&
-                !cellViewModel.isLast
+                !cellViewModel.isLastOutgoing
             )
         )
         messageStatusLabelPaddingView.isHidden = (

--- a/Session/Media Viewing & Editing/GIFs/GifPickerViewController.swift
+++ b/Session/Media Viewing & Editing/GIFs/GifPickerViewController.swift
@@ -2,7 +2,7 @@
 //  Copyright (c) 2019 Open Whisper Systems. All rights reserved.
 //
 
-import Foundation
+import UIKit
 import Reachability
 import SignalUtilitiesKit
 import PromiseKit

--- a/Session/Media Viewing & Editing/GIFs/GiphyAPI.swift
+++ b/Session/Media Viewing & Editing/GIFs/GiphyAPI.swift
@@ -6,6 +6,8 @@ import AFNetworking
 import Foundation
 import PromiseKit
 import CoreServices
+import SignalUtilitiesKit
+import SessionUtilitiesKit
 
 // There's no UTI type for webp!
 enum GiphyFormat {

--- a/Session/Meta/Translations/de.lproj/Localizable.strings
+++ b/Session/Meta/Translations/de.lproj/Localizable.strings
@@ -600,3 +600,4 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"delete_message_for_me_and_my_devices" = "Delete from all of my devices";

--- a/Session/Meta/Translations/de.lproj/Localizable.strings
+++ b/Session/Meta/Translations/de.lproj/Localizable.strings
@@ -600,4 +600,10 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"MESSAGE_DELIVERY_STATUS_FAILED_SYNC" = "Failed to sync";
+"MESSAGE_DELIVERY_STATUS_SYNCING" = "Syncing";
+"MESSAGE_DELIVERY_FAILED_TITLE" = "Failed to send message";
+"MESSAGE_DELIVERY_FAILED_SYNC_TITLE" = "Failed to sync message to your other devices";
 "delete_message_for_me_and_my_devices" = "Delete from all of my devices";
+"context_menu_resend" = "Resend";
+"context_menu_resync" = "Resync";

--- a/Session/Meta/Translations/en.lproj/Localizable.strings
+++ b/Session/Meta/Translations/en.lproj/Localizable.strings
@@ -600,3 +600,4 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"delete_message_for_me_and_my_devices" = "Delete from all of my devices";

--- a/Session/Meta/Translations/en.lproj/Localizable.strings
+++ b/Session/Meta/Translations/en.lproj/Localizable.strings
@@ -600,4 +600,10 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"MESSAGE_DELIVERY_STATUS_FAILED_SYNC" = "Failed to sync";
+"MESSAGE_DELIVERY_STATUS_SYNCING" = "Syncing";
+"MESSAGE_DELIVERY_FAILED_TITLE" = "Failed to send message";
+"MESSAGE_DELIVERY_FAILED_SYNC_TITLE" = "Failed to sync message to your other devices";
 "delete_message_for_me_and_my_devices" = "Delete from all of my devices";
+"context_menu_resend" = "Resend";
+"context_menu_resync" = "Resync";

--- a/Session/Meta/Translations/es.lproj/Localizable.strings
+++ b/Session/Meta/Translations/es.lproj/Localizable.strings
@@ -600,3 +600,4 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"delete_message_for_me_and_my_devices" = "Delete from all of my devices";

--- a/Session/Meta/Translations/es.lproj/Localizable.strings
+++ b/Session/Meta/Translations/es.lproj/Localizable.strings
@@ -600,4 +600,10 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"MESSAGE_DELIVERY_STATUS_FAILED_SYNC" = "Failed to sync";
+"MESSAGE_DELIVERY_STATUS_SYNCING" = "Syncing";
+"MESSAGE_DELIVERY_FAILED_TITLE" = "Failed to send message";
+"MESSAGE_DELIVERY_FAILED_SYNC_TITLE" = "Failed to sync message to your other devices";
 "delete_message_for_me_and_my_devices" = "Delete from all of my devices";
+"context_menu_resend" = "Resend";
+"context_menu_resync" = "Resync";

--- a/Session/Meta/Translations/fa.lproj/Localizable.strings
+++ b/Session/Meta/Translations/fa.lproj/Localizable.strings
@@ -600,3 +600,4 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"delete_message_for_me_and_my_devices" = "Delete from all of my devices";

--- a/Session/Meta/Translations/fa.lproj/Localizable.strings
+++ b/Session/Meta/Translations/fa.lproj/Localizable.strings
@@ -600,4 +600,10 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"MESSAGE_DELIVERY_STATUS_FAILED_SYNC" = "Failed to sync";
+"MESSAGE_DELIVERY_STATUS_SYNCING" = "Syncing";
+"MESSAGE_DELIVERY_FAILED_TITLE" = "Failed to send message";
+"MESSAGE_DELIVERY_FAILED_SYNC_TITLE" = "Failed to sync message to your other devices";
 "delete_message_for_me_and_my_devices" = "Delete from all of my devices";
+"context_menu_resend" = "Resend";
+"context_menu_resync" = "Resync";

--- a/Session/Meta/Translations/fi.lproj/Localizable.strings
+++ b/Session/Meta/Translations/fi.lproj/Localizable.strings
@@ -600,3 +600,4 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"delete_message_for_me_and_my_devices" = "Delete from all of my devices";

--- a/Session/Meta/Translations/fi.lproj/Localizable.strings
+++ b/Session/Meta/Translations/fi.lproj/Localizable.strings
@@ -600,4 +600,10 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"MESSAGE_DELIVERY_STATUS_FAILED_SYNC" = "Failed to sync";
+"MESSAGE_DELIVERY_STATUS_SYNCING" = "Syncing";
+"MESSAGE_DELIVERY_FAILED_TITLE" = "Failed to send message";
+"MESSAGE_DELIVERY_FAILED_SYNC_TITLE" = "Failed to sync message to your other devices";
 "delete_message_for_me_and_my_devices" = "Delete from all of my devices";
+"context_menu_resend" = "Resend";
+"context_menu_resync" = "Resync";

--- a/Session/Meta/Translations/fr.lproj/Localizable.strings
+++ b/Session/Meta/Translations/fr.lproj/Localizable.strings
@@ -600,3 +600,4 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"delete_message_for_me_and_my_devices" = "Delete from all of my devices";

--- a/Session/Meta/Translations/fr.lproj/Localizable.strings
+++ b/Session/Meta/Translations/fr.lproj/Localizable.strings
@@ -600,4 +600,10 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"MESSAGE_DELIVERY_STATUS_FAILED_SYNC" = "Failed to sync";
+"MESSAGE_DELIVERY_STATUS_SYNCING" = "Syncing";
+"MESSAGE_DELIVERY_FAILED_TITLE" = "Failed to send message";
+"MESSAGE_DELIVERY_FAILED_SYNC_TITLE" = "Failed to sync message to your other devices";
 "delete_message_for_me_and_my_devices" = "Delete from all of my devices";
+"context_menu_resend" = "Resend";
+"context_menu_resync" = "Resync";

--- a/Session/Meta/Translations/hi.lproj/Localizable.strings
+++ b/Session/Meta/Translations/hi.lproj/Localizable.strings
@@ -600,3 +600,4 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"delete_message_for_me_and_my_devices" = "Delete from all of my devices";

--- a/Session/Meta/Translations/hi.lproj/Localizable.strings
+++ b/Session/Meta/Translations/hi.lproj/Localizable.strings
@@ -600,4 +600,10 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"MESSAGE_DELIVERY_STATUS_FAILED_SYNC" = "Failed to sync";
+"MESSAGE_DELIVERY_STATUS_SYNCING" = "Syncing";
+"MESSAGE_DELIVERY_FAILED_TITLE" = "Failed to send message";
+"MESSAGE_DELIVERY_FAILED_SYNC_TITLE" = "Failed to sync message to your other devices";
 "delete_message_for_me_and_my_devices" = "Delete from all of my devices";
+"context_menu_resend" = "Resend";
+"context_menu_resync" = "Resync";

--- a/Session/Meta/Translations/hr.lproj/Localizable.strings
+++ b/Session/Meta/Translations/hr.lproj/Localizable.strings
@@ -600,3 +600,4 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"delete_message_for_me_and_my_devices" = "Delete from all of my devices";

--- a/Session/Meta/Translations/hr.lproj/Localizable.strings
+++ b/Session/Meta/Translations/hr.lproj/Localizable.strings
@@ -600,4 +600,10 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"MESSAGE_DELIVERY_STATUS_FAILED_SYNC" = "Failed to sync";
+"MESSAGE_DELIVERY_STATUS_SYNCING" = "Syncing";
+"MESSAGE_DELIVERY_FAILED_TITLE" = "Failed to send message";
+"MESSAGE_DELIVERY_FAILED_SYNC_TITLE" = "Failed to sync message to your other devices";
 "delete_message_for_me_and_my_devices" = "Delete from all of my devices";
+"context_menu_resend" = "Resend";
+"context_menu_resync" = "Resync";

--- a/Session/Meta/Translations/id-ID.lproj/Localizable.strings
+++ b/Session/Meta/Translations/id-ID.lproj/Localizable.strings
@@ -600,3 +600,4 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"delete_message_for_me_and_my_devices" = "Delete from all of my devices";

--- a/Session/Meta/Translations/id-ID.lproj/Localizable.strings
+++ b/Session/Meta/Translations/id-ID.lproj/Localizable.strings
@@ -600,4 +600,10 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"MESSAGE_DELIVERY_STATUS_FAILED_SYNC" = "Failed to sync";
+"MESSAGE_DELIVERY_STATUS_SYNCING" = "Syncing";
+"MESSAGE_DELIVERY_FAILED_TITLE" = "Failed to send message";
+"MESSAGE_DELIVERY_FAILED_SYNC_TITLE" = "Failed to sync message to your other devices";
 "delete_message_for_me_and_my_devices" = "Delete from all of my devices";
+"context_menu_resend" = "Resend";
+"context_menu_resync" = "Resync";

--- a/Session/Meta/Translations/it.lproj/Localizable.strings
+++ b/Session/Meta/Translations/it.lproj/Localizable.strings
@@ -600,3 +600,4 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"delete_message_for_me_and_my_devices" = "Delete from all of my devices";

--- a/Session/Meta/Translations/it.lproj/Localizable.strings
+++ b/Session/Meta/Translations/it.lproj/Localizable.strings
@@ -600,4 +600,10 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"MESSAGE_DELIVERY_STATUS_FAILED_SYNC" = "Failed to sync";
+"MESSAGE_DELIVERY_STATUS_SYNCING" = "Syncing";
+"MESSAGE_DELIVERY_FAILED_TITLE" = "Failed to send message";
+"MESSAGE_DELIVERY_FAILED_SYNC_TITLE" = "Failed to sync message to your other devices";
 "delete_message_for_me_and_my_devices" = "Delete from all of my devices";
+"context_menu_resend" = "Resend";
+"context_menu_resync" = "Resync";

--- a/Session/Meta/Translations/ja.lproj/Localizable.strings
+++ b/Session/Meta/Translations/ja.lproj/Localizable.strings
@@ -600,3 +600,4 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"delete_message_for_me_and_my_devices" = "Delete from all of my devices";

--- a/Session/Meta/Translations/ja.lproj/Localizable.strings
+++ b/Session/Meta/Translations/ja.lproj/Localizable.strings
@@ -600,4 +600,10 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"MESSAGE_DELIVERY_STATUS_FAILED_SYNC" = "Failed to sync";
+"MESSAGE_DELIVERY_STATUS_SYNCING" = "Syncing";
+"MESSAGE_DELIVERY_FAILED_TITLE" = "Failed to send message";
+"MESSAGE_DELIVERY_FAILED_SYNC_TITLE" = "Failed to sync message to your other devices";
 "delete_message_for_me_and_my_devices" = "Delete from all of my devices";
+"context_menu_resend" = "Resend";
+"context_menu_resync" = "Resync";

--- a/Session/Meta/Translations/nl.lproj/Localizable.strings
+++ b/Session/Meta/Translations/nl.lproj/Localizable.strings
@@ -600,3 +600,4 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"delete_message_for_me_and_my_devices" = "Delete from all of my devices";

--- a/Session/Meta/Translations/nl.lproj/Localizable.strings
+++ b/Session/Meta/Translations/nl.lproj/Localizable.strings
@@ -600,4 +600,10 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"MESSAGE_DELIVERY_STATUS_FAILED_SYNC" = "Failed to sync";
+"MESSAGE_DELIVERY_STATUS_SYNCING" = "Syncing";
+"MESSAGE_DELIVERY_FAILED_TITLE" = "Failed to send message";
+"MESSAGE_DELIVERY_FAILED_SYNC_TITLE" = "Failed to sync message to your other devices";
 "delete_message_for_me_and_my_devices" = "Delete from all of my devices";
+"context_menu_resend" = "Resend";
+"context_menu_resync" = "Resync";

--- a/Session/Meta/Translations/pl.lproj/Localizable.strings
+++ b/Session/Meta/Translations/pl.lproj/Localizable.strings
@@ -600,3 +600,4 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"delete_message_for_me_and_my_devices" = "Delete from all of my devices";

--- a/Session/Meta/Translations/pl.lproj/Localizable.strings
+++ b/Session/Meta/Translations/pl.lproj/Localizable.strings
@@ -600,4 +600,10 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"MESSAGE_DELIVERY_STATUS_FAILED_SYNC" = "Failed to sync";
+"MESSAGE_DELIVERY_STATUS_SYNCING" = "Syncing";
+"MESSAGE_DELIVERY_FAILED_TITLE" = "Failed to send message";
+"MESSAGE_DELIVERY_FAILED_SYNC_TITLE" = "Failed to sync message to your other devices";
 "delete_message_for_me_and_my_devices" = "Delete from all of my devices";
+"context_menu_resend" = "Resend";
+"context_menu_resync" = "Resync";

--- a/Session/Meta/Translations/pt_BR.lproj/Localizable.strings
+++ b/Session/Meta/Translations/pt_BR.lproj/Localizable.strings
@@ -600,3 +600,4 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"delete_message_for_me_and_my_devices" = "Delete from all of my devices";

--- a/Session/Meta/Translations/pt_BR.lproj/Localizable.strings
+++ b/Session/Meta/Translations/pt_BR.lproj/Localizable.strings
@@ -600,4 +600,10 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"MESSAGE_DELIVERY_STATUS_FAILED_SYNC" = "Failed to sync";
+"MESSAGE_DELIVERY_STATUS_SYNCING" = "Syncing";
+"MESSAGE_DELIVERY_FAILED_TITLE" = "Failed to send message";
+"MESSAGE_DELIVERY_FAILED_SYNC_TITLE" = "Failed to sync message to your other devices";
 "delete_message_for_me_and_my_devices" = "Delete from all of my devices";
+"context_menu_resend" = "Resend";
+"context_menu_resync" = "Resync";

--- a/Session/Meta/Translations/ru.lproj/Localizable.strings
+++ b/Session/Meta/Translations/ru.lproj/Localizable.strings
@@ -600,3 +600,4 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"delete_message_for_me_and_my_devices" = "Delete from all of my devices";

--- a/Session/Meta/Translations/ru.lproj/Localizable.strings
+++ b/Session/Meta/Translations/ru.lproj/Localizable.strings
@@ -600,4 +600,10 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"MESSAGE_DELIVERY_STATUS_FAILED_SYNC" = "Failed to sync";
+"MESSAGE_DELIVERY_STATUS_SYNCING" = "Syncing";
+"MESSAGE_DELIVERY_FAILED_TITLE" = "Failed to send message";
+"MESSAGE_DELIVERY_FAILED_SYNC_TITLE" = "Failed to sync message to your other devices";
 "delete_message_for_me_and_my_devices" = "Delete from all of my devices";
+"context_menu_resend" = "Resend";
+"context_menu_resync" = "Resync";

--- a/Session/Meta/Translations/si.lproj/Localizable.strings
+++ b/Session/Meta/Translations/si.lproj/Localizable.strings
@@ -600,3 +600,4 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"delete_message_for_me_and_my_devices" = "Delete from all of my devices";

--- a/Session/Meta/Translations/si.lproj/Localizable.strings
+++ b/Session/Meta/Translations/si.lproj/Localizable.strings
@@ -600,4 +600,10 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"MESSAGE_DELIVERY_STATUS_FAILED_SYNC" = "Failed to sync";
+"MESSAGE_DELIVERY_STATUS_SYNCING" = "Syncing";
+"MESSAGE_DELIVERY_FAILED_TITLE" = "Failed to send message";
+"MESSAGE_DELIVERY_FAILED_SYNC_TITLE" = "Failed to sync message to your other devices";
 "delete_message_for_me_and_my_devices" = "Delete from all of my devices";
+"context_menu_resend" = "Resend";
+"context_menu_resync" = "Resync";

--- a/Session/Meta/Translations/sk.lproj/Localizable.strings
+++ b/Session/Meta/Translations/sk.lproj/Localizable.strings
@@ -600,3 +600,4 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"delete_message_for_me_and_my_devices" = "Delete from all of my devices";

--- a/Session/Meta/Translations/sk.lproj/Localizable.strings
+++ b/Session/Meta/Translations/sk.lproj/Localizable.strings
@@ -600,4 +600,10 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"MESSAGE_DELIVERY_STATUS_FAILED_SYNC" = "Failed to sync";
+"MESSAGE_DELIVERY_STATUS_SYNCING" = "Syncing";
+"MESSAGE_DELIVERY_FAILED_TITLE" = "Failed to send message";
+"MESSAGE_DELIVERY_FAILED_SYNC_TITLE" = "Failed to sync message to your other devices";
 "delete_message_for_me_and_my_devices" = "Delete from all of my devices";
+"context_menu_resend" = "Resend";
+"context_menu_resync" = "Resync";

--- a/Session/Meta/Translations/sv.lproj/Localizable.strings
+++ b/Session/Meta/Translations/sv.lproj/Localizable.strings
@@ -600,3 +600,4 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"delete_message_for_me_and_my_devices" = "Delete from all of my devices";

--- a/Session/Meta/Translations/sv.lproj/Localizable.strings
+++ b/Session/Meta/Translations/sv.lproj/Localizable.strings
@@ -600,4 +600,10 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"MESSAGE_DELIVERY_STATUS_FAILED_SYNC" = "Failed to sync";
+"MESSAGE_DELIVERY_STATUS_SYNCING" = "Syncing";
+"MESSAGE_DELIVERY_FAILED_TITLE" = "Failed to send message";
+"MESSAGE_DELIVERY_FAILED_SYNC_TITLE" = "Failed to sync message to your other devices";
 "delete_message_for_me_and_my_devices" = "Delete from all of my devices";
+"context_menu_resend" = "Resend";
+"context_menu_resync" = "Resync";

--- a/Session/Meta/Translations/th.lproj/Localizable.strings
+++ b/Session/Meta/Translations/th.lproj/Localizable.strings
@@ -600,3 +600,4 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"delete_message_for_me_and_my_devices" = "Delete from all of my devices";

--- a/Session/Meta/Translations/th.lproj/Localizable.strings
+++ b/Session/Meta/Translations/th.lproj/Localizable.strings
@@ -600,4 +600,10 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"MESSAGE_DELIVERY_STATUS_FAILED_SYNC" = "Failed to sync";
+"MESSAGE_DELIVERY_STATUS_SYNCING" = "Syncing";
+"MESSAGE_DELIVERY_FAILED_TITLE" = "Failed to send message";
+"MESSAGE_DELIVERY_FAILED_SYNC_TITLE" = "Failed to sync message to your other devices";
 "delete_message_for_me_and_my_devices" = "Delete from all of my devices";
+"context_menu_resend" = "Resend";
+"context_menu_resync" = "Resync";

--- a/Session/Meta/Translations/vi-VN.lproj/Localizable.strings
+++ b/Session/Meta/Translations/vi-VN.lproj/Localizable.strings
@@ -600,3 +600,4 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"delete_message_for_me_and_my_devices" = "Delete from all of my devices";

--- a/Session/Meta/Translations/vi-VN.lproj/Localizable.strings
+++ b/Session/Meta/Translations/vi-VN.lproj/Localizable.strings
@@ -600,4 +600,10 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"MESSAGE_DELIVERY_STATUS_FAILED_SYNC" = "Failed to sync";
+"MESSAGE_DELIVERY_STATUS_SYNCING" = "Syncing";
+"MESSAGE_DELIVERY_FAILED_TITLE" = "Failed to send message";
+"MESSAGE_DELIVERY_FAILED_SYNC_TITLE" = "Failed to sync message to your other devices";
 "delete_message_for_me_and_my_devices" = "Delete from all of my devices";
+"context_menu_resend" = "Resend";
+"context_menu_resync" = "Resync";

--- a/Session/Meta/Translations/zh-Hant.lproj/Localizable.strings
+++ b/Session/Meta/Translations/zh-Hant.lproj/Localizable.strings
@@ -600,3 +600,4 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"delete_message_for_me_and_my_devices" = "Delete from all of my devices";

--- a/Session/Meta/Translations/zh-Hant.lproj/Localizable.strings
+++ b/Session/Meta/Translations/zh-Hant.lproj/Localizable.strings
@@ -600,4 +600,10 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"MESSAGE_DELIVERY_STATUS_FAILED_SYNC" = "Failed to sync";
+"MESSAGE_DELIVERY_STATUS_SYNCING" = "Syncing";
+"MESSAGE_DELIVERY_FAILED_TITLE" = "Failed to send message";
+"MESSAGE_DELIVERY_FAILED_SYNC_TITLE" = "Failed to sync message to your other devices";
 "delete_message_for_me_and_my_devices" = "Delete from all of my devices";
+"context_menu_resend" = "Resend";
+"context_menu_resync" = "Resync";

--- a/Session/Meta/Translations/zh_CN.lproj/Localizable.strings
+++ b/Session/Meta/Translations/zh_CN.lproj/Localizable.strings
@@ -600,3 +600,4 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"delete_message_for_me_and_my_devices" = "Delete from all of my devices";

--- a/Session/Meta/Translations/zh_CN.lproj/Localizable.strings
+++ b/Session/Meta/Translations/zh_CN.lproj/Localizable.strings
@@ -600,4 +600,10 @@
 "MESSAGE_DELIVERY_STATUS_SENT" = "Sent";
 "MESSAGE_DELIVERY_STATUS_READ" = "Read";
 "MESSAGE_DELIVERY_STATUS_FAILED" = "Failed to send";
+"MESSAGE_DELIVERY_STATUS_FAILED_SYNC" = "Failed to sync";
+"MESSAGE_DELIVERY_STATUS_SYNCING" = "Syncing";
+"MESSAGE_DELIVERY_FAILED_TITLE" = "Failed to send message";
+"MESSAGE_DELIVERY_FAILED_SYNC_TITLE" = "Failed to sync message to your other devices";
 "delete_message_for_me_and_my_devices" = "Delete from all of my devices";
+"context_menu_resend" = "Resend";
+"context_menu_resync" = "Resync";

--- a/Session/Notifications/UserNotificationsAdaptee.swift
+++ b/Session/Notifications/UserNotificationsAdaptee.swift
@@ -5,6 +5,8 @@
 import Foundation
 import UserNotifications
 import PromiseKit
+import SignalCoreKit
+import SignalUtilitiesKit
 import SessionMessagingKit
 
 class UserNotificationConfig {

--- a/Session/Path/PathStatusView.swift
+++ b/Session/Path/PathStatusView.swift
@@ -3,6 +3,7 @@
 import UIKit
 import Reachability
 import SessionUIKit
+import SessionSnodeKit
 
 final class PathStatusView: UIView {
     enum Size {

--- a/Session/Settings/QRCodeVC.swift
+++ b/Session/Settings/QRCodeVC.swift
@@ -4,6 +4,7 @@ import UIKit
 import AVFoundation
 import Curve25519Kit
 import SessionUIKit
+import SessionMessagingKit
 import SessionUtilitiesKit
 
 final class QRCodeVC : BaseVC, UIPageViewControllerDataSource, UIPageViewControllerDelegate, QRScannerDelegate {

--- a/SessionMessagingKit/Configuration.swift
+++ b/SessionMessagingKit/Configuration.swift
@@ -24,7 +24,8 @@ public enum SNMessagingKit { // Just to make the external API nice
                 [
                     _008_EmojiReacts.self,
                     _009_OpenGroupPermission.self,
-                    _010_AddThreadIdToFTS.self
+                    _010_AddThreadIdToFTS.self,
+                    _011_AddPendingReadReceipts.self
                 ]
             ]
         )

--- a/SessionMessagingKit/Database/Migrations/_011_AddPendingReadReceipts.swift
+++ b/SessionMessagingKit/Database/Migrations/_011_AddPendingReadReceipts.swift
@@ -1,0 +1,41 @@
+// Copyright © 2023 Rangeproof Pty Ltd. All rights reserved.
+
+import Foundation
+import GRDB
+import SessionUtilitiesKit
+
+/// This migration adds a table to track pending read receipts (it's possible to receive a read receipt message before getting the original
+/// message due to how one-to-one conversations work, by storing pending read receipts we should be able to prevent this case)
+enum _011_AddPendingReadReceipts: Migration {
+    static let target: TargetMigrations.Identifier = .messagingKit
+    static let identifier: String = "AddPendingReadReceipts"
+    static let needsConfigSync: Bool = false
+    static let minExpectedRunDuration: TimeInterval = 0.1
+    
+    static func migrate(_ db: Database) throws {
+        // Can't actually alter a virtual table in SQLite so we need to drop and recreate it,
+        // luckily this is actually pretty quick
+        if try db.tableExists(Interaction.fullTextSearchTableName) {
+            try db.drop(table: Interaction.fullTextSearchTableName)
+            try db.dropFTS5SynchronizationTriggers(forTable: Interaction.fullTextSearchTableName)
+        }
+        
+        try db.create(table: PendingReadReceipt.self) { t in
+            t.column(.threadId, .text)
+                .notNull()
+                .indexed()                                            // Quicker querying
+                .references(SessionThread.self, onDelete: .cascade)   // Delete if Thread deleted
+            t.column(.interactionTimestampMs, .integer)
+                .notNull()
+                .indexed()                                            // Quicker querying
+            t.column(.readTimestampMs, .integer)
+                .notNull()
+            t.column(.serverExpirationTimestamp, .double)
+                .notNull()
+            
+            t.primaryKey([.threadId, .interactionTimestampMs])
+        }
+        
+        Storage.update(progress: 1, for: self, in: target) // In case this is the last migration
+    }
+}

--- a/SessionMessagingKit/Database/Models/Interaction.swift
+++ b/SessionMessagingKit/Database/Models/Interaction.swift
@@ -450,26 +450,33 @@ public extension Interaction {
         trySendReadReceipt: Bool
     ) throws {
         guard let interactionId: Int64 = interactionId else { return }
+        
+        struct InteractionReadInfo: Decodable, FetchableRecord {
+            let id: Int64
+            let variant: Interaction.Variant
+            let timestampMs: Int64
+            let wasRead: Bool
+        }
 
         // Once all of the below is done schedule the jobs
-        func scheduleJobs(interactionIds: [Int64]) {
+        func scheduleJobs(interactionInfo: [InteractionReadInfo]) {
             // Add the 'DisappearingMessagesJob' if needed - this will update any expiring
             // messages `expiresStartedAtMs` values
             JobRunner.upsert(
                 db,
                 job: DisappearingMessagesJob.updateNextRunIfNeeded(
                     db,
-                    interactionIds: interactionIds,
+                    interactionIds: interactionInfo.map { $0.id },
                     startedAtMs: TimeInterval(SnodeAPI.currentOffsetTimestampMs())
                 )
             )
             
             // Clear out any notifications for the interactions we mark as read
             Environment.shared?.notificationsManager.wrappedValue?.cancelNotifications(
-                identifiers: interactionIds
-                    .map { interactionId in
+                identifiers: interactionInfo
+                    .map { interactionInfo in
                         Interaction.notificationIdentifier(
-                            for: interactionId,
+                            for: interactionInfo.id,
                             threadId: threadId,
                             shouldGroupMessagesForThread: false
                         )
@@ -482,43 +489,54 @@ public extension Interaction {
             )
             
             // If we want to send read receipts and it's a contact thread then try to add the
-            // 'SendReadReceiptsJob'
+            // 'SendReadReceiptsJob' for and unread messages that weren't outgoing
             if trySendReadReceipt && threadVariant == .contact {
                 JobRunner.upsert(
                     db,
                     job: SendReadReceiptsJob.createOrUpdateIfNeeded(
                         db,
                         threadId: threadId,
-                        interactionIds: interactionIds
+                        interactionIds: interactionInfo
+                            .filter { !$0.wasRead && $0.variant != .standardOutgoing }
+                            .map { $0.id }
                     )
                 )
             }
         }
         
-        // If we aren't including older interactions then update and save the current one
-        struct InteractionReadInfo: Decodable, FetchableRecord {
-            let timestampMs: Int64
-            let wasRead: Bool
-        }
-        
         // Since there is no guarantee on the order messages are inserted into the database
         // fetch the timestamp for the interaction and set everything before that as read
         let maybeInteractionInfo: InteractionReadInfo? = try Interaction
-            .select(.timestampMs, .wasRead)
+            .select(.id, .variant, .timestampMs, .wasRead)
             .filter(id: interactionId)
             .asRequest(of: InteractionReadInfo.self)
             .fetchOne(db)
         
+        // If we aren't including older interactions then update and save the current one
         guard includingOlder, let interactionInfo: InteractionReadInfo = maybeInteractionInfo else {
             // Only mark as read and trigger the subsequent jobs if the interaction is
             // actually not read (no point updating and triggering db changes otherwise)
-            guard maybeInteractionInfo?.wasRead == false else { return }
+            guard
+                maybeInteractionInfo?.wasRead == false,
+                let variant: Variant = try Interaction
+                    .filter(id: interactionId)
+                    .select(.variant)
+                    .asRequest(of: Variant.self)
+                    .fetchOne(db)
+            else { return }
             
             _ = try Interaction
                 .filter(id: interactionId)
                 .updateAll(db, Columns.wasRead.set(to: true))
             
-            scheduleJobs(interactionIds: [interactionId])
+            scheduleJobs(interactionInfo: [
+                InteractionReadInfo(
+                    id: interactionId,
+                    variant: variant,
+                    timestampMs: 0,
+                    wasRead: false
+                )
+            ])
             return
         }
         
@@ -526,16 +544,16 @@ public extension Interaction {
             .filter(Interaction.Columns.threadId == threadId)
             .filter(Interaction.Columns.timestampMs <= interactionInfo.timestampMs)
             .filter(Interaction.Columns.wasRead == false)
-        let interactionIdsToMarkAsRead: [Int64] = try interactionQuery
-            .select(.id)
-            .asRequest(of: Int64.self)
+        let interactionInfoToMarkAsRead: [InteractionReadInfo] = try interactionQuery
+            .select(.id, .variant, .timestampMs, .wasRead)
+            .asRequest(of: InteractionReadInfo.self)
             .fetchAll(db)
         
         // If there are no other interactions to mark as read then just schedule the jobs
         // for this interaction (need to ensure the disapeparing messages run for sync'ed
         // outgoing messages which will always have 'wasRead' as false)
-        guard !interactionIdsToMarkAsRead.isEmpty else {
-            scheduleJobs(interactionIds: [interactionId])
+        guard !interactionInfoToMarkAsRead.isEmpty else {
+            scheduleJobs(interactionInfo: [interactionInfo])
             return
         }
         
@@ -543,27 +561,71 @@ public extension Interaction {
         try interactionQuery.updateAll(db, Columns.wasRead.set(to: true))
         
         // Retrieve the interaction ids we want to update
-        scheduleJobs(interactionIds: interactionIdsToMarkAsRead)
+        scheduleJobs(interactionInfo: interactionInfoToMarkAsRead)
     }
     
     /// This method flags sent messages as read for the specified recipients
     ///
     /// **Note:** This method won't update the 'wasRead' flag (it will be updated via the above method)
-    static func markAsRead(_ db: Database, recipientId: String, timestampMsValues: [Double], readTimestampMs: Double) throws {
-        guard db[.areReadReceiptsEnabled] == true else { return }
+    @discardableResult static func markAsRead(
+        _ db: Database,
+        recipientId: String,
+        timestampMsValues: [Int64],
+        readTimestampMs: Int64
+    ) throws -> Set<Int64> {
+        guard db[.areReadReceiptsEnabled] == true else { return [] }
         
-        try RecipientState
+        // Update the read state
+        let rowIds: [Int64] = try RecipientState
+            .select(Column.rowID)
             .filter(RecipientState.Columns.recipientId == recipientId)
             .joining(
                 required: RecipientState.interaction
-                    .filter(Columns.variant == Variant.standardOutgoing)
                     .filter(timestampMsValues.contains(Columns.timestampMs))
+                    .filter(Columns.variant == Variant.standardOutgoing)
             )
+            .asRequest(of: Int64.self)
+            .fetchAll(db)
+        
+        // If there were no 'rowIds' then no need to run the below queries, all of the timestamps
+        // and for pending read receipts
+        guard !rowIds.isEmpty else { return timestampMsValues.asSet() }
+        
+        // Update the 'readTimestampMs' if it doesn't match (need to do this to prevent
+        // the UI update from being triggered for a redundant update)
+        try RecipientState
+            .filter(rowIds.contains(Column.rowID))
+            .filter(RecipientState.Columns.readTimestampMs == nil)
             .updateAll(
                 db,
-                RecipientState.Columns.readTimestampMs.set(to: readTimestampMs),
+                RecipientState.Columns.readTimestampMs.set(to: readTimestampMs)
+            )
+        
+        // If the message still appeared to be sending then mark it as sent
+        try RecipientState
+            .filter(rowIds.contains(Column.rowID))
+            .filter(RecipientState.Columns.state == RecipientState.State.sending)
+            .updateAll(
+                db,
                 RecipientState.Columns.state.set(to: RecipientState.State.sent)
             )
+        
+        // Retrieve the set of timestamps which were updated
+        let timestampsUpdated: Set<Int64> = try Interaction
+            .select(Columns.timestampMs)
+            .filter(timestampMsValues.contains(Columns.timestampMs))
+            .filter(Columns.variant == Variant.standardOutgoing)
+            .joining(
+                required: Interaction.recipientStates
+                    .filter(rowIds.contains(Column.rowID))
+            )
+            .asRequest(of: Int64.self)
+            .fetchSet(db)
+        
+        // Return the timestamps which weren't updated
+        return timestampMsValues
+            .asSet()
+            .subtracting(timestampsUpdated)
     }
 }
 

--- a/SessionMessagingKit/Database/Models/PendingReadReceipt.swift
+++ b/SessionMessagingKit/Database/Models/PendingReadReceipt.swift
@@ -1,0 +1,44 @@
+// Copyright © 2023 Rangeproof Pty Ltd. All rights reserved.
+
+import Foundation
+import GRDB
+import SessionUtilitiesKit
+
+public struct PendingReadReceipt: Codable, Equatable, Hashable, FetchableRecord, PersistableRecord, TableRecord, ColumnExpressible {
+    public static var databaseTableName: String { "pendingReadReceipt" }
+    public static let threadForeignKey = ForeignKey([Columns.threadId], to: [SessionThread.Columns.id])
+    
+    public typealias Columns = CodingKeys
+    public enum CodingKeys: String, CodingKey, ColumnExpression {
+        case threadId
+        case interactionTimestampMs
+        case readTimestampMs
+        case serverExpirationTimestamp
+    }
+    
+    /// The id for the thread this ReadReceipt belongs to
+    public let threadId: String
+    
+    /// The timestamp in milliseconds since epoch for the interaction this read receipt relates to
+    public let interactionTimestampMs: Int64
+    
+    /// The timestamp in milliseconds since epoch that the interaction this read receipt relates to was read
+    public let readTimestampMs: Int64
+    
+    /// The timestamp for when this message will expire on the server (will be used for garbage collection)
+    public let serverExpirationTimestamp: TimeInterval
+    
+    // MARK: - Initialization
+    
+    public init(
+        threadId: String,
+        interactionTimestampMs: Int64,
+        readTimestampMs: Int64,
+        serverExpirationTimestamp: TimeInterval
+    ) {
+        self.threadId = threadId
+        self.interactionTimestampMs = interactionTimestampMs
+        self.readTimestampMs = readTimestampMs
+        self.serverExpirationTimestamp = serverExpirationTimestamp
+    }
+}

--- a/SessionMessagingKit/Database/Models/RecipientState.swift
+++ b/SessionMessagingKit/Database/Models/RecipientState.swift
@@ -40,6 +40,8 @@ public struct RecipientState: Codable, Equatable, FetchableRecord, PersistableRe
         case failed
         case skipped
         case sent
+        case failedToSync   // One-to-one Only
+        case syncing        // One-to-one Only
         
         func message(hasAttachments: Bool, hasAtLeastOneReadReceipt: Bool) -> String {
             switch self {
@@ -58,6 +60,9 @@ public struct RecipientState: Codable, Equatable, FetchableRecord, PersistableRe
                     }
                     
                     return "MESSAGE_STATUS_READ".localized()
+                
+                case .failedToSync: return "MESSAGE_DELIVERY_STATUS_FAILED_SYNC".localized()
+                case .syncing: return "MESSAGE_DELIVERY_STATUS_SYNCING".localized()
                     
                 default:
                     owsFailDebug("Message has unexpected status: \(self).")
@@ -96,6 +101,21 @@ public struct RecipientState: Codable, Equatable, FetchableRecord, PersistableRe
                         "MESSAGE_DELIVERY_STATUS_FAILED".localized(),
                         .danger
                     )
+                    
+                case (.failedToSync, _):
+                    return (
+                        UIImage(systemName: "exclamationmark.triangle"),
+                        "MESSAGE_DELIVERY_STATUS_FAILED_SYNC".localized(),
+                        .warning
+                    )
+                    
+                case (.syncing, _):
+                    return (
+                        UIImage(systemName: "ellipsis.circle"),
+                        "MESSAGE_DELIVERY_STATUS_SYNCING".localized(),
+                        .warning
+                    )
+
             }
         }
     }
@@ -146,23 +166,5 @@ public struct RecipientState: Codable, Equatable, FetchableRecord, PersistableRe
         self.state = state
         self.readTimestampMs = readTimestampMs
         self.mostRecentFailureText = mostRecentFailureText
-    }
-}
-
-// MARK: - Mutation
-
-public extension RecipientState {
-    func with(
-        state: State? = nil,
-        readTimestampMs: Int64? = nil,
-        mostRecentFailureText: String? = nil
-    ) -> RecipientState {
-        return RecipientState(
-            interactionId: interactionId,
-            recipientId: recipientId,
-            state: (state ?? self.state),
-            readTimestampMs: (readTimestampMs ?? self.readTimestampMs),
-            mostRecentFailureText: (mostRecentFailureText ?? self.mostRecentFailureText)
-        )
     }
 }

--- a/SessionMessagingKit/Jobs/Types/MessageReceiveJob.swift
+++ b/SessionMessagingKit/Jobs/Types/MessageReceiveJob.swift
@@ -36,6 +36,7 @@ public enum MessageReceiveJob: JobExecutor {
                     try MessageReceiver.handle(
                         db,
                         message: messageInfo.message,
+                        serverExpirationTimestamp: messageInfo.serverExpirationTimestamp,
                         associatedWithProto: try SNProtoContent.parseData(messageInfo.serializedProtoData),
                         openGroupId: nil
                     )
@@ -104,30 +105,36 @@ extension MessageReceiveJob {
             private enum CodingKeys: String, CodingKey {
                 case message
                 case variant
+                case serverExpirationTimestamp
                 case serializedProtoData
             }
             
             public let message: Message
             public let variant: Message.Variant
+            public let serverExpirationTimestamp: TimeInterval?
             public let serializedProtoData: Data
             
             public init(
                 message: Message,
                 variant: Message.Variant,
+                serverExpirationTimestamp: TimeInterval?,
                 proto: SNProtoContent
             ) throws {
                 self.message = message
                 self.variant = variant
+                self.serverExpirationTimestamp = serverExpirationTimestamp
                 self.serializedProtoData = try proto.serializedData()
             }
             
             private init(
                 message: Message,
                 variant: Message.Variant,
+                serverExpirationTimestamp: TimeInterval?,
                 serializedProtoData: Data
             ) {
                 self.message = message
                 self.variant = variant
+                self.serverExpirationTimestamp = serverExpirationTimestamp
                 self.serializedProtoData = serializedProtoData
             }
             
@@ -144,6 +151,7 @@ extension MessageReceiveJob {
                 self = MessageInfo(
                     message: try variant.decode(from: container, forKey: .message),
                     variant: variant,
+                    serverExpirationTimestamp: try? container.decode(TimeInterval.self, forKey: .serverExpirationTimestamp),
                     serializedProtoData: try container.decode(Data.self, forKey: .serializedProtoData)
                 )
             }
@@ -158,6 +166,7 @@ extension MessageReceiveJob {
 
                 try container.encode(message, forKey: .message)
                 try container.encode(variant, forKey: .variant)
+                try container.encodeIfPresent(serverExpirationTimestamp, forKey: .serverExpirationTimestamp)
                 try container.encode(serializedProtoData, forKey: .serializedProtoData)
             }
         }

--- a/SessionMessagingKit/Jobs/Types/MessageReceiveJob.swift
+++ b/SessionMessagingKit/Jobs/Types/MessageReceiveJob.swift
@@ -88,7 +88,7 @@ public enum MessageReceiveJob: JobExecutor {
                 failure(updatedJob, error, true)
                 
             case .some(let error):
-                failure(updatedJob, error, false) // TODO: Confirm the 'noKeyPair' errors here aren't an issue
+                failure(updatedJob, error, false)
                 
             case .none:
                 success(updatedJob, false)

--- a/SessionMessagingKit/Jobs/Types/MessageSendJob.swift
+++ b/SessionMessagingKit/Jobs/Types/MessageSendJob.swift
@@ -167,7 +167,8 @@ public enum MessageSendJob: JobExecutor {
                 message: details.message,
                 to: details.destination
                     .with(fileIds: messageFileIds),
-                interactionId: job.interactionId
+                interactionId: job.interactionId,
+                isSyncMessage: (details.isSyncMessage == true)
             )
         }
         .done(on: queue) { _ in success(job, false) }
@@ -213,21 +214,25 @@ extension MessageSendJob {
         private enum CodingKeys: String, CodingKey {
             case destination
             case message
+            case isSyncMessage
             case variant
         }
         
         public let destination: Message.Destination
         public let message: Message
+        public let isSyncMessage: Bool?
         public let variant: Message.Variant?
         
         // MARK: - Initialization
         
         public init(
             destination: Message.Destination,
-            message: Message
+            message: Message,
+            isSyncMessage: Bool? = nil
         ) {
             self.destination = destination
             self.message = message
+            self.isSyncMessage = isSyncMessage
             self.variant = Message.Variant(from: message)
         }
         
@@ -243,7 +248,8 @@ extension MessageSendJob {
             
             self = Details(
                 destination: try container.decode(Message.Destination.self, forKey: .destination),
-                message: try variant.decode(from: container, forKey: .message)
+                message: try variant.decode(from: container, forKey: .message),
+                isSyncMessage: try? container.decode(Bool.self, forKey: .isSyncMessage)
             )
         }
         
@@ -257,6 +263,7 @@ extension MessageSendJob {
 
             try container.encode(destination, forKey: .destination)
             try container.encode(message, forKey: .message)
+            try container.encodeIfPresent(isSyncMessage, forKey: .isSyncMessage)
             try container.encode(variant, forKey: .variant)
         }
     }

--- a/SessionMessagingKit/Jobs/Types/SendReadReceiptsJob.swift
+++ b/SessionMessagingKit/Jobs/Types/SendReadReceiptsJob.swift
@@ -105,6 +105,7 @@ public extension SendReadReceiptsJob {
     /// ensure that is done correctly beforehand
     @discardableResult static func createOrUpdateIfNeeded(_ db: Database, threadId: String, interactionIds: [Int64]) -> Job? {
         guard db[.areReadReceiptsEnabled] == true else { return nil }
+        guard !interactionIds.isEmpty else { return nil }
         
         // Retrieve the timestampMs values for the specified interactions
         let timestampMsValues: [Int64] = (try? Interaction

--- a/SessionMessagingKit/Jobs/Types/SendReadReceiptsJob.swift
+++ b/SessionMessagingKit/Jobs/Types/SendReadReceiptsJob.swift
@@ -43,7 +43,8 @@ public enum SendReadReceiptsJob: JobExecutor {
                         timestamps: details.timestampMsValues.map { UInt64($0) }
                     ),
                     to: details.destination,
-                    interactionId: nil
+                    interactionId: nil,
+                    isSyncMessage: false
                 )
             }
             .done(on: queue) {

--- a/SessionMessagingKit/Messages/Message.swift
+++ b/SessionMessagingKit/Messages/Message.swift
@@ -547,6 +547,7 @@ public extension Message {
             try MessageReceiveJob.Details.MessageInfo(
                 message: message,
                 variant: variant,
+                serverExpirationTimestamp: serverExpirationTimestamp,
                 proto: proto
             )
         )

--- a/SessionMessagingKit/Messages/Message.swift
+++ b/SessionMessagingKit/Messages/Message.swift
@@ -177,6 +177,9 @@ public extension Message {
     }
     
     static func shouldSync(message: Message) -> Bool {
+        // For 'Note to Self' messages we always want to sync the message
+        guard message.sender != message.recipient else { return true }
+        
         switch message {
             case let controlMessage as ClosedGroupControlMessage:
                 switch controlMessage.kind {

--- a/SessionMessagingKit/Messages/Message.swift
+++ b/SessionMessagingKit/Messages/Message.swift
@@ -177,10 +177,12 @@ public extension Message {
     }
     
     static func shouldSync(message: Message) -> Bool {
-        // For 'Note to Self' messages we always want to sync the message
-        guard message.sender != message.recipient else { return true }
-        
         switch message {
+            case is VisibleMessage: return true
+            case is ExpirationTimerUpdate: return true
+            case is ConfigurationMessage: return true
+            case is UnsendRequest: return true
+            
             case let controlMessage as ClosedGroupControlMessage:
                 switch controlMessage.kind {
                     case .new: return true
@@ -192,9 +194,7 @@ public extension Message {
                     case .answer, .endCall: return true
                     default: return false
                 }
-                
-            case is ConfigurationMessage: return true
-            case is UnsendRequest: return true
+            
             default: return false
         }
     }

--- a/SessionMessagingKit/Open Groups/OpenGroupManager.swift
+++ b/SessionMessagingKit/Open Groups/OpenGroupManager.swift
@@ -576,6 +576,7 @@ public final class OpenGroupManager: NSObject {
                         try MessageReceiver.handle(
                             db,
                             message: messageInfo.message,
+                            serverExpirationTimestamp: messageInfo.serverExpirationTimestamp,
                             associatedWithProto: try SNProtoContent.parseData(messageInfo.serializedProtoData),
                             openGroupId: openGroup.id,
                             dependencies: dependencies
@@ -739,6 +740,7 @@ public final class OpenGroupManager: NSObject {
                     try MessageReceiver.handle(
                         db,
                         message: messageInfo.message,
+                        serverExpirationTimestamp: messageInfo.serverExpirationTimestamp,
                         associatedWithProto: try SNProtoContent.parseData(messageInfo.serializedProtoData),
                         openGroupId: nil,   // Intentionally nil as they are technically not open group messages
                         dependencies: dependencies

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+ReadReceipts.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+ReadReceipts.swift
@@ -4,16 +4,32 @@ import Foundation
 import GRDB
 
 extension MessageReceiver {
-    internal static func handleReadReceipt(_ db: Database, message: ReadReceipt) throws {
+    internal static func handleReadReceipt(
+        _ db: Database,
+        message: ReadReceipt,
+        serverExpirationTimestamp: TimeInterval?
+    ) throws {
         guard let sender: String = message.sender else { return }
-        guard let timestampMsValues: [Double] = message.timestamps?.map({ Double($0) }) else { return }
-        guard let readTimestampMs: Double = message.receivedTimestamp.map({ Double($0) }) else { return }
+        guard let timestampMsValues: [Int64] = message.timestamps?.map({ Int64($0) }) else { return }
+        guard let readTimestampMs: Int64 = message.receivedTimestamp.map({ Int64($0) }) else { return }
         
-        try Interaction.markAsRead(
+        let pendingTimestampMs: Set<Int64> = try Interaction.markAsRead(
             db,
             recipientId: sender,
             timestampMsValues: timestampMsValues,
             readTimestampMs: readTimestampMs
         )
+        
+        guard !pendingTimestampMs.isEmpty else { return }
+        
+        // We have some pending read receipts so store them in the database
+        try pendingTimestampMs.forEach { timestampMs in
+            try PendingReadReceipt(
+                threadId: sender,
+                interactionTimestampMs: timestampMs,
+                readTimestampMs: readTimestampMs,
+                serverExpirationTimestamp: (serverExpirationTimestamp ?? 0)
+            ).save(db)
+        }
     }
 }

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+VisibleMessages.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+VisibleMessages.swift
@@ -139,6 +139,13 @@ extension MessageReceiver {
                     return recipientParts[2]
                 }()
             ).inserted(db)
+            
+            // If the message was an outgoing message then immediately update the recipient state to 'sent'
+            if variant == .standardOutgoing, let interactionId: Int64 = interaction.id {
+                _ = try? RecipientState
+                    .filter(RecipientState.Columns.interactionId == interactionId)
+                    .updateAll(db, RecipientState.Columns.state.set(to: RecipientState.State.sent))
+            }
         }
         catch {
             switch error {

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+VisibleMessages.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+VisibleMessages.swift
@@ -161,6 +161,7 @@ extension MessageReceiver {
                         db,
                         thread: thread,
                         interactionId: existingInteractionId,
+                        messageSentTimestamp: messageSentTimestamp,
                         variant: variant,
                         syncTarget: message.syncTarget
                     )
@@ -178,6 +179,7 @@ extension MessageReceiver {
             db,
             thread: thread,
             interactionId: interactionId,
+            messageSentTimestamp: messageSentTimestamp,
             variant: variant,
             syncTarget: message.syncTarget
         )
@@ -363,6 +365,7 @@ extension MessageReceiver {
         _ db: Database,
         thread: SessionThread,
         interactionId: Int64,
+        messageSentTimestamp: TimeInterval,
         variant: Interaction.Variant,
         syncTarget: String?
     ) throws {
@@ -371,6 +374,7 @@ extension MessageReceiver {
         // Immediately update any existing outgoing message 'RecipientState' records to be 'sent'
         _ = try? RecipientState
             .filter(RecipientState.Columns.interactionId == interactionId)
+            .filter(RecipientState.Columns.state != RecipientState.State.sent)
             .updateAll(db, RecipientState.Columns.state.set(to: RecipientState.State.sent))
         
         // Create any addiitonal 'RecipientState' records as needed
@@ -415,5 +419,22 @@ extension MessageReceiver {
             includingOlder: true,
             trySendReadReceipt: true
         )
+        
+        // Process any PendingReadReceipt values
+        let maybePendingReadReceipt: PendingReadReceipt? = try PendingReadReceipt
+            .filter(PendingReadReceipt.Columns.threadId == thread.id)
+            .filter(PendingReadReceipt.Columns.interactionTimestampMs == Int64(messageSentTimestamp * 1000))
+            .fetchOne(db)
+        
+        if let pendingReadReceipt: PendingReadReceipt = maybePendingReadReceipt {
+            try Interaction.markAsRead(
+                db,
+                recipientId: thread.id,
+                timestampMsValues: [pendingReadReceipt.interactionTimestampMs],
+                readTimestampMs: pendingReadReceipt.readTimestampMs
+            )
+            
+            _ = try pendingReadReceipt.delete(db)
+        }
     }
 }

--- a/SessionMessagingKit/Sending & Receiving/MessageReceiver.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageReceiver.swift
@@ -179,13 +179,18 @@ public enum MessageReceiver {
     public static func handle(
         _ db: Database,
         message: Message,
+        serverExpirationTimestamp: TimeInterval?,
         associatedWithProto proto: SNProtoContent,
         openGroupId: String?,
         dependencies: SMKDependencies = SMKDependencies()
     ) throws {
         switch message {
             case let message as ReadReceipt:
-                try MessageReceiver.handleReadReceipt(db, message: message)
+                try MessageReceiver.handleReadReceipt(
+                    db,
+                    message: message,
+                    serverExpirationTimestamp: serverExpirationTimestamp
+                )
                 
             case let message as TypingIndicator:
                 try MessageReceiver.handleTypingIndicator(db, message: message)

--- a/SessionMessagingKit/Sending & Receiving/MessageSender.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageSender.swift
@@ -647,8 +647,9 @@ public final class MessageSender {
         // • it's a visible message or an expiration timer update
         // • the destination was a contact
         // • we didn't sync it already
+        // • it wasn't set to 'Note to Self'
         let userPublicKey = getUserHexEncodedPublicKey(db)
-        if case .contact(let publicKey) = destination, !isSyncMessage {
+        if case .contact(let publicKey) = destination, !isSyncMessage, publicKey != userPublicKey {
             if let message = message as? VisibleMessage { message.syncTarget = publicKey }
             if let message = message as? ExpirationTimerUpdate { message.syncTarget = publicKey }
             

--- a/SessionMessagingKit/Sending & Receiving/MessageSender.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageSender.swift
@@ -42,10 +42,16 @@ public final class MessageSender {
 
     // MARK: - Convenience
     
-    public static func sendImmediate(_ db: Database, message: Message, to destination: Message.Destination, interactionId: Int64?) throws -> Promise<Void> {
+    public static func sendImmediate(
+        _ db: Database,
+        message: Message,
+        to destination: Message.Destination,
+        interactionId: Int64?,
+        isSyncMessage: Bool
+    ) throws -> Promise<Void> {
         switch destination {
             case .contact, .closedGroup:
-                return try sendToSnodeDestination(db, message: message, to: destination, interactionId: interactionId)
+                return try sendToSnodeDestination(db, message: message, to: destination, interactionId: interactionId, isSyncMessage: isSyncMessage)
 
             case .openGroup:
                 return sendToOpenGroupDestination(db, message: message, to: destination, interactionId: interactionId)
@@ -65,7 +71,7 @@ public final class MessageSender {
         isSyncMessage: Bool = false
     ) throws -> Promise<Void> {
         let (promise, seal) = Promise<Void>.pending()
-        let userPublicKey: String = getUserHexEncodedPublicKey(db)
+        let currentUserPublicKey: String = getUserHexEncodedPublicKey(db)
         let messageSendTimestamp: Int64 = SnodeAPI.currentOffsetTimestampMs()
         
         // Set the timestamp, sender and recipient
@@ -73,7 +79,7 @@ public final class MessageSender {
             message.sentTimestamp ??     // Visible messages will already have their sent timestamp set
             UInt64(messageSendTimestamp)
         )
-        message.sender = userPublicKey
+        message.sender = currentUserPublicKey
         message.recipient = {
             switch destination {
                 case .contact(let publicKey): return publicKey
@@ -84,7 +90,7 @@ public final class MessageSender {
         
         // Set the failure handler (need it here already for precondition failure handling)
         func handleFailure(_ db: Database, with error: MessageSenderError) {
-            MessageSender.handleFailedMessageSend(db, message: message, with: error, interactionId: interactionId)
+            MessageSender.handleFailedMessageSend(db, message: message, with: error, interactionId: interactionId, isSyncMessage: isSyncMessage)
             seal.reject(error)
         }
         
@@ -94,21 +100,8 @@ public final class MessageSender {
             return promise
         }
         
-        // Stop here if this is a self-send, unless we should sync the message
-        let isSelfSend: Bool = (message.recipient == userPublicKey)
-
-        guard
-            !isSelfSend ||
-            isSyncMessage ||
-            Message.shouldSync(message: message)
-        else {
-            try MessageSender.handleSuccessfulMessageSend(db, message: message, to: destination, interactionId: interactionId)
-            seal.fulfill(())
-            return promise
-        }
-        
         // Attach the user's profile if needed
-        if var messageWithProfile: MessageWithProfile = message as? MessageWithProfile {
+        if !isSyncMessage, var messageWithProfile: MessageWithProfile = message as? MessageWithProfile {
             let profile: Profile = Profile.fetchOrCreateCurrentUser(db)
             
             if let profileKey: Data = profile.profileEncryptionKey?.keyData, let profilePictureUrl: String = profile.profilePictureUrl {
@@ -122,6 +115,9 @@ public final class MessageSender {
                 messageWithProfile.profile = VisibleMessage.VMProfile(displayName: profile.name)
             }
         }
+        
+        // Perform any pre-send actions
+        handleMessageWillSend(db, message: message, interactionId: interactionId, isSyncMessage: isSyncMessage)
         
         // Convert it to protobuf
         guard let proto = message.toProto(db) else {
@@ -233,6 +229,9 @@ public final class MessageSender {
                             )
                             
                             let shouldNotify: Bool = {
+                                // Don't send a notification when sending messages in 'Note to Self'
+                                guard message.recipient != currentUserPublicKey else { return false }
+                                
                                 switch message {
                                     case is VisibleMessage, is UnsendRequest: return !isSyncMessage
                                     case let callMessage as CallMessage:
@@ -402,6 +401,9 @@ public final class MessageSender {
             return promise
         }
         
+        // Perform any pre-send actions
+        handleMessageWillSend(db, message: message, interactionId: interactionId)
+        
         // Convert it to protobuf
         guard let proto = message.toProto(db) else {
             handleFailure(db, with: .protoConversionFailed)
@@ -465,7 +467,7 @@ public final class MessageSender {
         dependencies: SMKDependencies = SMKDependencies()
     ) -> Promise<Void> {
         let (promise, seal) = Promise<Void>.pending()
-        let userPublicKey: String = getUserHexEncodedPublicKey(db, dependencies: dependencies)
+        let currentUserPublicKey: String = getUserHexEncodedPublicKey(db, dependencies: dependencies)
         
         guard case .openGroupInbox(let server, let openGroupPublicKey, let recipientBlindedPublicKey) = destination else {
             preconditionFailure()
@@ -476,7 +478,7 @@ public final class MessageSender {
             message.sentTimestamp = UInt64(SnodeAPI.currentOffsetTimestampMs())
         }
         
-        message.sender = userPublicKey
+        message.sender = currentUserPublicKey
         message.recipient = recipientBlindedPublicKey
         
         // Set the failure handler (need it here already for precondition failure handling)
@@ -500,6 +502,9 @@ public final class MessageSender {
                 message.profile = VisibleMessage.VMProfile(displayName: profile.name)
             }
         }
+        
+        // Perform any pre-send actions
+        handleMessageWillSend(db, message: message, interactionId: interactionId)
         
         // Convert it to protobuf
         guard let proto = message.toProto(db) else {
@@ -569,6 +574,32 @@ public final class MessageSender {
 
     // MARK: Success & Failure Handling
     
+    public static func handleMessageWillSend(
+        _ db: Database,
+        message: Message,
+        interactionId: Int64?,
+        isSyncMessage: Bool = false
+    ) {
+        // If the message was a reaction then we don't want to do anything to the original
+        // interaction (which the 'interactionId' is pointing to
+        guard (message as? VisibleMessage)?.reaction == nil else { return }
+        
+        // Mark messages as "sending"/"syncing" if needed (this is for retries)
+        _ = try? RecipientState
+            .filter(RecipientState.Columns.interactionId == interactionId)
+            .filter(isSyncMessage ?
+                RecipientState.Columns.state == RecipientState.State.failedToSync :
+                RecipientState.Columns.state == RecipientState.State.failed
+            )
+            .updateAll(
+                db,
+                RecipientState.Columns.state.set(to: isSyncMessage ?
+                    RecipientState.State.syncing :
+                    RecipientState.State.sending
+                )
+            )
+    }
+    
     private static func handleSuccessfulMessageSend(
         _ db: Database,
         message: Message,
@@ -578,7 +609,7 @@ public final class MessageSender {
         isSyncMessage: Bool = false
     ) throws {
         // If the message was a reaction then we want to update the reaction instead of the original
-        // interaciton (which the 'interactionId' is pointing to
+        // interaction (which the 'interactionId' is pointing to
         if let visibleMessage: VisibleMessage = message as? VisibleMessage, let reaction: VisibleMessage.VMReaction = visibleMessage.reaction {
             try Reaction
                 .filter(Reaction.Columns.interactionId == interactionId)
@@ -624,18 +655,20 @@ public final class MessageSender {
             }
         }
         
+        let threadId: String = {
+            switch destination {
+                case .contact(let publicKey): return publicKey
+                case .closedGroup(let groupPublicKey): return groupPublicKey
+                case .openGroup(let roomToken, let server, _, _, _):
+                    return OpenGroup.idFor(roomToken: roomToken, server: server)
+                
+                case .openGroupInbox(_, _, let blindedPublicKey): return blindedPublicKey
+            }
+        }()
+        
         // Prevent ControlMessages from being handled multiple times if not supported
         try? ControlMessageProcessRecord(
-            threadId: {
-                switch destination {
-                    case .contact(let publicKey): return publicKey
-                    case .closedGroup(let groupPublicKey): return groupPublicKey
-                    case .openGroup(let roomToken, let server, _, _, _):
-                        return OpenGroup.idFor(roomToken: roomToken, server: server)
-                    
-                    case .openGroupInbox(_, _, let blindedPublicKey): return blindedPublicKey
-                }
-            }(),
+            threadId: threadId,
             message: message,
             serverExpirationTimestamp: (
                 (TimeInterval(SnodeAPI.currentOffsetTimestampMs()) / 1000) +
@@ -643,36 +676,27 @@ public final class MessageSender {
             )
         )?.insert(db)
         
-        // Sync the message if:
-        // • it's a visible message or an expiration timer update
-        // • the destination was a contact
-        // • we didn't sync it already
-        // • it wasn't set to 'Note to Self'
-        let userPublicKey = getUserHexEncodedPublicKey(db)
-        if case .contact(let publicKey) = destination, !isSyncMessage, publicKey != userPublicKey {
-            if let message = message as? VisibleMessage { message.syncTarget = publicKey }
-            if let message = message as? ExpirationTimerUpdate { message.syncTarget = publicKey }
-            
-            // FIXME: Make this a job
-            try sendToSnodeDestination(
-                db,
-                message: message,
-                to: .contact(publicKey: userPublicKey),
-                interactionId: interactionId,
-                isSyncMessage: true
-            ).retainUntilComplete()
-        }
+        // Sync the message if needed
+        scheduleSyncMessageIfNeeded(
+            db,
+            message: message,
+            destination: destination,
+            threadId: threadId,
+            interactionId: interactionId,
+            isAlreadySyncMessage: isSyncMessage
+        )
     }
 
     public static func handleFailedMessageSend(
         _ db: Database,
         message: Message,
         with error: MessageSenderError,
-        interactionId: Int64?
+        interactionId: Int64?,
+        isSyncMessage: Bool = false
     ) {
         // TODO: Revert the local database change
         // If the message was a reaction then we don't want to do anything to the original
-        // interaciton (which the 'interactionId' is pointing to
+        // interaction (which the 'interactionId' is pointing to
         guard (message as? VisibleMessage)?.reaction == nil else { return }
         
         // Check if we need to mark any "sending" recipients as "failed"
@@ -683,7 +707,12 @@ public final class MessageSender {
         let rowIds: [Int64] = (try? RecipientState
             .select(Column.rowID)
             .filter(RecipientState.Columns.interactionId == interactionId)
-            .filter(RecipientState.Columns.state == RecipientState.State.sending)
+            .filter(!isSyncMessage ?
+                RecipientState.Columns.state == RecipientState.State.sending : (
+                    RecipientState.Columns.state == RecipientState.State.syncing ||
+                    RecipientState.Columns.state == RecipientState.State.sent
+                )
+            )
             .asRequest(of: Int64.self)
             .fetchAll(db))
             .defaulting(to: [])
@@ -698,7 +727,9 @@ public final class MessageSender {
                     .filter(rowIds.contains(Column.rowID))
                     .updateAll(
                         db,
-                        RecipientState.Columns.state.set(to: RecipientState.State.failed),
+                        RecipientState.Columns.state.set(
+                            to: (isSyncMessage ? RecipientState.State.failedToSync : RecipientState.State.failed)
+                        ),
                         RecipientState.Columns.mostRecentFailureText.set(to: error.localizedDescription)
                     )
             }
@@ -719,6 +750,43 @@ public final class MessageSender {
         }
         
         return nil
+    }
+    
+    public static func scheduleSyncMessageIfNeeded(
+        _ db: Database,
+        message: Message,
+        destination: Message.Destination,
+        threadId: String?,
+        interactionId: Int64?,
+        isAlreadySyncMessage: Bool
+    ) {
+        // Sync the message if it's not a sync message, wasn't already sent to the current user and
+        // it's a message type which should be synced
+        let currentUserPublicKey = getUserHexEncodedPublicKey(db)
+        
+        if
+            case .contact(let publicKey) = destination,
+            !isAlreadySyncMessage,
+            publicKey != currentUserPublicKey,
+            Message.shouldSync(message: message)
+        {
+            if let message = message as? VisibleMessage { message.syncTarget = publicKey }
+            if let message = message as? ExpirationTimerUpdate { message.syncTarget = publicKey }
+            
+            JobRunner.add(
+                db,
+                job: Job(
+                    variant: .messageSend,
+                    threadId: threadId,
+                    interactionId: interactionId,
+                    details: MessageSendJob.Details(
+                        destination: .contact(publicKey: currentUserPublicKey),
+                        message: message,
+                        isSyncMessage: true
+                    )
+                )
+            )
+        }
     }
 }
 

--- a/SessionMessagingKit/Shared Models/MessageViewModel.swift
+++ b/SessionMessagingKit/Shared Models/MessageViewModel.swift
@@ -39,6 +39,7 @@ public struct MessageViewModel: FetchableRecordWithRowId, Decodable, Equatable, 
     public static let positionInClusterKey: SQL = SQL(stringLiteral: CodingKeys.positionInCluster.stringValue)
     public static let isOnlyMessageInClusterKey: SQL = SQL(stringLiteral: CodingKeys.isOnlyMessageInCluster.stringValue)
     public static let isLastKey: SQL = SQL(stringLiteral: CodingKeys.isLast.stringValue)
+    public static let isLastOutgoingKey: SQL = SQL(stringLiteral: CodingKeys.isLastOutgoing.stringValue)
     
     public static let profileString: String = CodingKeys.profile.stringValue
     public static let quoteString: String = CodingKeys.quote.stringValue
@@ -140,6 +141,8 @@ public struct MessageViewModel: FetchableRecordWithRowId, Decodable, Equatable, 
     /// This value indicates whether this is the last message in the thread
     public let isLast: Bool
     
+    public let isLastOutgoing: Bool
+    
     /// This is the users blinded key (will only be set for messages within open groups)
     public let currentUserBlindedPublicKey: String?
 
@@ -191,6 +194,7 @@ public struct MessageViewModel: FetchableRecordWithRowId, Decodable, Equatable, 
             positionInCluster: self.positionInCluster,
             isOnlyMessageInCluster: self.isOnlyMessageInCluster,
             isLast: self.isLast,
+            isLastOutgoing: self.isLastOutgoing,
             currentUserBlindedPublicKey: self.currentUserBlindedPublicKey
         )
     }
@@ -199,6 +203,7 @@ public struct MessageViewModel: FetchableRecordWithRowId, Decodable, Equatable, 
         prevModel: MessageViewModel?,
         nextModel: MessageViewModel?,
         isLast: Bool,
+        isLastOutgoing: Bool,
         currentUserBlindedPublicKey: String?
     ) -> MessageViewModel {
         let cellType: CellType = {
@@ -403,6 +408,7 @@ public struct MessageViewModel: FetchableRecordWithRowId, Decodable, Equatable, 
             positionInCluster: positionInCluster,
             isOnlyMessageInCluster: isOnlyMessageInCluster,
             isLast: isLast,
+            isLastOutgoing: isLastOutgoing,
             currentUserBlindedPublicKey: currentUserBlindedPublicKey
         )
     }
@@ -498,7 +504,8 @@ public extension MessageViewModel {
         quote: Quote? = nil,
         cellType: CellType = .typingIndicator,
         isTypingIndicator: Bool? = nil,
-        isLast: Bool = true
+        isLast: Bool = true,
+        isLastOutgoing: Bool = false
     ) {
         self.threadId = "INVALID_THREAD_ID"
         self.threadVariant = .contact
@@ -554,6 +561,7 @@ public extension MessageViewModel {
         self.positionInCluster = .middle
         self.isOnlyMessageInCluster = true
         self.isLast = isLast
+        self.isLastOutgoing = isLastOutgoing
         self.currentUserBlindedPublicKey = nil
     }
 }
@@ -700,7 +708,8 @@ public extension MessageViewModel {
                     false AS \(ViewModel.shouldShowDateHeaderKey),
                     \(Position.middle) AS \(ViewModel.positionInClusterKey),
                     false AS \(ViewModel.isOnlyMessageInClusterKey),
-                    false AS \(ViewModel.isLastKey)
+                    false AS \(ViewModel.isLastKey),
+                    false AS \(ViewModel.isLastOutgoingKey)
                 
                 FROM \(Interaction.self)
                 JOIN \(SessionThread.self) ON \(thread[.id]) = \(interaction[.threadId])

--- a/SessionUIKit/Style Guide/Themes/Theme+ClassicDark.swift
+++ b/SessionUIKit/Style Guide/Themes/Theme+ClassicDark.swift
@@ -10,6 +10,7 @@ internal enum Theme_ClassicDark: ThemeColors {
         .clear: .clear,
         .primary: .primary,
         .defaultPrimary: Theme.PrimaryColor.green.color,
+        .warning: .warning,
         .danger: .dangerDark,
         .disabled: .disabledDark,
         .backgroundPrimary: .classicDark0,

--- a/SessionUIKit/Style Guide/Themes/Theme+ClassicLight.swift
+++ b/SessionUIKit/Style Guide/Themes/Theme+ClassicLight.swift
@@ -10,6 +10,7 @@ internal enum Theme_ClassicLight: ThemeColors {
         .clear: .clear,
         .primary: .primary,
         .defaultPrimary: Theme.PrimaryColor.green.color,
+        .warning: .warning,
         .danger: .dangerLight,
         .disabled: .disabledLight,
         .backgroundPrimary: .classicLight6,

--- a/SessionUIKit/Style Guide/Themes/Theme+Colors.swift
+++ b/SessionUIKit/Style Guide/Themes/Theme+Colors.swift
@@ -41,6 +41,7 @@ public extension Theme {
 // MARK: - Standard Theme Colors
 
 internal extension UIColor {
+    static let warning: UIColor = #colorLiteral(red: 0.9882352941, green: 0.6941176471, blue: 0.3490196078, alpha: 1)            // #FCB159
     static let dangerDark: UIColor = #colorLiteral(red: 1, green: 0.2274509804, blue: 0.2274509804, alpha: 1)         // #FF3A3A
     static let dangerLight: UIColor = #colorLiteral(red: 0.8823529412, green: 0.1764705882, blue: 0.09803921569, alpha: 1)        // #E12D19
     static let disabledDark: UIColor = #colorLiteral(red: 0.631372549, green: 0.6352941176, blue: 0.631372549, alpha: 1)       // #A1A2A1

--- a/SessionUIKit/Style Guide/Themes/Theme+OceanDark.swift
+++ b/SessionUIKit/Style Guide/Themes/Theme+OceanDark.swift
@@ -10,6 +10,7 @@ internal enum Theme_OceanDark: ThemeColors {
         .clear: .clear,
         .primary: .primary,
         .defaultPrimary: Theme.PrimaryColor.blue.color,
+        .warning: .warning,
         .danger: .dangerDark,
         .disabled: .disabledDark,
         .backgroundPrimary: .oceanDark2,

--- a/SessionUIKit/Style Guide/Themes/Theme+OceanLight.swift
+++ b/SessionUIKit/Style Guide/Themes/Theme+OceanLight.swift
@@ -10,6 +10,7 @@ internal enum Theme_OceanLight: ThemeColors {
         .clear: .clear,
         .primary: .primary,
         .defaultPrimary: Theme.PrimaryColor.blue.color,
+        .warning: .warning,
         .danger: .dangerLight,
         .disabled: .disabledLight,
         .backgroundPrimary: .oceanLight7,

--- a/SessionUIKit/Style Guide/Themes/Theme.swift
+++ b/SessionUIKit/Style Guide/Themes/Theme.swift
@@ -98,6 +98,7 @@ public indirect enum ThemeValue: Hashable {
     case clear
     case primary
     case defaultPrimary
+    case warning
     case danger
     case disabled
     case backgroundPrimary


### PR DESCRIPTION
- Updated the PathVC to indicate the network reachability
- Updated messages sent to 'Note to Self' to properly indicate whether they were sent to the swarm
- Simplified the behaviour of sending 'Note to Self' messages to the swarm (make them behave like other messages)
- Added logic to indicate when a sync message failed to send (and the ability to retry)
- Added the retry/resync button to the long press message menu
- Updated sync messages to run via the MessageSendJob (so they have a built-in retry mechanism)
- Updated the delivery status to always show on the last outgoing message
- Updated the logic to update the delivery status when retrying to send a failed message
- Started caching pending ReadReceipt messages to resolve an edge-case
- Fixed an issue where read receipts could be sent for already read messages
- Fixed an issue where the read state change might not update the UI

Fixes #717 
(Might) Fix #774