### PR TITLE
Number of fixes and tweaks related to the deadlock issue

### DIFF
--- a/Session/Closed Groups/EditClosedGroupVC.swift
+++ b/Session/Closed Groups/EditClosedGroupVC.swift
@@ -496,7 +496,7 @@ final class EditClosedGroupVC: BaseVC, UITableViewDataSource, UITableViewDelegat
                             case .failure(let error):
                                 self?.showError(
                                     title: "GROUP_UPDATE_ERROR_TITLE".localized(),
-                                    message: error.localizedDescription
+                                    message: "\(error)"
                                 )
                         }
                     }

--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -1812,7 +1812,7 @@ extension ConversationVC:
                                         let errorModal: ConfirmationModal = ConfirmationModal(
                                             info: ConfirmationModal.Info(
                                                 title: "COMMUNITY_ERROR_GENERIC".localized(),
-                                                body: .text(error.localizedDescription),
+                                                body: .text("\(error)"),
                                                 cancelTitle: "BUTTON_OK".localized(),
                                                 cancelStyle: .alert_text
                                             )

--- a/Session/Media Viewing & Editing/GIFs/GifPickerViewController.swift
+++ b/Session/Media Viewing & Editing/GIFs/GifPickerViewController.swift
@@ -365,7 +365,7 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
                                 targetView: self?.view,
                                 info: ConfirmationModal.Info(
                                     title: "GIF_PICKER_FAILURE_ALERT_TITLE".localized(),
-                                    body: .text(error.localizedDescription),
+                                    body: .text("\(error)"),
                                     confirmTitle: CommonStrings.retryButton,
                                     cancelTitle: CommonStrings.dismissButton,
                                     cancelStyle: .alert_text,

--- a/Session/Media Viewing & Editing/PhotoCaptureViewController.swift
+++ b/Session/Media Viewing & Editing/PhotoCaptureViewController.swift
@@ -334,7 +334,7 @@ class PhotoCaptureViewController: OWSViewController {
         let modal: ConfirmationModal = ConfirmationModal(
             info: ConfirmationModal.Info(
                 title: CommonStrings.errorAlertTitle,
-                body: .text(error.localizedDescription),
+                body: .text("\(error)"),
                 cancelTitle: CommonStrings.dismissButton,
                 cancelStyle: .alert_text,
                 afterClosed: { [weak self] in self?.dismiss(animated: true) }

--- a/Session/Onboarding/Onboarding.swift
+++ b/Session/Onboarding/Onboarding.swift
@@ -36,11 +36,8 @@ enum Onboarding {
             .poll(
                 namespaces: [.configUserProfile],
                 for: userPublicKey,
-                // Note: These values mean the received messages will be
-                // processed immediately rather than async as part of a Job
-                calledFromBackgroundPoller: true,
-                isBackgroundPollValid: { true },
                 drainBehaviour: .alwaysRandom,
+                forceSynchronousProcessing: true,
                 using: dependencies
             )
             .map { _ -> String? in

--- a/Session/Open Groups/JoinOpenGroupVC.swift
+++ b/Session/Open Groups/JoinOpenGroupVC.swift
@@ -210,7 +210,7 @@ final class JoinOpenGroupVC: BaseVC, UIPageViewControllerDataSource, UIPageViewC
                                 self?.dismiss(animated: true) { // Dismiss the loader
                                     self?.showError(
                                         title: "COMMUNITY_ERROR_GENERIC".localized(),
-                                        message: error.localizedDescription,
+                                        message: "\(error)",
                                         onError: onError
                                     )
                                 }

--- a/Session/Settings/NukeDataModal.swift
+++ b/Session/Settings/NukeDataModal.swift
@@ -209,7 +209,7 @@ final class NukeDataModal: Modal {
                                         targetView: self?.view,
                                         info: ConfirmationModal.Info(
                                             title: "ALERT_ERROR_TITLE".localized(),
-                                            body: .text(error.localizedDescription),
+                                            body: .text("\(error)"),
                                             cancelTitle: "BUTTON_OK".localized(),
                                             cancelStyle: .alert_text
                                         )

--- a/Session/Shared/ScreenLockUI.swift
+++ b/Session/Shared/ScreenLockUI.swift
@@ -242,7 +242,7 @@ class ScreenLockUI {
                 Log.info("unlock screen lock failed.")
                 self?.clearAuthUIWhenActive()
                 self?.didLastUnlockAttemptFail = true
-                self?.showScreenLockFailureAlert(message: error.localizedDescription)
+                self?.showScreenLockFailureAlert(message: "\(error)")
             },
             unexpectedFailure: { [weak self] error in
                 Log.info("unlock screen lock unexpectedly failed.")

--- a/Session/Utilities/BackgroundPoller.swift
+++ b/Session/Utilities/BackgroundPoller.swift
@@ -8,14 +8,15 @@ import SessionMessagingKit
 import SessionUtilitiesKit
 
 public final class BackgroundPoller {
-    private static var publishers: [AnyPublisher<Void, Error>] = []
-    public static var isValid: Bool = false
-
-    public static func poll(
-        completionHandler: @escaping (UIBackgroundFetchResult) -> Void,
-        using dependencies: Dependencies = Dependencies()
-    ) {
-        let (groupIds, servers): (Set<String>, Set<String>) = Storage.shared.read { db in
+    let currentUserPoller: CurrentUserPoller = CurrentUserPoller()
+    var groupPollers: [Poller] = []
+    var communityPollers: [OpenGroupAPI.Poller] = []
+    
+    public func poll(using dependencies: Dependencies) -> AnyPublisher<Void, Never> {
+        let pollStart: TimeInterval = dependencies.dateNow.timeIntervalSince1970
+        
+        return dependencies.storage
+            .readPublisher(using: dependencies) { db -> (Set<String>, Set<String>) in
                 (
                     try ClosedGroup
                         .select(.threadId)
@@ -42,19 +43,29 @@ public final class BackgroundPoller {
                         .fetchSet(db)
                 )
             }
-            .defaulting(to: ([], []))
-        
-        let pollStart: TimeInterval = dependencies.dateNow.timeIntervalSince1970
-        Log.info("[BackgroundPoller] Fetching Users: 1, Groups: \(groupIds.count), Communities: \(servers.count).")
-        Publishers
-            .MergeMany(
-                [pollForMessages(using: dependencies)]
-                    .appending(contentsOf: pollForClosedGroupMessages(groupIds: groupIds, using: dependencies))
-                    .appending(contentsOf: pollForCommunityMessages(servers: servers, using: dependencies))
+            .catch { _ in Just(([], [])).eraseToAnyPublisher() }
+            .handleEvents(
+                receiveOutput: { groupIds, servers in
+                    Log.info("[BackgroundPoller] Fetching Users: 1, Groups: \(groupIds.count), Communities: \(servers.count).")
+                }
             )
-            .subscribe(on: DispatchQueue.global(qos: .background), using: dependencies)
-            .receive(on: DispatchQueue.main, using: dependencies)
+            .map { [weak self] groupIds, servers -> ([(Poller, String)], [(OpenGroupAPI.Poller, String)]) in
+                let groupPollerInfo: [(Poller, String)] = groupIds.map { (ClosedGroupPoller(), $0) }
+                let communityPollerInfo: [(OpenGroupAPI.Poller, String)] = servers.map { (OpenGroupAPI.Poller(for: $0), $0) }
+                self?.groupPollers = groupPollerInfo.map { poller, _ in poller }
+                self?.communityPollers = communityPollerInfo.map { poller, _ in poller }
+                
+                return (groupPollerInfo, communityPollerInfo)
+            }
+            .flatMap { groupPollerInfo, communityPollerInfo in
+                Publishers.MergeMany(
+                    [BackgroundPoller.pollUserMessages(using: dependencies)]
+                        .appending(contentsOf: BackgroundPoller.poll(pollerInfo: groupPollerInfo, using: dependencies))
+                        .appending(contentsOf: BackgroundPoller.poll(pollerInfo: communityPollerInfo, using: dependencies))
+                )
+            }
             .collect()
+            .map { _ in () }
             .handleEvents(
                 receiveOutput: { _ in
                     let endTime: TimeInterval = dependencies.dateNow.timeIntervalSince1970
@@ -62,24 +73,10 @@ public final class BackgroundPoller {
                     Log.info("[BackgroundPoller] Finished polling after \(duration, unit: .s).")
                 }
             )
-            .sinkUntilComplete(
-                receiveCompletion: { result in
-                    // If we have already invalidated the timer then do nothing (we essentially timed out)
-                    guard BackgroundPoller.isValid else { return }
-                    
-                    switch result {
-                        case .finished: completionHandler(.newData)
-                        case .failure(let error):
-                            let endTime: TimeInterval = dependencies.dateNow.timeIntervalSince1970
-                            let duration: TimeUnit = .seconds(endTime - pollStart)
-                            Log.error("[BackgroundPoller] Failed due to error: \(error) after \(duration, unit: .s).")
-                            completionHandler(.failed)
-                    }
-                }
-            )
+            .eraseToAnyPublisher()
     }
     
-    private static func pollForMessages(
+    private static func pollUserMessages(
         using dependencies: Dependencies
     ) -> AnyPublisher<Void, Never> {
         let userPublicKey: String = getUserHexEncodedPublicKey(using: dependencies)
@@ -88,11 +85,9 @@ public final class BackgroundPoller {
         let pollerName: String = poller.pollerName(for: userPublicKey)
         let pollStart: TimeInterval = dependencies.dateNow.timeIntervalSince1970
         
-        return poller.poll(
+        return poller.pollFromBackground(
             namespaces: CurrentUserPoller.namespaces,
             for: userPublicKey,
-            calledFromBackgroundPoller: true,
-            isBackgroundPollValid: { BackgroundPoller.isValid },
             drainBehaviour: .alwaysRandom,
             using: dependencies
         )
@@ -117,69 +112,27 @@ public final class BackgroundPoller {
         .eraseToAnyPublisher()
     }
     
-    private static func pollForClosedGroupMessages(
-        groupIds: Set<String>,
+    private static func poll(
+        pollerInfo: [(poller: Poller, groupPublicKey: String)],
         using dependencies: Dependencies
     ) -> [AnyPublisher<Void, Never>] {
         // Fetch all closed groups (excluding any don't contain the current user as a
         // GroupMemeber as the user is no longer a member of those)
-        return groupIds.map { groupPublicKey in
-            let poller: Poller = ClosedGroupPoller()
+        return pollerInfo.map { poller, groupPublicKey in
             let pollerName: String = poller.pollerName(for: groupPublicKey)
             let pollStart: TimeInterval = dependencies.dateNow.timeIntervalSince1970
             
-            return poller
-                .poll(
-                    namespaces: ClosedGroupPoller.namespaces,
-                    for: groupPublicKey,
-                    calledFromBackgroundPoller: true,
-                    isBackgroundPollValid: { BackgroundPoller.isValid },
-                    drainBehaviour: .alwaysRandom,
-                    using: dependencies
-                )
-                .handleEvents(
-                    receiveOutput: { _, _, validMessageCount, _ in
-                        let endTime: TimeInterval = dependencies.dateNow.timeIntervalSince1970
-                        let duration: TimeUnit = .seconds(endTime - pollStart)
-                        Log.info("[BackgroundPoller] \(pollerName) received \(validMessageCount) valid message(s) after \(duration, unit: .s).")
-                    },
-                    receiveCompletion: { result in
-                        switch result {
-                            case .finished: break
-                            case .failure(let error):
-                                let endTime: TimeInterval = dependencies.dateNow.timeIntervalSince1970
-                                let duration: TimeUnit = .seconds(endTime - pollStart)
-                                Log.error("[BackgroundPoller] \(pollerName) failed after \(duration, unit: .s) due to error: \(error).")
-                        }
-                    }
-                )
-                .map { _ in () }
-                .catch { _ in Just(()).eraseToAnyPublisher() }
-                .eraseToAnyPublisher()
-        }
-    }
-    
-    private static func pollForCommunityMessages(
-        servers: Set<String>,
-        using dependencies: Dependencies
-    ) -> [AnyPublisher<Void, Never>] {
-        return servers.map { server -> AnyPublisher<Void, Never> in
-            let poller: OpenGroupAPI.Poller = OpenGroupAPI.Poller(for: server)
-            let pollerName: String = "Community poller for server: \(server)"
-            let pollStart: TimeInterval = dependencies.dateNow.timeIntervalSince1970
-            poller.stop()
-            
-            return poller.poll(
-                calledFromBackgroundPoller: true,
-                isBackgroundPollerValid: { BackgroundPoller.isValid },
-                isPostCapabilitiesRetry: false,
+            return poller.pollFromBackground(
+                namespaces: ClosedGroupPoller.namespaces,
+                for: groupPublicKey,
+                drainBehaviour: .alwaysRandom,
                 using: dependencies
             )
             .handleEvents(
-                receiveOutput: { _ in
+                receiveOutput: { _, _, validMessageCount, _ in
                     let endTime: TimeInterval = dependencies.dateNow.timeIntervalSince1970
                     let duration: TimeUnit = .seconds(endTime - pollStart)
-                    Log.info("[BackgroundPoller] \(pollerName) succeeded after \(duration, unit: .s).")
+                    Log.info("[BackgroundPoller] \(pollerName) received \(validMessageCount) valid message(s) after \(duration, unit: .s).")
                 },
                 receiveCompletion: { result in
                     switch result {
@@ -194,6 +147,38 @@ public final class BackgroundPoller {
             .map { _ in () }
             .catch { _ in Just(()).eraseToAnyPublisher() }
             .eraseToAnyPublisher()
+        }
+    }
+    
+    private static func poll(
+        pollerInfo: [(poller: OpenGroupAPI.Poller, server: String)],
+        using dependencies: Dependencies
+    ) -> [AnyPublisher<Void, Never>] {
+        return pollerInfo.map { poller, server -> AnyPublisher<Void, Never> in
+            let pollerName: String = "Community poller for server: \(server)"   // stringlint:disable
+            let pollStart: TimeInterval = dependencies.dateNow.timeIntervalSince1970
+            
+            return poller
+                .pollFromBackground(using: dependencies)
+                .handleEvents(
+                    receiveOutput: { _ in
+                        let endTime: TimeInterval = dependencies.dateNow.timeIntervalSince1970
+                        let duration: TimeUnit = .seconds(endTime - pollStart)
+                        Log.info("[BackgroundPoller] \(pollerName) succeeded after \(duration, unit: .s).")
+                    },
+                    receiveCompletion: { result in
+                        switch result {
+                            case .finished: break
+                            case .failure(let error):
+                                let endTime: TimeInterval = dependencies.dateNow.timeIntervalSince1970
+                                let duration: TimeUnit = .seconds(endTime - pollStart)
+                                Log.error("[BackgroundPoller] \(pollerName) failed after \(duration, unit: .s) due to error: \(error).")
+                        }
+                    }
+                )
+                .map { _ in () }
+                .catch { _ in Just(()).eraseToAnyPublisher() }
+                .eraseToAnyPublisher()
         }
     }
 }

--- a/SessionMessagingKit/Jobs/Types/ConfigMessageReceiveJob.swift
+++ b/SessionMessagingKit/Jobs/Types/ConfigMessageReceiveJob.swift
@@ -101,12 +101,8 @@ extension ConfigMessageReceiveJob {
         }
         
         public let messages: [MessageInfo]
-        private let calledFromBackgroundPoller: Bool
         
-        public init(
-            messages: [ProcessedMessage],
-            calledFromBackgroundPoller: Bool
-        ) {
+        public init(messages: [ProcessedMessage]) {
             self.messages = messages
                 .compactMap { processedMessage -> MessageInfo? in
                     switch processedMessage {
@@ -120,7 +116,6 @@ extension ConfigMessageReceiveJob {
                             )
                     }
             }
-            self.calledFromBackgroundPoller = calledFromBackgroundPoller
         }
     }
 }

--- a/SessionMessagingKit/Jobs/Types/GarbageCollectionJob.swift
+++ b/SessionMessagingKit/Jobs/Types/GarbageCollectionJob.swift
@@ -335,6 +335,14 @@ public enum GarbageCollectionJob: JobExecutor {
                         )
                     """)
                 }
+                
+                if finalTypesToCollect.contains(.pruneExpiredLastHashRecords) {
+                    // Delete any expired SnodeReceivedMessageInfo values associated to a specific node
+                    try SnodeReceivedMessageInfo
+                        .select(Column.rowID)
+                        .filter(SnodeReceivedMessageInfo.Columns.expirationDateMs <= timestampNow)
+                        .deleteAll(db)
+                }
             },
             completion: { _, _ in
                 // Dispatch async so we can swap from the write queue to a read one (we are done writing)
@@ -491,6 +499,7 @@ extension GarbageCollectionJob {
         case expiredUnreadDisappearingMessages // unread disappearing messages after 14 days
         case expiredPendingReadReceipts
         case shadowThreads
+        case pruneExpiredLastHashRecords
     }
     
     public struct Details: Codable {

--- a/SessionMessagingKit/Jobs/Types/MessageReceiveJob.swift
+++ b/SessionMessagingKit/Jobs/Types/MessageReceiveJob.swift
@@ -91,12 +91,7 @@ public enum MessageReceiveJob: JobExecutor {
             guard !remainingMessagesToProcess.isEmpty else { return }
             
             updatedJob = try job
-                .with(
-                    details: Details(
-                        messages: remainingMessagesToProcess,
-                        calledFromBackgroundPoller: details.calledFromBackgroundPoller
-                    )
-                )
+                .with(details: Details(messages: remainingMessagesToProcess))
                 .defaulting(to: job)
                 .saved(db)
         }
@@ -215,31 +210,18 @@ extension MessageReceiveJob {
         }
         
         public let messages: [MessageInfo]
-        private let isBackgroundPoll: Bool
         
-        // Renamed variable for clarity (and didn't want to migrate old MessageReceiveJob
-        // values so didn't rename the original)
-        public var calledFromBackgroundPoller: Bool { isBackgroundPoll }
-        
-        public init(
-            messages: [ProcessedMessage],
-            calledFromBackgroundPoller: Bool
-        ) {
+        public init(messages: [ProcessedMessage]) {
             self.messages = messages.compactMap { processedMessage in
                 switch processedMessage {
                     case .config: return nil
                     case .standard(_, _, _, let messageInfo): return messageInfo
                 }
             }
-            self.isBackgroundPoll = calledFromBackgroundPoller
         }
         
-        public init(
-            messages: [MessageInfo],
-            calledFromBackgroundPoller: Bool
-        ) {
+        public init(messages: [MessageInfo]) {
             self.messages = messages
-            self.isBackgroundPoll = calledFromBackgroundPoller
         }
     }
 }

--- a/SessionMessagingKit/Sending & Receiving/Errors/MessageSenderError.swift
+++ b/SessionMessagingKit/Sending & Receiving/Errors/MessageSenderError.swift
@@ -69,7 +69,7 @@ public enum MessageSenderError: Error, CustomStringConvertible, Equatable {
             
             case (.other(let lhsError), .other(let rhsError)):
                 // Not ideal but the best we can do
-                return (lhsError.localizedDescription == rhsError.localizedDescription)
+                return ("\(lhsError)" == "\(rhsError)")
                 
             default: return false
         }

--- a/SessionMessagingKit/Sending & Receiving/Notifications/PushNotificationAPI.swift
+++ b/SessionMessagingKit/Sending & Receiving/Notifications/PushNotificationAPI.swift
@@ -475,7 +475,7 @@ public enum PushNotificationAPI {
                         return keySpec
                     }
                     catch {
-                        SNLog("Setting keychain value failed with error: \(error.localizedDescription)")
+                        SNLog("Setting keychain value failed with error: \(error)")
                         throw StorageError.keySpecCreationFailed
                     }
                     

--- a/SessionMessagingKit/Sending & Receiving/Pollers/OpenGroupPoller.swift
+++ b/SessionMessagingKit/Sending & Receiving/Pollers/OpenGroupPoller.swift
@@ -17,8 +17,8 @@ extension OpenGroupAPI {
         
         private let server: String
         private var recursiveLoopId: UUID = UUID()
-        private var hasStarted: Bool = false
         private var isPolling: Bool = false
+        private var cancellable: AnyCancellable?
 
         // MARK: - Settings
         
@@ -41,30 +41,32 @@ extension OpenGroupAPI {
         }
         
         public func startIfNeeded(using dependencies: Dependencies) {
-            guard !hasStarted else { return }
+            guard !isPolling else { return }
             
-            hasStarted = true
+            isPolling = true
             recursiveLoopId = UUID()
             pollRecursively(using: dependencies)
         }
 
         @objc public func stop() {
-            hasStarted = false
+            isPolling = false
+            cancellable?.cancel()
             recursiveLoopId = UUID()
         }
 
         // MARK: - Polling
         
         private func pollRecursively(using dependencies: Dependencies) {
-            guard hasStarted else { return }
+            guard isPolling else { return }
             
             let server: String = self.server
             let originalRecursiveLoopId: UUID = self.recursiveLoopId
             
-            poll(using: dependencies)
+            cancellable?.cancel()
+            cancellable = poll(isPostCapabilitiesRetry: false, using: dependencies)
                 .subscribe(on: Threading.communityPollerQueue, using: dependencies)
                 .receive(on: OpenGroupAPI.workQueue, using: dependencies)
-                .sinkUntilComplete(
+                .sink(
                     receiveCompletion: { [weak self] _ in
                         let minPollFailureCount: Int64 = dependencies.storage
                             .read(using: dependencies) { db in
@@ -91,23 +93,21 @@ extension OpenGroupAPI {
                             
                             self?.pollRecursively(using: dependencies)
                         }
-                    }
+                    },
+                    receiveValue: { _ in }
                 )
+        }
+        
+        /// This doesn't do anything functional _but_ does mean if we get a crash from the `BackgroundPoller` we can better distinguish
+        /// it from a crash from a foreground poll
+        public func pollFromBackground(using dependencies: Dependencies) -> AnyPublisher<Void, Error> {
+            return poll(isPostCapabilitiesRetry: false, using: dependencies)
         }
 
         public func poll(
-            calledFromBackgroundPoller: Bool = false,
-            isBackgroundPollerValid: @escaping (() -> Bool) = { true },
-            isPostCapabilitiesRetry: Bool = false,
-            using dependencies: Dependencies = Dependencies()
+            isPostCapabilitiesRetry: Bool,
+            using dependencies: Dependencies
         ) -> AnyPublisher<Void, Error> {
-            guard !self.isPolling && self.hasStarted else {
-                return Just(())
-                    .setFailureType(to: Error.self)
-                    .eraseToAnyPublisher()
-            }
-            
-            self.isPolling = true
             let server: String = self.server
             let pollStartTime: TimeInterval = dependencies.dateNow.timeIntervalSince1970
             let hasPerformedInitialPoll: Bool = (dependencies.caches[.openGroupManager].hasPerformedInitialPoll[server] == true)
@@ -143,24 +143,16 @@ extension OpenGroupAPI {
                     preparedRequest.send(using: dependencies)
                         .map { info, response in (failureCount, info, response) }
                 }
+                .flatMapOptional { [weak self] failureCount, info, response in
+                    self?.handlePollResponse(
+                        info: info,
+                        response: response,
+                        failureCount: failureCount,
+                        using: dependencies
+                    )
+                }
                 .handleEvents(
-                    receiveOutput: { [weak self] failureCount, info, response in
-                        guard !calledFromBackgroundPoller || isBackgroundPollerValid() else {
-                            // If this was a background poll and the background poll is no longer valid
-                            // then just stop
-                            self?.isPolling = false
-                            self?.hasStarted = false
-                            return
-                        }
-
-                        self?.isPolling = false
-                        self?.handlePollResponse(
-                            info: info,
-                            response: response,
-                            failureCount: failureCount,
-                            using: dependencies
-                        )
-
+                    receiveOutput: { _ in
                         dependencies.caches.mutate(cache: .openGroupManager) { cache in
                             cache.hasPerformedInitialPoll[server] = true
                             cache.timeSinceLastPoll[server] = dependencies.dateNow.timeIntervalSince1970
@@ -168,134 +160,120 @@ extension OpenGroupAPI {
                         }
                         
                         let pollEndTime: TimeInterval = dependencies.dateNow.timeIntervalSince1970
-                        SNLog("Open group polling finished for \(server) in \(.seconds(pollEndTime - pollStartTime), unit: .s).")
+                        Log.info("Open group polling finished for \(server) in \(.seconds(pollEndTime - pollStartTime), unit: .s).")
                     }
                 )
-                .map { _ in () }
-                .catch { [weak self] error -> AnyPublisher<Void, Error> in
-                    guard
-                        let strongSelf = self,
-                        strongSelf.hasStarted,
-                        (!calledFromBackgroundPoller || isBackgroundPollerValid())
-                    else {
-                        // If this was a background poll and the background poll is no longer valid
-                        // then just stop
-                        self?.isPolling = false
-                        self?.hasStarted = false
-
-                        return Just(())
-                            .setFailureType(to: Error.self)
-                            .eraseToAnyPublisher()
-                    }
-
+                .catchOptional { [weak self] error -> AnyPublisher<Void, Error>? in
                     // If we are retrying then the error is being handled so no need to continue (this
                     // method will always resolve)
-                    return strongSelf
-                        .updateCapabilitiesAndRetryIfNeeded(
-                            server: server,
-                            calledFromBackgroundPoller: calledFromBackgroundPoller,
-                            isBackgroundPollerValid: isBackgroundPollerValid,
-                            isPostCapabilitiesRetry: isPostCapabilitiesRetry,
-                            error: error,
-                            using: dependencies
-                        )
-                        .handleEvents(
-                            receiveOutput: { [weak self] didHandleError in
-                                if !didHandleError && isBackgroundPollerValid() {
-                                    // Increase the failure count
-                                    let pollFailureCount: Int64 = dependencies.storage
-                                        .read(using: dependencies) { db in
-                                            try OpenGroup
-                                                .filter(OpenGroup.Columns.server == server)
-                                                .select(max(OpenGroup.Columns.pollFailureCount))
-                                                .asRequest(of: Int64.self)
-                                                .fetchOne(db)
-                                        }
-                                        .defaulting(to: 0)
-                                    var prunedIds: [String] = []
+                    self?.updateCapabilitiesAndRetryIfNeeded(
+                        server: server,
+                        isPostCapabilitiesRetry: isPostCapabilitiesRetry,
+                        error: error,
+                        using: dependencies
+                    )
+                    .flatMap { [weak self] didHandleError in
+                        guard !didHandleError else {
+                            self?.isPolling = false
+                            return Just(())
+                                .setFailureType(to: Error.self)
+                                .eraseToAnyPublisher()
+                        }
+                        
+                        // Increase the failure count
+                        var prunedIds: [String] = []
 
-                                    dependencies.storage.writeAsync(using: dependencies) { db in
-                                        struct Info: Decodable, FetchableRecord {
-                                            let id: String
-                                            let shouldBeVisible: Bool
+                        return dependencies.storage
+                            .writePublisher(using: dependencies) { db -> (Int64, [String]) in
+                                struct Info: Decodable, FetchableRecord {
+                                    let id: String
+                                    let shouldBeVisible: Bool
+                                }
+                                
+                                let rooms: [String] = try OpenGroup
+                                    .filter(
+                                        OpenGroup.Columns.server == server &&
+                                        OpenGroup.Columns.isActive == true
+                                    )
+                                    .select(.roomToken)
+                                    .asRequest(of: String.self)
+                                    .fetchAll(db)
+                                let roomsAreVisible: [Info] = try SessionThread
+                                    .select(.id, .shouldBeVisible)
+                                    .filter(
+                                        ids: rooms.map {
+                                            OpenGroup.idFor(roomToken: $0, server: server)
                                         }
-                                        
-                                        let rooms: [String] = try OpenGroup
-                                            .filter(
-                                                OpenGroup.Columns.server == server &&
-                                                OpenGroup.Columns.isActive == true
-                                            )
-                                            .select(.roomToken)
-                                            .asRequest(of: String.self)
-                                            .fetchAll(db)
-                                        let roomsAreVisible: [Info] = try SessionThread
-                                            .select(.id, .shouldBeVisible)
-                                            .filter(
-                                                ids: rooms.map {
-                                                    OpenGroup.idFor(roomToken: $0, server: server)
-                                                }
-                                            )
-                                            .asRequest(of: Info.self)
-                                            .fetchAll(db)
-                                        
-                                        // Increase the failure count
-                                        try OpenGroup
-                                            .filter(OpenGroup.Columns.server == server)
-                                            .updateAll(
-                                                db,
-                                                OpenGroup.Columns.pollFailureCount
-                                                    .set(to: (pollFailureCount + 1))
-                                            )
-                                        
-                                        /// If the polling has failed 10+ times then try to prune any invalid rooms that
-                                        /// aren't visible (they would have been added via config messages and will
-                                        /// likely always fail but the user has no way to delete them)
-                                        guard pollFailureCount > Poller.maxHiddenRoomFailureCount else { return }
-                                        
-                                        prunedIds = roomsAreVisible
-                                            .filter { !$0.shouldBeVisible }
-                                            .map { $0.id }
-                                        
-                                        prunedIds.forEach { id in
-                                            OpenGroupManager.shared.delete(
-                                                db,
-                                                openGroupId: id,
-                                                /// **Note:** We pass `calledFromConfigHandling` as `true`
-                                                /// here because we want to avoid syncing this deletion as the room might
-                                                /// not be in an invalid state on other devices - one of the other devices
-                                                /// will eventually trigger a new config update which will re-add this room
-                                                /// and hopefully at that time it'll work again
-                                                calledFromConfigHandling: true,
-                                                using: dependencies
-                                            )
-                                        }
-                                    }
-                                    
+                                    )
+                                    .asRequest(of: Info.self)
+                                    .fetchAll(db)
+                                
+                                // Increase the failure count
+                                let pollFailureCount: Int64 = (try? OpenGroup
+                                    .filter(OpenGroup.Columns.server == server)
+                                    .select(max(OpenGroup.Columns.pollFailureCount))
+                                    .asRequest(of: Int64.self)
+                                    .fetchOne(db))
+                                    .defaulting(to: 0)
+                                try OpenGroup
+                                    .filter(OpenGroup.Columns.server == server)
+                                    .updateAll(
+                                        db,
+                                        OpenGroup.Columns.pollFailureCount
+                                            .set(to: (pollFailureCount + 1))
+                                    )
+                                
+                                /// If the polling has failed 10+ times then try to prune any invalid rooms that
+                                /// aren't visible (they would have been added via config messages and will
+                                /// likely always fail but the user has no way to delete them)
+                                guard pollFailureCount > Poller.maxHiddenRoomFailureCount else {
+                                    return (pollFailureCount, [])
+                                }
+                                
+                                prunedIds = roomsAreVisible
+                                    .filter { !$0.shouldBeVisible }
+                                    .map { $0.id }
+                                
+                                prunedIds.forEach { id in
+                                    OpenGroupManager.shared.delete(
+                                        db,
+                                        openGroupId: id,
+                                        /// **Note:** We pass `calledFromConfigHandling` as `true`
+                                        /// here because we want to avoid syncing this deletion as the room might
+                                        /// not be in an invalid state on other devices - one of the other devices
+                                        /// will eventually trigger a new config update which will re-add this room
+                                        /// and hopefully at that time it'll work again
+                                        calledFromConfigHandling: true,
+                                        using: dependencies
+                                    )
+                                }
+                                
+                                return (pollFailureCount, prunedIds)
+                            }
+                            .handleEvents(
+                                receiveOutput: { pollFailureCount, prunedIds in
                                     let pollEndTime: TimeInterval = dependencies.dateNow.timeIntervalSince1970
-                                    SNLog("Open group polling to \(server) failed in \(.seconds(pollEndTime - pollStartTime), unit: .s) due to error: \(error). Setting failure count to \(pollFailureCount + 1).")
+                                    Log.info("Open group polling to \(server) failed in \(.seconds(pollEndTime - pollStartTime), unit: .s) due to error: \(error). Setting failure count to \(pollFailureCount + 1).")
                                     
                                     // Add a note to the logs that this happened
                                     if !prunedIds.isEmpty {
                                         let rooms: String = prunedIds
                                             .compactMap { $0.components(separatedBy: server).last }
                                             .joined(separator: ", ")
-                                        SNLog("Hidden open group failure count surpassed \(Poller.maxHiddenRoomFailureCount), removed hidden rooms \(rooms).")
+                                        Log.info("Hidden open group failure count surpassed \(Poller.maxHiddenRoomFailureCount), removed hidden rooms \(rooms).")
                                     }
                                 }
-
-                                self?.isPolling = false
-                            }
-                        )
-                        .map { _ in () }
-                        .eraseToAnyPublisher()
+                            )
+                            .map { _ in () }
+                            .eraseToAnyPublisher()
+                    }
+                    .eraseToAnyPublisher()
                 }
                 .eraseToAnyPublisher()
         }
         
         private func updateCapabilitiesAndRetryIfNeeded(
             server: String,
-            calledFromBackgroundPoller: Bool,
-            isBackgroundPollerValid: @escaping (() -> Bool) = { true },
             isPostCapabilitiesRetry: Bool,
             error: Error,
             using dependencies: Dependencies
@@ -326,29 +304,19 @@ extension OpenGroupAPI {
                     )
                 }
                 .flatMap { $0.send(using: dependencies) }
-                .flatMap { [weak self] _, responseBody -> AnyPublisher<Void, Error> in
-                    guard let strongSelf = self, strongSelf.hasStarted, isBackgroundPollerValid() else {
-                        return Just(())
-                            .setFailureType(to: Error.self)
-                            .eraseToAnyPublisher()
-                    }
-                    
-                    // Handle the updated capabilities and re-trigger the poll
-                    strongSelf.isPolling = false
-                    
-                    dependencies.storage.write { db in
+                .flatMap { _, responseBody -> AnyPublisher<Void, Error> in
+                    dependencies.storage.writePublisher(using: dependencies) { db in
                         OpenGroupManager.handleCapabilities(
                             db,
                             capabilities: responseBody,
                             on: server
                         )
                     }
-                    
+                }
+                .flatMapOptional { [weak self] _ -> AnyPublisher<Void, Error>? in
                     // Regardless of the outcome we can just resolve this
                     // immediately as it'll handle it's own response
-                    return strongSelf.poll(
-                        calledFromBackgroundPoller: calledFromBackgroundPoller,
-                        isBackgroundPollerValid: isBackgroundPollerValid,
+                    self?.poll(
                         isPostCapabilitiesRetry: true,
                         using: dependencies
                     )
@@ -370,7 +338,7 @@ extension OpenGroupAPI {
             response: Network.BatchResponseMap<OpenGroupAPI.Endpoint>,
             failureCount: Int64,
             using dependencies: Dependencies
-        ) {
+        ) -> AnyPublisher<Void, Error> {
             let server: String = self.server
             let validResponses: [OpenGroupAPI.Endpoint: Any] = response.data
                 .filter { endpoint, data in
@@ -436,7 +404,11 @@ extension OpenGroupAPI {
             
             // If there are no remaining 'validResponses' and there hasn't been a failure then there is
             // no need to do anything else
-            guard !validResponses.isEmpty || failureCount != 0 else { return }
+            guard !validResponses.isEmpty || failureCount != 0 else {
+                return Just(())
+                    .setFailureType(to: Error.self)
+                    .eraseToAnyPublisher()
+            }
             
             // Retrieve the current capability & group info to check if anything changed
             let rooms: [String] = validResponses
@@ -447,146 +419,157 @@ extension OpenGroupAPI {
                         default: return nil
                     }
                 }
-            let currentInfo: (capabilities: Capabilities, groups: [OpenGroup])? = dependencies.storage.read { db in
-                let allCapabilities: [Capability] = try Capability
-                    .filter(Capability.Columns.openGroupServer == server)
-                    .fetchAll(db)
-                let capabilities: Capabilities = Capabilities(
-                    capabilities: allCapabilities
-                        .filter { !$0.isMissing }
-                        .map { $0.variant },
-                    missing: {
-                        let missingCapabilities: [Capability.Variant] = allCapabilities
-                            .filter { $0.isMissing }
-                            .map { $0.variant }
-                        
-                        return (missingCapabilities.isEmpty ? nil : missingCapabilities)
-                    }()
-                )
-                let openGroupIds: [String] = rooms
-                    .map { OpenGroup.idFor(roomToken: $0, server: server) }
-                let groups: [OpenGroup] = try OpenGroup
-                    .filter(ids: openGroupIds)
-                    .fetchAll(db)
-                
-                return (capabilities, groups)
-            }
-            let changedResponses: [OpenGroupAPI.Endpoint: Any] = validResponses
-                .filter { endpoint, data in
-                    switch endpoint {
-                        case .capabilities:
-                            guard
-                                let responseData: Network.BatchSubResponse<Capabilities> = data as? Network.BatchSubResponse<Capabilities>,
-                                let responseBody: Capabilities = responseData.body
-                            else { return false }
+            
+            return dependencies.storage
+                .readPublisher(using: dependencies) { db -> (capabilities: Capabilities, groups: [OpenGroup]) in
+                    let allCapabilities: [Capability] = try Capability
+                        .filter(Capability.Columns.openGroupServer == server)
+                        .fetchAll(db)
+                    let capabilities: Capabilities = Capabilities(
+                        capabilities: allCapabilities
+                            .filter { !$0.isMissing }
+                            .map { $0.variant },
+                        missing: {
+                            let missingCapabilities: [Capability.Variant] = allCapabilities
+                                .filter { $0.isMissing }
+                                .map { $0.variant }
                             
-                            return (responseBody != currentInfo?.capabilities)
-                            
-                        case .roomPollInfo(let roomToken, _):
-                            guard
-                                let responseData: Network.BatchSubResponse<RoomPollInfo> = data as? Network.BatchSubResponse<RoomPollInfo>,
-                                let responseBody: RoomPollInfo = responseData.body
-                            else { return false }
-                            guard let existingOpenGroup: OpenGroup = currentInfo?.groups.first(where: { $0.roomToken == roomToken }) else {
-                                return true
+                            return (missingCapabilities.isEmpty ? nil : missingCapabilities)
+                        }()
+                    )
+                    let openGroupIds: [String] = rooms
+                        .map { OpenGroup.idFor(roomToken: $0, server: server) }
+                    let groups: [OpenGroup] = try OpenGroup
+                        .filter(ids: openGroupIds)
+                        .fetchAll(db)
+                    
+                    return (capabilities, groups)
+                }
+                .flatMap { (capabilities: Capabilities, groups: [OpenGroup]) -> AnyPublisher<Void, Error> in
+                    let changedResponses: [OpenGroupAPI.Endpoint: Any] = validResponses
+                        .filter { endpoint, data in
+                            switch endpoint {
+                                case .capabilities:
+                                    guard
+                                        let responseData: Network.BatchSubResponse<Capabilities> = data as? Network.BatchSubResponse<Capabilities>,
+                                        let responseBody: Capabilities = responseData.body
+                                    else { return false }
+                                    
+                                    return (responseBody != capabilities)
+                                    
+                                case .roomPollInfo(let roomToken, _):
+                                    guard
+                                        let responseData: Network.BatchSubResponse<RoomPollInfo> = data as? Network.BatchSubResponse<RoomPollInfo>,
+                                        let responseBody: RoomPollInfo = responseData.body
+                                    else { return false }
+                                    guard let existingOpenGroup: OpenGroup = groups.first(where: { $0.roomToken == roomToken }) else {
+                                        return true
+                                    }
+                                    
+                                    // Note: This might need to be updated in the future when we start tracking
+                                    // user permissions if changes to permissions don't trigger a change to
+                                    // the 'infoUpdates'
+                                    return (
+                                        responseBody.activeUsers != existingOpenGroup.userCount || (
+                                            responseBody.details != nil &&
+                                            responseBody.details?.infoUpdates != existingOpenGroup.infoUpdates
+                                        )
+                                    )
+                                
+                                default: return true
+                            }
+                        }
+                    
+                    // If there are no 'changedResponses' and there hasn't been a failure then there is
+                    // no need to do anything else
+                    guard !changedResponses.isEmpty || failureCount != 0 else {
+                        return Just(())
+                            .setFailureType(to: Error.self)
+                            .eraseToAnyPublisher()
+                    }
+                    
+                    return dependencies.storage
+                        .writePublisher(using: dependencies) { db in
+                            // Reset the failure count
+                            if failureCount > 0 {
+                                try OpenGroup
+                                    .filter(OpenGroup.Columns.server == server)
+                                    .updateAll(db, OpenGroup.Columns.pollFailureCount.set(to: 0))
                             }
                             
-                            // Note: This might need to be updated in the future when we start tracking
-                            // user permissions if changes to permissions don't trigger a change to
-                            // the 'infoUpdates'
-                            return (
-                                responseBody.activeUsers != existingOpenGroup.userCount || (
-                                    responseBody.details != nil &&
-                                    responseBody.details?.infoUpdates != existingOpenGroup.infoUpdates
-                                )
-                            )
-                        
-                        default: return true
-                    }
-                }
-            
-            // If there are no 'changedResponses' and there hasn't been a failure then there is
-            // no need to do anything else
-            guard !changedResponses.isEmpty || failureCount != 0 else { return }
-            
-            dependencies.storage.write { db in
-                // Reset the failure count
-                if failureCount > 0 {
-                    try OpenGroup
-                        .filter(OpenGroup.Columns.server == server)
-                        .updateAll(db, OpenGroup.Columns.pollFailureCount.set(to: 0))
-                }
-                
-                try changedResponses.forEach { endpoint, data in
-                    switch endpoint {
-                        case .capabilities:
-                            guard
-                                let responseData: Network.BatchSubResponse<Capabilities> = data as? Network.BatchSubResponse<Capabilities>,
-                                let responseBody: Capabilities = responseData.body
-                            else { return }
-                            
-                            OpenGroupManager.handleCapabilities(
-                                db,
-                                capabilities: responseBody,
-                                on: server
-                            )
-                            
-                        case .roomPollInfo(let roomToken, _):
-                            guard
-                                let responseData: Network.BatchSubResponse<RoomPollInfo> = data as? Network.BatchSubResponse<RoomPollInfo>,
-                                let responseBody: RoomPollInfo = responseData.body
-                            else { return }
-                            
-                            try OpenGroupManager.handlePollInfo(
-                                db,
-                                pollInfo: responseBody,
-                                publicKey: nil,
-                                for: roomToken,
-                                on: server,
-                                using: dependencies
-                            )
-                            
-                        case .roomMessagesRecent(let roomToken), .roomMessagesBefore(let roomToken, _), .roomMessagesSince(let roomToken, _):
-                            guard
-                                let responseData: Network.BatchSubResponse<[Failable<Message>]> = data as? Network.BatchSubResponse<[Failable<Message>]>,
-                                let responseBody: [Failable<Message>] = responseData.body
-                            else { return }
-                            
-                            OpenGroupManager.handleMessages(
-                                db,
-                                messages: responseBody.compactMap { $0.value },
-                                for: roomToken,
-                                on: server,
-                                using: dependencies
-                            )
-                            
-                        case .inbox, .inboxSince, .outbox, .outboxSince:
-                            guard
-                                let responseData: Network.BatchSubResponse<[DirectMessage]?> = data as? Network.BatchSubResponse<[DirectMessage]?>,
-                                !responseData.failedToParseBody
-                            else { return }
-                            
-                            // Double optional because the server can return a `304` with an empty body
-                            let messages: [OpenGroupAPI.DirectMessage] = ((responseData.body ?? []) ?? [])
-                            let fromOutbox: Bool = {
+                            try changedResponses.forEach { endpoint, data in
                                 switch endpoint {
-                                    case .outbox, .outboxSince: return true
-                                    default: return false
+                                    case .capabilities:
+                                        guard
+                                            let responseData: Network.BatchSubResponse<Capabilities> = data as? Network.BatchSubResponse<Capabilities>,
+                                            let responseBody: Capabilities = responseData.body
+                                        else { return }
+                                        
+                                        OpenGroupManager.handleCapabilities(
+                                            db,
+                                            capabilities: responseBody,
+                                            on: server
+                                        )
+                                        
+                                    case .roomPollInfo(let roomToken, _):
+                                        guard
+                                            let responseData: Network.BatchSubResponse<RoomPollInfo> = data as? Network.BatchSubResponse<RoomPollInfo>,
+                                            let responseBody: RoomPollInfo = responseData.body
+                                        else { return }
+                                        
+                                        try OpenGroupManager.handlePollInfo(
+                                            db,
+                                            pollInfo: responseBody,
+                                            publicKey: nil,
+                                            for: roomToken,
+                                            on: server,
+                                            using: dependencies
+                                        )
+                                        
+                                    case .roomMessagesRecent(let roomToken), .roomMessagesBefore(let roomToken, _), .roomMessagesSince(let roomToken, _):
+                                        guard
+                                            let responseData: Network.BatchSubResponse<[Failable<Message>]> = data as? Network.BatchSubResponse<[Failable<Message>]>,
+                                            let responseBody: [Failable<Message>] = responseData.body
+                                        else { return }
+                                        
+                                        OpenGroupManager.handleMessages(
+                                            db,
+                                            messages: responseBody.compactMap { $0.value },
+                                            for: roomToken,
+                                            on: server,
+                                            using: dependencies
+                                        )
+                                        
+                                    case .inbox, .inboxSince, .outbox, .outboxSince:
+                                        guard
+                                            let responseData: Network.BatchSubResponse<[DirectMessage]?> = data as? Network.BatchSubResponse<[DirectMessage]?>,
+                                            !responseData.failedToParseBody
+                                        else { return }
+                                        
+                                        // Double optional because the server can return a `304` with an empty body
+                                        let messages: [OpenGroupAPI.DirectMessage] = ((responseData.body ?? []) ?? [])
+                                        let fromOutbox: Bool = {
+                                            switch endpoint {
+                                                case .outbox, .outboxSince: return true
+                                                default: return false
+                                            }
+                                        }()
+                                        
+                                        OpenGroupManager.handleDirectMessages(
+                                            db,
+                                            messages: messages,
+                                            fromOutbox: fromOutbox,
+                                            on: server,
+                                            using: dependencies
+                                        )
+                                        
+                                    default: break // No custom handling needed
                                 }
-                            }()
-                            
-                            OpenGroupManager.handleDirectMessages(
-                                db,
-                                messages: messages,
-                                fromOutbox: fromOutbox,
-                                on: server,
-                                using: dependencies
-                            )
-                            
-                        default: break // No custom handling needed
-                    }
+                            }
+                        }
+                        .eraseToAnyPublisher()
                 }
-            }
+                .eraseToAnyPublisher()
         }
         
         // MARK: - Convenience

--- a/SessionMessagingKit/Sending & Receiving/Pollers/Poller.swift
+++ b/SessionMessagingKit/Sending & Receiving/Pollers/Poller.swift
@@ -62,7 +62,10 @@ public class Poller {
         isPolling.mutate { $0[publicKey] = false }
         failureCount.mutate { $0[publicKey] = nil }
         drainBehaviour.mutate { $0[publicKey] = nil }
-        cancellables.mutate { $0[publicKey]?.cancel() }
+        cancellables.mutate {
+            $0[publicKey]?.cancel()
+            $0.removeAll()
+        }
     }
     
     // MARK: - Abstract Methods
@@ -116,10 +119,12 @@ public class Poller {
         
         // Store the publisher intp the cancellables dictionary
         cancellables.mutate { [weak self] cancellables in
+            cancellables[swarmPublicKey]?.cancel()
             cancellables[swarmPublicKey] = self?.poll(
                     namespaces: namespaces,
                     for: swarmPublicKey,
                     drainBehaviour: drainBehaviour,
+                    forceSynchronousProcessing: false,
                     using: dependencies
                 )
                 .subscribe(on: pollerQueue, using: dependencies)
@@ -193,6 +198,23 @@ public class Poller {
         }
     }
     
+    /// This doesn't do anything functional _but_ does mean if we get a crash from the `BackgroundPoller` we can better distinguish
+    /// it from a crash from a foreground poll
+    public func pollFromBackground(
+        namespaces: [SnodeAPI.Namespace],
+        for swarmPublicKey: String,
+        drainBehaviour: Atomic<SwarmDrainBehaviour>,
+        using dependencies: Dependencies
+    ) -> AnyPublisher<PollResponse, Error> {
+        return poll(
+            namespaces: namespaces,
+            for: swarmPublicKey,
+            drainBehaviour: drainBehaviour,
+            forceSynchronousProcessing: true,
+            using: dependencies
+        )
+    }
+    
     /// Polls the specified namespaces and processes any messages, returning an array of messages that were
     /// successfully processed
     ///
@@ -201,47 +223,31 @@ public class Poller {
     public func poll(
         namespaces: [SnodeAPI.Namespace],
         for swarmPublicKey: String,
-        calledFromBackgroundPoller: Bool = false,
-        isBackgroundPollValid: @escaping (() -> Bool) = { true },
         drainBehaviour: Atomic<SwarmDrainBehaviour>,
+        forceSynchronousProcessing: Bool,
         using dependencies: Dependencies
     ) -> AnyPublisher<PollResponse, Error> {
-        // If the polling has been cancelled then don't continue
-        guard
-            (calledFromBackgroundPoller && isBackgroundPollValid()) ||
-            isPolling.wrappedValue[swarmPublicKey] == true
-        else {
-            return Just(([], 0, 0, false))
-                .setFailureType(to: Error.self)
-                .eraseToAnyPublisher()
-        }
-        
         let pollerQueue: DispatchQueue = self.pollerQueue
         let configHashes: [String] = LibSession.configHashes(for: swarmPublicKey)
         
         // Fetch the messages
         return LibSession.getSwarm(swarmPublicKey: swarmPublicKey)
-            .tryFlatMapWithRandomSnode(drainBehaviour: drainBehaviour, using: dependencies) { snode -> AnyPublisher<[SnodeAPI.Namespace: (info: ResponseInfoType, data: (messages: [SnodeReceivedMessage], lastHash: String?)?)], Error> in
-                SnodeAPI.poll(
-                    namespaces: namespaces,
-                    refreshingConfigHashes: configHashes,
-                    from: snode,
-                    swarmPublicKey: swarmPublicKey,
-                    calledFromBackgroundPoller: calledFromBackgroundPoller,
-                    isBackgroundPollValid: isBackgroundPollValid,
-                    using: dependencies
-                )
-            }
-            .flatMap { [weak self] namespacedResults -> AnyPublisher<PollResponse, Error> in
-                guard
-                    (calledFromBackgroundPoller && isBackgroundPollValid()) ||
-                    self?.isPolling.wrappedValue[swarmPublicKey] == true
-                else {
-                    return Just(([], 0, 0, false))
-                        .setFailureType(to: Error.self)
-                        .eraseToAnyPublisher()
+            .tryFlatMapWithRandomSnode(drainBehaviour: drainBehaviour, using: dependencies) { snode -> AnyPublisher<Network.PreparedRequest<SnodeAPI.PollResponse>, Error> in
+                dependencies.storage.readPublisher(using: dependencies) { db in
+                    try SnodeAPI.preparedPoll(
+                        db,
+                        namespaces: namespaces,
+                        refreshingConfigHashes: configHashes,
+                        from: snode,
+                        swarmPublicKey: swarmPublicKey,
+                        using: dependencies
+                    )
                 }
-                
+            }
+            .flatMap { [dependencies] (request: Network.PreparedRequest<SnodeAPI.PollResponse>) -> AnyPublisher<(ResponseInfoType, SnodeAPI.PollResponse), Error> in
+                request.send(using: dependencies)
+            }
+            .flatMap { (_: ResponseInfoType, namespacedResults: SnodeAPI.PollResponse) -> AnyPublisher<([Job], [Job], PollResponse), Error> in
                 // Get all of the messages and sort them by their required 'processingOrder'
                 let sortedMessages: [(namespace: SnodeAPI.Namespace, messages: [SnodeReceivedMessage])] = namespacedResults
                     .compactMap { namespace, result in (result.data?.messages).map { (namespace, $0) } }
@@ -250,7 +256,7 @@ public class Poller {
                 
                 // No need to do anything if there are no messages
                 guard rawMessageCount > 0 else {
-                    return Just(([], 0, 0, false))
+                    return Just(([], [], ([], 0, 0, false)))
                         .setFailureType(to: Error.self)
                         .eraseToAnyPublisher()
                 }
@@ -265,10 +271,8 @@ public class Poller {
                 var messageCount: Int = 0
                 var processedMessages: [ProcessedMessage] = []
                 var hadValidHashUpdate: Bool = false
-                var configMessageJobsToRun: [Job] = []
-                var standardMessageJobsToRun: [Job] = []
                 
-                dependencies.storage.write { db in
+                return dependencies.storage.writePublisher(using: dependencies) { db -> ([Job], [Job], PollResponse) in
                     let allProcessedMessages: [ProcessedMessage] = sortedMessages
                         .compactMap { namespace, messages -> [ProcessedMessage]? in
                             let processedMessages: [ProcessedMessage] = messages
@@ -297,12 +301,7 @@ public class Poller {
                                                 break
                                                 
                                             case DatabaseError.SQLITE_ABORT:
-                                                /// In the background ignore 'SQLITE_ABORT' (it generally means the
-                                                /// BackgroundPoller has timed out
-                                                if !calledFromBackgroundPoller {
-                                                    Log.warn("Failed to the database being suspended (running in background with no background task).")
-                                                }
-                                                break
+                                                Log.warn("Failed to the database being suspended (running in background with no background task).")
                                                 
                                             default: Log.error("Failed to deserialize envelope due to error: \(error).")
                                         }
@@ -320,10 +319,7 @@ public class Poller {
                                     try LibSession.handleConfigMessages(
                                         db,
                                         messages: ConfigMessageReceiveJob
-                                            .Details(
-                                                messages: processedMessages,
-                                                calledFromBackgroundPoller: false
-                                            )
+                                            .Details(messages: processedMessages)
                                             .messages,
                                         publicKey: swarmPublicKey
                                     )
@@ -356,6 +352,7 @@ public class Poller {
                         .flatMap { $0 }
                     
                     // Add a job to process the config messages first
+                    var configMessageJobs: [Job] = []
                     let configJobIds: [Int64] = allProcessedMessages
                         .filter { $0.isConfigMessage && !$0.namespace.shouldHandleSynchronously }
                         .grouped { $0.threadId }
@@ -363,16 +360,13 @@ public class Poller {
                             messageCount += threadMessages.count
                             processedMessages += threadMessages
                             
-                            let jobToRun: Job? = Job(
+                            let job: Job? = Job(
                                 variant: .configMessageReceive,
                                 behaviour: .runOnce,
                                 threadId: threadId,
-                                details: ConfigMessageReceiveJob.Details(
-                                    messages: threadMessages,
-                                    calledFromBackgroundPoller: calledFromBackgroundPoller
-                                )
+                                details: ConfigMessageReceiveJob.Details(messages: threadMessages)
                             )
-                            configMessageJobsToRun = configMessageJobsToRun.appending(jobToRun)
+                            configMessageJobs = configMessageJobs.appending(job)
                             
                             // If we are force-polling then add to the JobRunner so they are
                             // persistent and will retry on the next app run if they fail but
@@ -380,16 +374,20 @@ public class Poller {
                             let updatedJob: Job? = dependencies.jobRunner
                                 .add(
                                     db,
-                                    job: jobToRun,
-                                    canStartJob: !calledFromBackgroundPoller,
+                                    job: job,
+                                    canStartJob: (
+                                        !forceSynchronousProcessing &&
+                                        (Singleton.hasAppContext && !Singleton.appContext.isInBackground)
+                                    ),
                                     using: dependencies
                                 )
-                                
+                            
                             return updatedJob?.id
                         }
                     
                     // Add jobs for processing non-config messages which are dependant on the config message
                     // processing jobs
+                    var standardMessageJobs: [Job] = []
                     allProcessedMessages
                         .filter { !$0.isConfigMessage && !$0.namespace.shouldHandleSynchronously }
                         .grouped { $0.threadId }
@@ -397,16 +395,13 @@ public class Poller {
                             messageCount += threadMessages.count
                             processedMessages += threadMessages
                             
-                            let jobToRun: Job? = Job(
+                            let job: Job? = Job(
                                 variant: .messageReceive,
                                 behaviour: .runOnce,
                                 threadId: threadId,
-                                details: MessageReceiveJob.Details(
-                                    messages: threadMessages,
-                                    calledFromBackgroundPoller: calledFromBackgroundPoller
-                                )
+                                details: MessageReceiveJob.Details(messages: threadMessages)
                             )
-                            standardMessageJobsToRun = standardMessageJobsToRun.appending(jobToRun)
+                            standardMessageJobs = standardMessageJobs.appending(job)
                             
                             // If we are force-polling then add to the JobRunner so they are
                             // persistent and will retry on the next app run if they fail but
@@ -414,8 +409,11 @@ public class Poller {
                             let updatedJob: Job? = dependencies.jobRunner
                                 .add(
                                     db,
-                                    job: jobToRun,
-                                    canStartJob: !calledFromBackgroundPoller,
+                                    job: job,
+                                    canStartJob: (
+                                        !forceSynchronousProcessing &&
+                                        (Singleton.hasAppContext && !Singleton.appContext.isInBackground)
+                                    ),
                                     using: dependencies
                                 )
                             
@@ -445,11 +443,14 @@ public class Poller {
                             otherKnownValidHashes: otherKnownHashes
                         )
                     }
+                    
+                    return (configMessageJobs, standardMessageJobs, (processedMessages, rawMessageCount, messageCount, hadValidHashUpdate))
                 }
-                
-                // If we aren't runing in a background poller then just finish immediately
-                guard calledFromBackgroundPoller else {
-                    return Just((processedMessages, rawMessageCount, messageCount, hadValidHashUpdate))
+            }
+            .flatMap { (configMessageJobs: [Job], standardMessageJobs: [Job], pollResponse: PollResponse) -> AnyPublisher<PollResponse, Error> in
+                // If we don't want to forcible process the response synchronously then just finish immediately
+                guard forceSynchronousProcessing else {
+                    return Just(pollResponse)
                         .setFailureType(to: Error.self)
                         .eraseToAnyPublisher()
                 }
@@ -457,7 +458,7 @@ public class Poller {
                 // We want to try to handle the receive jobs immediately in the background
                 return Publishers
                     .MergeMany(
-                        configMessageJobsToRun.map { job -> AnyPublisher<Void, Error> in
+                        configMessageJobs.map { job -> AnyPublisher<Void, Error> in
                             Deferred {
                                 Future<Void, Error> { resolver in
                                     // Note: In the background we just want jobs to fail silently
@@ -478,7 +479,7 @@ public class Poller {
                     .flatMap { _ in
                         Publishers
                             .MergeMany(
-                                standardMessageJobsToRun.map { job -> AnyPublisher<Void, Error> in
+                                standardMessageJobs.map { job -> AnyPublisher<Void, Error> in
                                     Deferred {
                                         Future<Void, Error> { resolver in
                                             // Note: In the background we just want jobs to fail silently
@@ -497,7 +498,7 @@ public class Poller {
                             )
                             .collect()
                     }
-                    .map { _ in (processedMessages, rawMessageCount, messageCount, hadValidHashUpdate) }
+                    .map { _ in pollResponse }
                     .eraseToAnyPublisher()
             }
             .eraseToAnyPublisher()

--- a/SessionMessagingKitTests/Jobs/Types/MessageSendJobSpec.swift
+++ b/SessionMessagingKitTests/Jobs/Types/MessageSendJobSpec.swift
@@ -103,8 +103,7 @@ class MessageSendJobSpec: QuickSpec {
                 job = Job(
                     variant: .messageSend,
                     details: MessageReceiveJob.Details(
-                        messages: [MessageReceiveJob.Details.MessageInfo](),
-                        calledFromBackgroundPoller: false
+                        messages: [MessageReceiveJob.Details.MessageInfo]()
                     )
                 )
                 

--- a/SessionShareExtension/SAEScreenLockViewController.swift
+++ b/SessionShareExtension/SAEScreenLockViewController.swift
@@ -121,7 +121,7 @@ final class SAEScreenLockViewController: ScreenLockViewController {
                 
                 self?.isShowingAuthUI = false
                 self?.ensureUI()
-                self?.showScreenLockFailureAlert(message: error.localizedDescription)
+                self?.showScreenLockFailureAlert(message: "\(error)")
             },
             unexpectedFailure: { [weak self] error in
                 AssertIsOnMainThread()

--- a/SessionShareExtension/ShareNavController.swift
+++ b/SessionShareExtension/ShareNavController.swift
@@ -256,7 +256,7 @@ final class ShareNavController: UINavigationController, ShareViewDelegate {
             targetView: self.view,
             info: ConfirmationModal.Info(
                 title: "Session",
-                body: .text(error.localizedDescription),
+                body: .text("\(error)"),
                 cancelTitle: "BUTTON_OK".localized(),
                 cancelStyle: .alert_text,
                 afterClosed: { [weak self] in self?.extensionContext?.cancelRequest(withError: error) }

--- a/SessionSnodeKit/Database/Models/SnodeReceivedMessageInfo.swift
+++ b/SessionSnodeKit/Database/Models/SnodeReceivedMessageInfo.swift
@@ -65,79 +65,23 @@ public extension SnodeReceivedMessageInfo {
 // MARK: - GRDB Interactions
 
 public extension SnodeReceivedMessageInfo {
-    static func pruneExpiredMessageHashInfo(
-        for snode: LibSession.Snode,
-        namespace: SnodeAPI.Namespace,
-        associatedWith publicKey: String,
-        using dependencies: Dependencies
-    ) {
-        // Delete any expired SnodeReceivedMessageInfo values associated to a specific node (even
-        // though this runs very quickly we fetch the rowIds we want to delete from a 'read' call
-        // to avoid blocking the write queue since this method is called very frequently)
-        let rowIds: [Int64] = dependencies.storage
-            .read { db in
-                // Only prune the hashes if new hashes exist for this Snode (if they don't then
-                // we don't want to clear out the legacy hashes)
-                let hasNonLegacyHash: Bool = SnodeReceivedMessageInfo
-                    .filter(SnodeReceivedMessageInfo.Columns.key == key(for: snode, publicKey: publicKey, namespace: namespace))
-                    .isNotEmpty(db)
-                
-                guard hasNonLegacyHash else { return [] }
-                
-                return try SnodeReceivedMessageInfo
-                    .select(Column.rowID)
-                    .filter(SnodeReceivedMessageInfo.Columns.key == key(for: snode, publicKey: publicKey, namespace: namespace))
-                    .filter(SnodeReceivedMessageInfo.Columns.expirationDateMs <= SnodeAPI.currentOffsetTimestampMs())
-                    .asRequest(of: Int64.self)
-                    .fetchAll(db)
-            }
-            .defaulting(to: [])
-        
-        // If there are no rowIds to delete then do nothing
-        guard !rowIds.isEmpty else { return }
-        
-        dependencies.storage.write { db in
-            try SnodeReceivedMessageInfo
-                .filter(rowIds.contains(Column.rowID))
-                .deleteAll(db)
-        }
-    }
-    
     /// This method fetches the last non-expired hash from the database for message retrieval
-    ///
-    /// **Note:** This method uses a `write` instead of a read because there is a single write queue for the database and it's
-    /// very common for this method to be called after the hash value has been updated but before the various `read` threads
-    /// have been updated, resulting in a pointless fetch for data the app has already received
     static func fetchLastNotExpired(
+        _ db: Database,
         for snode: LibSession.Snode,
         namespace: SnodeAPI.Namespace,
         associatedWith publicKey: String,
         using dependencies: Dependencies
-    ) -> SnodeReceivedMessageInfo? {
-        return dependencies.storage.read { db in
-            let nonLegacyHash: SnodeReceivedMessageInfo? = try SnodeReceivedMessageInfo
-                .filter(
-                    SnodeReceivedMessageInfo.Columns.wasDeletedOrInvalid == nil ||
-                    SnodeReceivedMessageInfo.Columns.wasDeletedOrInvalid == false
-                )
-                .filter(SnodeReceivedMessageInfo.Columns.key == key(for: snode, publicKey: publicKey, namespace: namespace))
-                .filter(SnodeReceivedMessageInfo.Columns.expirationDateMs > SnodeAPI.currentOffsetTimestampMs())
-                .order(Column.rowID.desc)
-                .fetchOne(db)
-            
-            // If we have a non-legacy hash then return it immediately (legacy hashes had a different
-            // 'key' structure)
-            if nonLegacyHash != nil { return nonLegacyHash }
-            
-            return try SnodeReceivedMessageInfo
-                .filter(
-                    SnodeReceivedMessageInfo.Columns.wasDeletedOrInvalid == nil ||
-                    SnodeReceivedMessageInfo.Columns.wasDeletedOrInvalid == false
-                )
-                .filter(SnodeReceivedMessageInfo.Columns.key == publicKey)
-                .order(Column.rowID.desc)
-                .fetchOne(db)
-        }
+    ) throws -> SnodeReceivedMessageInfo? {
+        return try SnodeReceivedMessageInfo
+            .filter(
+                SnodeReceivedMessageInfo.Columns.wasDeletedOrInvalid == nil ||
+                SnodeReceivedMessageInfo.Columns.wasDeletedOrInvalid == false
+            )
+            .filter(SnodeReceivedMessageInfo.Columns.key == key(for: snode, publicKey: publicKey, namespace: namespace))
+            .filter(SnodeReceivedMessageInfo.Columns.expirationDateMs > SnodeAPI.currentOffsetTimestampMs())
+            .order(Column.rowID.desc)
+            .fetchOne(db)
     }
     
     /// There are some cases where the latest message can be removed from a swarm, if we then try to poll for that message the swarm

--- a/SessionSnodeKit/LibSession/LibSession+Networking.swift
+++ b/SessionSnodeKit/LibSession/LibSession+Networking.swift
@@ -569,7 +569,15 @@ public extension LibSession {
                     throw NetworkError.badGateway
                 }
                 
-                throw SnodeAPIError.nodeNotFound(String(responseString.suffix(64)))
+                let nodeHex: String = String(responseString.suffix(64))
+                
+                for path in lastPaths.wrappedValue {
+                    if let index: Int = path.firstIndex(where: { $0.ed25519PubkeyHex == nodeHex }) {
+                        throw SnodeAPIError.nodeNotFound(index, nodeHex)
+                    }
+                }
+                
+                throw SnodeAPIError.nodeNotFound(nil, nodeHex)
                 
             case (504, _): throw NetworkError.gatewayTimeout
             case (_, .none): throw NetworkError.unknown

--- a/SessionSnodeKit/Types/SnodeAPIError.swift
+++ b/SessionSnodeKit/Types/SnodeAPIError.swift
@@ -33,7 +33,7 @@ public enum SnodeAPIError: Error, CustomStringConvertible {
     case invalidNetwork
     case invalidPayload
     case missingSecretKey
-    case nodeNotFound(String)
+    case nodeNotFound(Int?, String)
     case unassociatedPubkey
     case unableToRetrieveSwarm
 
@@ -70,7 +70,12 @@ public enum SnodeAPIError: Error, CustomStringConvertible {
             case .invalidNetwork: return "Unable to create network (SnodeAPIError.invalidNetwork)."
             case .invalidPayload: return "Invalid payload (SnodeAPIError.invalidPayload)."
             case .missingSecretKey: return "Missing secret key (SnodeAPIError.missingSecretKey)."
-            case .nodeNotFound(let nodePubkey): return "Next node was not found: \(nodePubkey) (SnodeAPIError.nodeNotFound)."
+            case .nodeNotFound(let nodeIndex, _):
+                switch nodeIndex {
+                    case .some(let index): return "Error in Onion request path, with hop \(index) (SnodeAPIError.nodeNotFound)."
+                    case .none: return "Error in Onion request path (SnodeAPIError.nodeNotFound)."
+                }
+                
             case .unassociatedPubkey: return "The service node is no longer associated with the public key (SnodeAPIError.unassociatedPubkey)."
             case .unableToRetrieveSwarm: return "Unable to retrieve the swarm for the given public key (SnodeAPIError.unableToRetrieveSwarm)."
         }


### PR DESCRIPTION
- Fixed some cases where errors weren't being displayed correctly
- Tweaked the "nodeNotFound" error to be a bit more human readable
- Tweaked the BackgroundPoller timeout to have a 5 second buffer instead of a 1 second buffer
- Moved the lastHash pruning into the GarbageCollectionJob instead of the pre-poll fetching to avoid needing to use a write query before polling
- Reworked the Pollers to make their database queries part of the polling stream (and as such, cancellable)