### PR TITLE
Removed the codecov setup

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -89,36 +89,11 @@ local sim_delete_cmd = 'if [ -f build/artifacts/sim_uuid ]; then rm -f /Users/$U
         },
       },
       {
-        name: 'Install Codecov CLI',
-        commands: [
-          'mkdir -p build/artifacts',
-          'pip3 install codecov-cli',
-          'find $HOME/Library/Python -name codecovcli -print -quit > ./build/artifacts/codecov_path',
-          |||
-            if [[ ! -s ./build/artifacts/codecov_path ]]; then
-              which codecovcli > ./build/artifacts/codecov_path
-            fi
-          |||,
-          '$(<./build/artifacts/codecov_path) --version',
-        ],
-      },
-      {
         name: 'Convert xcresult to xml',
         commands: [
           'xcresultparser --output-format cobertura ./build/artifacts/testResults.xcresult > ./build/artifacts/coverage.xml',
         ],
         depends_on: ['Build and Run Tests'],
-      },
-      {
-        // No token needed for public repos
-        name: 'Upload coverage to Codecov',
-        commands: [
-          '$(<./build/artifacts/codecov_path) upload-process --fail-on-error -f ./build/artifacts/coverage.xml',
-        ],
-        depends_on: [
-          'Convert xcresult to xml',
-          'Install Codecov CLI',
-        ],
       },
     ],
   },


### PR DESCRIPTION
Looks like the requirements for Codecov changed slightly and we now need to provide a proper token - will be nice to add this back at some point but will have to wait until we have time to properly configure it