### PR TITLE
Fixed a bug with return from background logs

### DIFF
--- a/SessionUtilitiesKit/General/Logging.swift
+++ b/SessionUtilitiesKit/General/Logging.swift
@@ -68,8 +68,8 @@ public enum Log {
     private static var pendingStartupLogs: Atomic<[LogInfo]> = Atomic([])
     
     public static func setup(with logger: Logger) {
-        logger.retrievePendingStartupLogs.mutate {
-            $0 = {
+        logger.pendingLogsRetriever.mutate { callback in
+            callback = {
                 pendingStartupLogs.mutate { pendingStartupLogs in
                     let logs: [LogInfo] = pendingStartupLogs
                     pendingStartupLogs = []
@@ -344,7 +344,7 @@ public class Logger {
     private let systemLoggers: Atomic<[String: SystemLoggerType]> = Atomic([:])
     fileprivate let fileLogger: DDFileLogger
     fileprivate let isSuspended: Atomic<Bool> = Atomic(true)
-    fileprivate let retrievePendingStartupLogs: Atomic<(() -> [Log.LogInfo])?> = Atomic(nil)
+    fileprivate let pendingLogsRetriever: Atomic<(() -> [Log.LogInfo])?> = Atomic(nil)
     
     public init(
         primaryPrefix: String,
@@ -483,11 +483,7 @@ public class Logger {
             isSuspended = false
             
             // Retrieve any logs that were added during
-            return retrievePendingStartupLogs.mutate { retriever in
-                let result: [Log.LogInfo] = (retriever?() ?? [])
-                retriever = nil
-                return result
-            }
+            return pendingLogsRetriever.mutate { retriever in (retriever?() ?? []) }
         }
         
         // If we had an error loading the extension logs then actually log it


### PR DESCRIPTION
Fixed a bug where logs sent before the logger finishes setting up after returning from the background weren't getting added to the log file