### PR TITLE
Removed the iCloud entitlements

### DIFF
--- a/Session/Meta/Signal.entitlements
+++ b/Session/Meta/Signal.entitlements
@@ -4,19 +4,6 @@
 <dict>
 	<key>aps-environment</key>
 	<string>production</string>
-	<key>com.apple.developer.icloud-container-identifiers</key>
-	<array>
-		<string>iCloud.$(CFBundleIdentifier)</string>
-	</array>
-	<key>com.apple.developer.icloud-services</key>
-	<array>
-		<string>CloudDocuments</string>
-		<string>CloudKit</string>
-	</array>
-	<key>com.apple.developer.ubiquity-container-identifiers</key>
-	<array>
-		<string>iCloud.$(CFBundleIdentifier)</string>
-	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.loki-project.loki-messenger</string>


### PR DESCRIPTION
We currently include the entitlements needed for iCloud and iCloud Documents, these are unused (seem to be left over from Signal) and aren't supported by BrowserStack (see https://github.com/oxen-io/session-ios/issues/827 for more info)