### PR TITLE
Fix global search hanging issue

### DIFF
--- a/Session/Shared/FullConversationCell.swift
+++ b/Session/Shared/FullConversationCell.swift
@@ -8,6 +8,11 @@ import SessionMessagingKit
 public final class FullConversationCell: UITableViewCell {
     public static let unreadCountViewSize: CGFloat = 20
     private static let statusIndicatorSize: CGFloat = 14
+    // If a message is much too long, it will take forever to calculate its width and
+    // cause the app to be frozen. So if a search result string is longer than 100
+    // characters, we assume it cannot be shown within one line and need to be truncated
+    // to avoid the calculation.
+    private static let maxApproxCharactersCanBeShownInOneLine: Int = 100
     
     // MARK: - UI
     
@@ -657,14 +662,25 @@ public final class FullConversationCell: UITableViewCell {
                 return authorPrefix
                     .appending(
                         truncatingIfNeeded(
-                            approxWidth: (authorPrefix.size().width + result.size().width),
+                            approxWidth: (
+                                authorPrefix.size().width +
+                                (
+                                    result.length > Self.maxApproxCharactersCanBeShownInOneLine ?
+                                    bounds.width :
+                                    result.size().width
+                                )
+                            ),
                             content: result
                         )
                     )
             }
             .defaulting(
                 to: truncatingIfNeeded(
-                    approxWidth: result.size().width,
+                    approxWidth: (
+                        result.length > Self.maxApproxCharactersCanBeShownInOneLine ?
+                        bounds.width :
+                        result.size().width
+                    ),
                     content: result
                 )
             )


### PR DESCRIPTION
When using global search and there is a extremely long message search result, the app will hang forever to calculate the width of the message to decide whether it needs to be truncated.