### PR TITLE
feat: Implement "scroll-back" to latest message when navigating replies

### DIFF
--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -972,6 +972,8 @@ extension ConversationVC:
                     }
                     
                     self.scrollToInteractionIfNeeded(with: interactionInfo, focusBehaviour: .highlight)
+                    let originalMessageTimestamp = Interaction.TimestampInfo(id: cellViewModel.id, timestampMs: cellViewModel.timestampMs)
+                    self.replyNavigationStack.add(originalMessageTimestamp)
                 }
                 else if let linkPreview: LinkPreview = cellViewModel.linkPreview {
                     switch linkPreview.variant {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
* iPad Air (5th generation) on Simulator; iOS 16.4

- - - - - - - - - -

### Description
This commit adds a navigation history for quoted messages, such as if
Alice navigated to message A by pressing the "quoted message" inside the
reply message B and pressed the "scroll down button", the chat will be
scrolled back to message B instead of the very bottom. This is true for
as many replies as the user navigates through.
All the messages higher than the lowest fully visible message
are automatically cleared from the stack as the user scrolls.

This feature makes it easier to read threaded conversations,
especially in scenarios with much to catch up on. This is most useful in
group chats and communities.

Demo screen recording:


https://github.com/oxen-io/session-ios/assets/31893391/02b25be6-619f-4594-887a-c6de8572149e

