### PR TITLE
Fixed an issue where the voice recording could break the input view

### DIFF
--- a/Session/Conversations/Input View/InputView.swift
+++ b/Session/Conversations/Input View/InputView.swift
@@ -404,8 +404,11 @@ final class InputView: UIView, InputViewButtonDelegate, InputTextViewDelegate, M
     func handleInputViewButtonLongPressBegan(_ inputViewButton: InputViewButton?) {
         guard inputViewButton == voiceMessageButton else { return }
         
-        delegate?.startVoiceMessageRecording()
+        // Note: The 'showVoiceMessageUI' call MUST come before triggering 'startVoiceMessageRecording'
+        // because if something goes wrong it'll trigger `hideVoiceMessageUI` and we don't want it to
+        // end up in a state with the input content hidden
         showVoiceMessageUI()
+        delegate?.startVoiceMessageRecording()
     }
 
     func handleInputViewButtonLongPressMoved(_ inputViewButton: InputViewButton, with touch: UITouch?) {
@@ -466,9 +469,9 @@ final class InputView: UIView, InputViewButtonDelegate, InputTextViewDelegate, M
         UIView.animate(withDuration: 0.25, animations: {
             allOtherViews.forEach { $0.alpha = 1 }
             self.voiceMessageRecordingView?.alpha = 0
-        }, completion: { _ in
-            self.voiceMessageRecordingView?.removeFromSuperview()
-            self.voiceMessageRecordingView = nil
+        }, completion: { [weak self] _ in
+            self?.voiceMessageRecordingView?.removeFromSuperview()
+            self?.voiceMessageRecordingView = nil
         })
     }
 


### PR DESCRIPTION
Looks like there was an issue where if the voice recording failed to start the UI would end up in a state where the input elements remain hidden