### PR TITLE
feat: Enable upside down orientation for iPad

### DIFF
--- a/Session/Media Viewing & Editing/DocumentTitleViewController.swift
+++ b/Session/Media Viewing & Editing/DocumentTitleViewController.swift
@@ -45,6 +45,10 @@ public class DocumentTileViewController: UIViewController, UITableViewDelegate, 
     // MARK: - UI
     
     override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        if UIDevice.current.isIPad {
+            return .all
+        }
+
         return .allButUpsideDown
     }
     

--- a/Session/Media Viewing & Editing/MediaGalleryNavigationController.swift
+++ b/Session/Media Viewing & Editing/MediaGalleryNavigationController.swift
@@ -44,6 +44,10 @@ class MediaGalleryNavigationController: UINavigationController {
     // MARK: - Orientation
 
     public override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        if UIDevice.current.isIPad {
+            return .all
+        }
+
         return .allButUpsideDown
     }
     

--- a/Session/Media Viewing & Editing/MediaTileViewController.swift
+++ b/Session/Media Viewing & Editing/MediaTileViewController.swift
@@ -53,6 +53,10 @@ public class MediaTileViewController: UIViewController, UICollectionViewDataSour
     // MARK: - UI
     
     override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        if UIDevice.current.isIPad {
+            return .all
+        }
+
         return .allButUpsideDown
     }
     

--- a/Session/Meta/AppDelegate.swift
+++ b/Session/Meta/AppDelegate.swift
@@ -192,7 +192,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
         if UIDevice.current.isIPad {
-            return .allButUpsideDown
+            return .all
         }
         
         return .portrait

--- a/Session/Meta/Session-Info.plist
+++ b/Session/Meta/Session-Info.plist
@@ -147,6 +147,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>

--- a/SignalUtilitiesKit/Shared View Controllers/OWSViewController.m
+++ b/SignalUtilitiesKit/Shared View Controllers/OWSViewController.m
@@ -11,12 +11,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 BOOL IsLandscapeOrientationEnabled(void)
 {
-    return NO;
+    return UIDevice.currentDevice.isIPad;
 }
 
 UIInterfaceOrientationMask DefaultUIInterfaceOrientationMask(void)
 {
-    return (IsLandscapeOrientationEnabled() ? UIInterfaceOrientationMaskAllButUpsideDown
+    return (IsLandscapeOrientationEnabled() ? UIInterfaceOrientationMaskAll
                                             : UIInterfaceOrientationMaskPortrait);
 }
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPad Air (5th generation) on Simulator; iOS 16.4

- - - - - - - - - -

### Description
The "upside down" orientation for iPad devices was disabled in 05814add86d765b83c91baa3120ba65569803906b55b159fbd091a95876e40a70d. However, as an iPad user, not having all orientations is quite uncomfortable and sometimes annoying. Most apps support all orientations on iPad nowadays. This commit brings back the upside-down orientation in all places where it was disabled.

Upside-down screenshots:

<table>
<tr>

 <td>
<img src="https://github.com/oxen-io/session-ios/assets/31893391/bec259dc-068d-46a0-8018-caec317da836"/>

 <td>
<img src="https://github.com/oxen-io/session-ios/assets/31893391/66b88544-ffb2-41d9-acf8-35a2a7897305"/>

</table>



~~The weird glitch I noticed occurs when picking a single picture from the gallery:~~ 

https://github.com/oxen-io/session-ios/assets/31893391/7671c678-9a72-4d8e-8055-65a47b8525b7

~~But I still believe this provides a better experience for iPad users than no upside down at all :)~~
(the glitch is fixed in 57dbad7e2e235ccc9757f43c8049e6948ee47b88)