### PR TITLE
Fixed a bug where the quote preview width could be too small

### DIFF
--- a/Session/Conversations/Message Cells/Content Views/QuoteView.swift
+++ b/Session/Conversations/Message Cells/Content Views/QuoteView.swift
@@ -119,8 +119,7 @@ final class QuoteView: UIView {
         // Content view
         let contentView = UIView()
         addSubview(contentView)
-        contentView.pin([ UIView.HorizontalEdge.left, UIView.VerticalEdge.top, UIView.VerticalEdge.bottom ], to: self)
-        contentView.rightAnchor.constraint(lessThanOrEqualTo: self.rightAnchor).isActive = true
+        contentView.pin(to: self)
         
         if let attachment: Attachment = attachment {
             let isAudio: Bool = MIMETypeUtil.isAudio(attachment.contentType)


### PR DESCRIPTION
**Before:**
<img width="250" alt="Screenshot 2023-09-07 at 5 26 16 pm" src="https://github.com/oxen-io/session-ios/assets/15862619/96c7ed42-5b04-4cc1-b43c-5d4e2b26bd96">


**After:**
<img width="250" alt="Screenshot 2023-09-07 at 5 38 56 pm" src="https://github.com/oxen-io/session-ios/assets/15862619/fcea1d39-c442-42e1-b2f4-fdbf6839c580">
