### PR TITLE
Fixed a SignalAttachment hash uniqueness issue, fixed attachment UX issues

### DIFF
--- a/Session/Media Viewing & Editing/SendMediaNavigationController.swift
+++ b/Session/Media Viewing & Editing/SendMediaNavigationController.swift
@@ -691,6 +691,7 @@ private class DoneButton: UIView {
     func updateCount() {
         guard let delegate = delegate else { return }
 
+        badge.themeBackgroundColor = (delegate.doneButtonCount > 0 ? .primary : .disabled)
         badgeLabel.text = numberFormatter.string(for: delegate.doneButtonCount)
     }
     
@@ -729,11 +730,14 @@ private class DoneButton: UIView {
     }
 
     @objc func didTap(tapGesture: UITapGestureRecognizer) {
+        guard (delegate?.doneButtonCount ?? 0) > 0 else { return }
+        
         delegate?.doneButtonWasTapped(self)
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         guard
+            (delegate?.doneButtonCount ?? 0) > 0,
             isUserInteractionEnabled,
             let location: CGPoint = touches.first?.location(in: self),
             bounds.contains(location)

--- a/SessionMessagingKit/Sending & Receiving/Attachments/SignalAttachment.swift
+++ b/SessionMessagingKit/Sending & Receiving/Attachments/SignalAttachment.swift
@@ -1140,11 +1140,11 @@ public class SignalAttachment: Equatable, Hashable {
         isConvertibleToContactShare.hash(into: &hasher)
         isVoiceMessage.hash(into: &hasher)
         
-        /// There was a crash in `AttachmentApprovalViewController when trying to generate the hash
+        /// There was a crash in `AttachmentApprovalViewController` when trying to generate the hash
         /// value to store in a dictionary, I'm guessing it's due to either `dataSource`, `cachedImage` or `cachedVideoPreview`
         /// so, instead of trying to hash them directly which involves unknown behaviours due to `NSObject` & `UIImage` types, this
         /// has been reworked to use primitives
-        dataSource.sourceFilename.hash(into: &hasher)
+        dataSource.uniqueId.hash(into: &hasher)
         cachedImage?.size.width.hash(into: &hasher)
         cachedImage?.size.height.hash(into: &hasher)
         cachedVideoPreview?.size.width.hash(into: &hasher)

--- a/SessionUtilitiesKit/Media/DataSource.h
+++ b/SessionUtilitiesKit/Media/DataSource.h
@@ -10,6 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface DataSource : NSObject
 
 @property (nonatomic, nullable) NSString *sourceFilename;
+@property (nonatomic) NSUUID *uniqueId;
 
 // Should not be called unless necessary as it can involve an expensive read.
 - (NSData *)data;

--- a/SessionUtilitiesKit/Media/DataSource.m
+++ b/SessionUtilitiesKit/Media/DataSource.m
@@ -124,6 +124,7 @@ NS_ASSUME_NONNULL_BEGIN
     instance.dataValue = data;
     instance.fileExtension = fileExtension;
     instance.shouldDeleteOnDeallocation = YES;
+    instance.uniqueId = [NSUUID UUID];
     return instance;
 }
 
@@ -246,6 +247,7 @@ NS_ASSUME_NONNULL_BEGIN
     DataSourcePath *instance = [DataSourcePath new];
     instance.filePath = fileUrl.path;
     instance.shouldDeleteOnDeallocation = shouldDeleteOnDeallocation;
+    instance.uniqueId = [NSUUID UUID];
     return instance;
 }
 
@@ -259,6 +261,7 @@ NS_ASSUME_NONNULL_BEGIN
     DataSourcePath *instance = [DataSourcePath new];
     instance.filePath = filePath;
     instance.shouldDeleteOnDeallocation = shouldDeleteOnDeallocation;
+    instance.uniqueId = [NSUUID UUID];
     return instance;
 }
 


### PR DESCRIPTION
- Fixed an issue where you could select 0 attachments and go to the "send attachment" screen
- Fixed an issue where returning from the "send attachment" screen wouldn't have the initially selected attachment selected
- Added a uniqueId to the DataSource so instances can be better distinguished from each other (not ideal as the same file would have separate identifiers)