### PR TITLE
Added new PrivacyInfo plist required by Apple

### DIFF
--- a/Scripts/build_libSession_util.sh
+++ b/Scripts/build_libSession_util.sh
@@ -26,41 +26,26 @@
 # request ever gets implemented: https://github.com/CocoaPods/CocoaPods/issues/8464
 
 # Need to set the path or we won't find cmake
-PATH=${PATH}:/usr/local/bin:/opt/homebrew/bin:/sbin/md5
+PATH=${PATH}:/usr/local/bin:/opt/local/bin:/opt/homebrew/bin:/sbin/md5
 
 exec 3>&1 # Save original stdout
 
 # Ensure the build directory exists (in case we need it before XCode creates it)
 mkdir -p "${TARGET_BUILD_DIR}/libSessionUtil"
 
-# Remove any old build errors
-rm -rf "${TARGET_BUILD_DIR}/libSessionUtil/libsession_util_output.log"
-
-# Restore stdout and stderr and redirect it to the 'libsession_util_output.log' file
-exec &> "${TARGET_BUILD_DIR}/libSessionUtil/libsession_util_output.log"
-
-# Define a function to echo a message.
-function echo_message() {
-  exec 1>&3 # Restore stdout
-  echo "$1"
-  exec >> "${TARGET_BUILD_DIR}/libSessionUtil/libsession_util_output.log" # Redirect all output to the log file
-}
-
-echo_message "info: Validating build requirements"
-
-set -x
+echo "Validating build requirements"
 
 # Ensure the build directory exists (in case we need it before XCode creates it)
 mkdir -p "${TARGET_BUILD_DIR}"
 
 if ! which cmake > /dev/null; then
-  echo_message "error: cmake is required to build, please install (can install via homebrew with 'brew install cmake')."
+  echo "error: cmake is required to build, please install (can install via homebrew with 'brew install cmake')."
   exit 0
 fi
 
 # Check if we have the `LibSession-Util` submodule checked out and if not (depending on the 'SHOULD_AUTO_INIT_SUBMODULES' argument) perform the checkout
 if [ ! -d "${SRCROOT}/LibSession-Util" ] || [ ! -d "${SRCROOT}/LibSession-Util/src" ] || [ ! "$(ls -A "${SRCROOT}/LibSession-Util")" ]; then
-  echo_message "error: Need to fetch LibSession-Util submodule (git submodule update --init --recursive)."
+  echo "error: Need to fetch LibSession-Util submodule (git submodule update --init --recursive)."
   exit 0
 else
   are_submodules_valid() {
@@ -86,7 +71,7 @@ else
       
       # If the child path doesn't exist then it's invalid
       if [ ! -d "${PARENT_PATH}/${CHILD_PATH}" ]; then
-        echo_message "info: Submodule '${RELATIVE_PATH}/${CHILD_PATH}' doesn't exist."
+        echo "Submodule '${RELATIVE_PATH}/${CHILD_PATH}' doesn't exist."
         return 1
       fi
 
@@ -94,7 +79,7 @@ else
       local RESULT=$?
 
       if [ "${RESULT}" -eq 1 ]; then
-        echo_message "info: Submodule '${RELATIVE_PATH}/${CHILD_PATH}' is in an invalid state."
+        echo "Submodule '${RELATIVE_PATH}/${CHILD_PATH}' is in an invalid state."
         return 1
       fi
     done
@@ -108,13 +93,13 @@ else
   HAS_INVALID_SUBMODULE=$?
 
   if [ "${HAS_INVALID_SUBMODULE}" -eq 1 ]; then
-    echo_message "error: Submodules are in an invalid state, please delete 'LibSession-Util' and run 'git submodule update --init --recursive'."
+    echo "error: Submodules are in an invalid state, please delete 'LibSession-Util' and run 'git submodule update --init --recursive'."
     exit 0
   fi
 fi
 
 # Generate a hash of the libSession-util source files and check if they differ from the last hash
-echo "info: Checking for changes to source"
+echo "Checking for changes to source"
 
 NEW_SOURCE_HASH=$(find "${SRCROOT}/LibSession-Util/src" -type f -exec md5 {} + | awk '{print $NF}' | sort | md5 | awk '{print $NF}')
 NEW_HEADER_HASH=$(find "${SRCROOT}/LibSession-Util/include" -type f -exec md5 {} + | awk '{print $NF}' | sort | md5 | awk '{print $NF}')
@@ -133,12 +118,12 @@ fi
 
 # If all of the hashes match, the archs match and there is a library file then we can just stop here
 if [ "${NEW_SOURCE_HASH}" == "${OLD_SOURCE_HASH}" ] && [ "${NEW_HEADER_HASH}" == "${OLD_HEADER_HASH}" ] && [ "${ARCHS[*]}" == "${OLD_ARCHS}" ] && [ -f "${TARGET_BUILD_DIR}/libSessionUtil/libSessionUtil.a" ]; then
-  echo_message "info: Build is up-to-date"
+  echo "Build is up-to-date"
   exit 0
 fi
 
 # If any of the above differ then we need to rebuild
-echo_message "info: Build is not up-to-date - creating new build"
+echo "Build is not up-to-date - creating new build"
 
 # Import settings from XCode (defaulting values if not present)
 VALID_SIM_ARCHS=(arm64 x86_64)
@@ -182,22 +167,54 @@ if [ -z $PLATFORM_NAME ] || [ $PLATFORM_NAME = "iphoneos" ]; then
     done
 fi
 
+# Remove any old build logs (since we are doing a new build)
+rm -rf "${TARGET_BUILD_DIR}/libSessionUtil/libsession_util_output.log"
+
 # Build the individual architectures
 for i in "${!TARGET_ARCHS[@]}"; do
     build="${TARGET_BUILD_DIR}/libSessionUtil/${TARGET_ARCHS[$i]}"
     platform="${TARGET_PLATFORMS[$i]}"
-    echo_message "Building ${TARGET_ARCHS[$i]} for $platform in $build"
+    echo "Building ${TARGET_ARCHS[$i]} for $platform in $build"
+    
+    # Redirect the build output to a log file and only include the progress lines in the XCode output
+    exec > >(tee "${TARGET_BUILD_DIR}/libSessionUtil/libsession_util_output.log" | grep --line-buffered '^\[.*%\]') 2>&1
 
     cd "${SRCROOT}/LibSession-Util"
-    ./utils/static-bundle.sh "$build" "" \
+    env -i PATH="$PATH" SDKROOT="$(xcrun --sdk macosx --show-sdk-path)" \
+        ./utils/static-bundle.sh "$build" "" \
         -DCMAKE_TOOLCHAIN_FILE="${SRCROOT}/LibSession-Util/external/ios-cmake/ios.toolchain.cmake" \
         -DPLATFORM=$platform \
         -DDEPLOYMENT_TARGET=$IPHONEOS_DEPLOYMENT_TARGET \
-        -DENABLE_BITCODE=$ENABLE_BITCODE
-    
-    if [ $? -ne 0 ]; then
-      LAST_OUTPUT=$(tail -n 4 "${TARGET_BUILD_DIR}/libSessionUtil/libsession_util_output.log" | head -n 1)
-      echo_message "error: $LAST_OUTPUT"
+        -DENABLE_BITCODE=$ENABLE_BITCODE \
+        -DBUILD_TESTS=OFF \
+        -DBUILD_STATIC_DEPS=ON
+        
+    # Capture the exit status of the ./utils/static-bundle.sh command
+    EXIT_STATUS=$?
+        
+    # Flush the tee buffer (ensure any errors have been properly written to the log before continuing) and
+    # restore stdout
+    echo ""
+    exec 1>&3
+
+    if [ $EXIT_STATUS -ne 0 ]; then
+      ALL_ERROR_LINES=($(grep -n "error:" "${TARGET_BUILD_DIR}/libSessionUtil/libsession_util_output.log" | cut -d ":" -f 1))
+
+      for e in "${!ALL_ERROR_LINES[@]}"; do
+        error_line="${ALL_ERROR_LINES[$e]}"
+        error=$(sed "${error_line}q;d" "${TARGET_BUILD_DIR}/libSessionUtil/libsession_util_output.log")
+
+        # If it was a CMake Error then the actual error will be on the next line so we want to append that info
+        if [[ $error == *'CMake Error'* ]]; then
+            actual_error_line=$((error_line + 1))
+            error="${error}$(sed "${actual_error_line}q;d" "${TARGET_BUILD_DIR}/libSessionUtil/libsession_util_output.log")"
+        fi
+
+        # Exclude the 'ALL_ERROR_LINES' line and the 'grep' line
+        if [[ ! $error == *'grep -n "error'* ]] && [[ ! $error == *'grep -n error'* ]]; then
+            echo "error: $error"
+        fi
+      done
       exit 1
     fi
 done
@@ -212,7 +229,7 @@ if [ "${#TARGET_SIM_ARCHS[@]}" -eq "1" ]; then
     cp "${TARGET_BUILD_DIR}/libSessionUtil/${TARGET_SIM_ARCHS[0]}/libsession-util.a" "${TARGET_BUILD_DIR}/libSessionUtil/libSessionUtil.a"
 elif [ "${#TARGET_SIM_ARCHS[@]}" -gt "1" ]; then
     # Combine multiple device builds into a multi-arch lib
-    echo_message "info: Built multiple architectures, merging into single static library"
+    echo "Built multiple architectures, merging into single static library"
     lipo -create "${TARGET_BUILD_DIR}/libSessionUtil"/sim-*/libsession-util.a -output "${TARGET_BUILD_DIR}/libSessionUtil/libSessionUtil.a"
 fi
 
@@ -221,7 +238,7 @@ if [ "${#TARGET_DEVICE_ARCHS[@]}" -eq "1" ]; then
     cp "${TARGET_BUILD_DIR}/libSessionUtil/${TARGET_DEVICE_ARCHS[0]}/libsession-util.a" "${TARGET_BUILD_DIR}/libSessionUtil/libSessionUtil.a"
 elif [ "${#TARGET_DEVICE_ARCHS[@]}" -gt "1" ]; then
     # Combine multiple device builds into a multi-arch lib
-    echo_message "info: Built multiple architectures, merging into single static library"
+    echo "Built multiple architectures, merging into single static library"
     lipo -create "${TARGET_BUILD_DIR}/libSessionUtil"/ios-*/libsession-util.a -output "${TARGET_BUILD_DIR}/libSessionUtil/libSessionUtil.a"
 fi
 
@@ -229,10 +246,10 @@ fi
 echo "${NEW_SOURCE_HASH}" > "${TARGET_BUILD_DIR}/libSessionUtil/libsession_util_source_hash.log"
 echo "${NEW_HEADER_HASH}" > "${TARGET_BUILD_DIR}/libSessionUtil/libsession_util_header_hash.log"
 echo "${ARCHS[*]}" > "${TARGET_BUILD_DIR}/libSessionUtil/libsession_util_archs.log"
-echo_message "info: Build complete"
+echo "Build complete"
 
 # Copy the headers across
-echo_message "info: Copy headers and prepare modulemap"
+echo "Copy headers and prepare modulemap"
 mkdir -p "${TARGET_BUILD_DIR}/libSessionUtil/Headers"
 cp -r "${SRCROOT}/LibSession-Util/include/session" "${TARGET_BUILD_DIR}/libSessionUtil/Headers"
 
@@ -240,22 +257,11 @@ cp -r "${SRCROOT}/LibSession-Util/include/session" "${TARGET_BUILD_DIR}/libSessi
 modmap="${TARGET_BUILD_DIR}/libSessionUtil/Headers/module.modulemap"
 echo "module SessionUtil {" >"$modmap"
 echo "  module capi {" >>"$modmap"
-for x in $(cd include && find session -name '*.h'); do
+for x in $(cd "${TARGET_BUILD_DIR}/libSessionUtil/Headers" && find session -name '*.h'); do
     echo "    header \"$x\"" >>"$modmap"
 done
 echo -e "    export *\n  }" >>"$modmap"
-if false; then
-    # If we include the cpp headers like this then Xcode will try to load them as C headers (which
-    # of course breaks) and doesn't provide any way to only load the ones you need (because this is
-    # Apple land, why would anything useful be available?).  So we include the headers in the
-    # archive but can't let xcode discover them because it will do it wrong.
-    echo -e "\n  module cppapi {" >>"$modmap"
-    for x in $(cd include && find session -name '*.hpp'); do
-        echo "    header \"$x\"" >>"$modmap"
-    done
-    echo -e "    export *\n  }" >>"$modmap"
-fi
 echo "}" >>"$modmap"
 
 # Output to XCode just so the output is good
-echo_message "info: libSessionUtil Ready"
+echo "libSession is Ready"

--- a/Session.xcodeproj/project.pbxproj
+++ b/Session.xcodeproj/project.pbxproj
@@ -738,6 +738,9 @@
 		FD848B9828422F1A000E298B /* Date+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD848B9728422F1A000E298B /* Date+Utilities.swift */; };
 		FD848B9A28442CE6000E298B /* StorageError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD848B9928442CE6000E298B /* StorageError.swift */; };
 		FD848B9C284435D7000E298B /* AppSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD848B9B284435D7000E298B /* AppSetup.swift */; };
+		FD86FDA32BC5020600EC251B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = FD86FDA22BC5020600EC251B /* PrivacyInfo.xcprivacy */; };
+		FD86FDA42BC51C5400EC251B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = FD86FDA22BC5020600EC251B /* PrivacyInfo.xcprivacy */; };
+		FD86FDA52BC51C5500EC251B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = FD86FDA22BC5020600EC251B /* PrivacyInfo.xcprivacy */; };
 		FD87DCFA28B74DB300AF0F98 /* ConversationSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD87DCF928B74DB300AF0F98 /* ConversationSettingsViewModel.swift */; };
 		FD87DCFE28B7582C00AF0F98 /* BlockedContactsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD87DCFD28B7582C00AF0F98 /* BlockedContactsViewModel.swift */; };
 		FD87DD0428B8727D00AF0F98 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD87DD0328B8727D00AF0F98 /* Configuration.swift */; };
@@ -1870,6 +1873,7 @@
 		FD859EEF27BF207700510D0C /* SessionProtos.proto */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.protobuf; path = SessionProtos.proto; sourceTree = "<group>"; };
 		FD859EF027BF207C00510D0C /* WebSocketResources.proto */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.protobuf; path = WebSocketResources.proto; sourceTree = "<group>"; };
 		FD859EF127BF6BA200510D0C /* Data+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Utilities.swift"; sourceTree = "<group>"; };
+		FD86FDA22BC5020600EC251B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		FD87DCF928B74DB300AF0F98 /* ConversationSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationSettingsViewModel.swift; sourceTree = "<group>"; };
 		FD87DCFD28B7582C00AF0F98 /* BlockedContactsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedContactsViewModel.swift; sourceTree = "<group>"; };
 		FD87DD0328B8727D00AF0F98 /* Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
@@ -3517,6 +3521,7 @@
 				45CB2FA71CB7146C00E1B343 /* Launch Screen.storyboard */,
 				FDE125222A837E4E002DA685 /* MainAppContext.swift */,
 				C3CA3AA0255CDA7000F4C6D4 /* Mnemonic */,
+				FD86FDA22BC5020600EC251B /* PrivacyInfo.xcprivacy */,
 				B67EBF5C19194AC60084CCFD /* Settings.bundle */,
 				B657DDC91911A40500F45B0C /* Signal.entitlements */,
 				FDF2220A2818F38D000A4995 /* SessionApp.swift */,
@@ -5068,6 +5073,7 @@
 				4535186E1FC635DD00210559 /* MainInterface.storyboard in Resources */,
 				FDC498C22AC17BFC00EDD897 /* Localizable.strings in Resources */,
 				B8D07406265C683A00F77E07 /* ElegantIcons.ttf in Resources */,
+				FD86FDA42BC51C5400EC251B /* PrivacyInfo.xcprivacy in Resources */,
 				3478504C1FD7496D007B8332 /* Images.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -5076,6 +5082,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FD86FDA52BC51C5500EC251B /* PrivacyInfo.xcprivacy in Resources */,
 				FDC498BE2AC1732E00EDD897 /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -5121,6 +5128,7 @@
 			files = (
 				4C63CC00210A620B003AE45C /* SignalTSan.supp in Resources */,
 				4C6F527C20FFE8400097DEEE /* SignalUBSan.supp in Resources */,
+				FD86FDA32BC5020600EC251B /* PrivacyInfo.xcprivacy in Resources */,
 				34CF078A203E6B78005C4D61 /* end_call_tone_cept.caf in Resources */,
 				C3CA3AA2255CDADA00F4C6D4 /* english.txt in Resources */,
 				B66DBF4A19D5BBC8006EA940 /* Images.xcassets in Resources */,

--- a/Session/Meta/PrivacyInfo.xcprivacy
+++ b/Session/Meta/PrivacyInfo.xcprivacy
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>1C8F.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Session/Meta/PrivacyInfo.xcprivacy
+++ b/Session/Meta/PrivacyInfo.xcprivacy
@@ -2,6 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>

--- a/Session/Meta/PrivacyInfo.xcprivacy
+++ b/Session/Meta/PrivacyInfo.xcprivacy
@@ -12,6 +12,14 @@
 				<string>1C8F.1</string>
 			</array>
 		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Apple seem to have added a new required plist as part of iOS 17.0 (https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api) - this PR adds the required plist to the project as we are using:
- `UserDefaults`
- `FileTimestamp` (access the `modificationDate` for files in `MainAppContext.clearOldTemporaryDirectories` - might be able to rework this one?)