### PR TITLE
Deduplicate IP2Country

### DIFF
--- a/Scripts/ProcessIP2CountryData.swift
+++ b/Scripts/ProcessIP2CountryData.swift
@@ -142,6 +142,7 @@ class Processor {
 
         /// Structure of the data should be `network,registered_country_geoname_id`
         let countryBlockPrefix: String = "Processing country blocks: "
+        var prevId: String? = nil
         lines[1...].enumerated().forEach { index, line in
             guard keepRunning else { return }
             
@@ -149,14 +150,22 @@ class Processor {
                 .trimmingCharacters(in: .whitespacesAndNewlines)
                 .components(separatedBy: ",")
             
+            let currId = values[1]
+            
             guard
                 values.count == 2,
                 let ipNoSubnetMask: String = values[0].components(separatedBy: "/").first,
                 let ipAsInt: Int = IPv4.toInt(ipNoSubnetMask)
             else { return }
             
-            cache.countryBlocksIPInt.append(ipAsInt)
-            cache.countryBlocksGeonameId.append(values[1])
+            if prevId == currId {
+                cache.countryBlocksIPInt[cache.countryBlocksIPInt.count - 1] = ipAsInt
+            } else {
+                cache.countryBlocksIPInt.append(ipAsInt)
+                cache.countryBlocksGeonameId.append(currId)
+            }
+            
+            prevId = currId
             
             let progress = (Double(index) / Double(lines.count))
             printProgressBar(prefix: countryBlockPrefix, progress: progress, total: (terminalWidth - 10))


### PR DESCRIPTION
This PR removes unnecessary IP repetitions, saving 6MB in the `.ipa` and reduces initial file read from `230ms` to `50ms` in one test on simulator, and reduces worst case time to find each path from `25ms` to `8ms` in one test.

Looking at [this line](https://github.com/oxen-io/session-ios/blob/2544cd6bc8deb28c9722d27eebd1c1e91fa2f9f7/Session/Utilities/IP2Country.swift#L155), we don't need to keep all of the sequential IPs that have the same id, we can just keep the largest one, and that index will have the same id as the omitted entries, so 🎉 

### before
```
Execution time: 0.23808503150939941 seconds <- initial processing
Execution time: 0.00807797908782959 seconds
Execution time: 0.025856971740722656 seconds
Execution time: 0.008671998977661133 seconds
Execution time: 0.014480948448181152 seconds
Execution time: 0.018723011016845703 seconds
Execution time: 0.004633069038391113 seconds
```

### after
```
Execution time: 0.05160403251647949 seconds <- initial processing
Execution time: 0.0013350248336791992 seconds
Execution time: 0.008152008056640625 seconds
Execution time: 0.0023429393768310547 seconds
Execution time: 0.003697991371154785 seconds
Execution time: 0.003881096839904785 seconds
Execution time: 0.0021229982376098633 seconds
```
