### PR TITLE
Refactored the LintLocalizableStrings script

### DIFF
--- a/Scripts/LintLocalizableStrings.swift
+++ b/Scripts/LintLocalizableStrings.swift
@@ -11,13 +11,28 @@
 /// 3. Functionality to update and copy localized permission requirement strings to infoPlist.xcstrings
 
 import Foundation
+import Dispatch
 
 typealias JSON = [String:AnyHashable]
 
 extension ProjectState {
-    /// Adding `// stringlint:disable` to the top of a source file (before imports) or after a string will mean that file/line gets
-    /// ignored by this script (good for some things like the auto-generated emoji strings or debug strings)
-    static let lintSuppression: String = "stringlint:disable"
+    /// Linting control commands
+    enum LintControl: String, CaseIterable {
+        /// Add `// stringlint:disable` to the top of a source file (before imports) to make this script ignore a file
+        case disable = "stringlint:disable"
+        
+        /// Add `// stringlint:ignore` after a line to ignore it
+        case ignoreLine = "stringlint:ignore"
+        
+        /// Add `// stringlint:ignore_start` and `// stringlint:ignore_stop` before and after a
+        /// lines of code to make this script ignore the contents for string linting purposes
+        case ignoreStart = "stringlint:ignore_start"
+        case ignoreStop = "stringlint:ignore_stop"
+        
+        /// Add `// stringlint:ignore_contents` before anything with curly braces (eg. function, class, closure, etc.)
+        /// to everything within the curly braces
+        case ignoreContents = "stringlint:ignore_contents"
+    }
     static let primaryLocalisation: String = "en"
     static let permissionStrings: Set<String> = [
         "permissionsStorageSend",
@@ -47,29 +62,18 @@ extension ProjectState {
         "_SharedTestUtilities/",    // Exclude shared test directory
         "external/"                 // External dependencies
     ]
-    static let excludedPhrases: Set<String> = [ "", " ", "  ", ",", ", ", "null", "\"", "@[0-9a-fA-F]{66}", "^[0-9A-Fa-f]+$", "/" ]
-    static let excludedUnlocalizedStringLineMatching: Set<MatchType> = [
-        .contains(ProjectState.lintSuppression, caseSensitive: false),
+    static let excludedPhrases: Set<String> = ["", " ", "  ", ",", ", ", "null", "\"", "@[0-9a-fA-F]{66}", "^[0-9A-Fa-f]+$", "/"]
+    static let excludedUnlocalizedStringLineMatching: [MatchType] = [
         .prefix("#import", caseSensitive: false),
         .prefix("@available(", caseSensitive: false),
+        .prefix("print(", caseSensitive: false),
+        .prefix("Log.Category =", caseSensitive: false),
         .contains("fatalError(", caseSensitive: false),
         .contains("precondition(", caseSensitive: false),
         .contains("preconditionFailure(", caseSensitive: false),
-        .contains("print(", caseSensitive: false),
-        .contains("SNLog(", caseSensitive: false),
-        .contains("Log.setup(", caseSensitive: false),
-        .contains("Log.verbose(", caseSensitive: false),
-        .contains("Log.debug(", caseSensitive: false),
-        .contains("Log.info(", caseSensitive: false),
-        .contains("Log.warn(", caseSensitive: false),
-        .contains("Log.error(", caseSensitive: false),
-        .contains("Log.critical(", caseSensitive: false),
-        .contains("Log.Category =", caseSensitive: false),
         .contains("logMessage:", caseSensitive: false),
         .contains("owsFailDebug(", caseSensitive: false),
         .contains("#imageLiteral(resourceName:", caseSensitive: false),
-        .contains("UIImage(named:", caseSensitive: false),
-        .contains("UIImage(systemName:", caseSensitive: false),
         .contains("[UIImage imageNamed:", caseSensitive: false),
         .contains("UIFont(name:", caseSensitive: false),
         .contains(".dateFormat =", caseSensitive: false),
@@ -84,39 +88,37 @@ extension ProjectState {
         .contains("Notification.Name(", caseSensitive: false),
         .contains("Notification.Key(", caseSensitive: false),
         .contains("DispatchQueue(", caseSensitive: false),
-        .containsAnd(
-            "identifier:",
-            caseSensitive: false,
-            .previousLine(numEarlier: 1, .contains("Accessibility(", caseSensitive: false))
+        .and(
+            .prefix("static let identifier: String = ", caseSensitive: false),
+            .previousLine(numEarlier: 2, .suffix(": Migration {", caseSensitive: false))
         ),
-        .containsAnd(
-            "label:",
-            caseSensitive: false,
-            .previousLine(numEarlier: 1, .contains("Accessibility(", caseSensitive: false))
+        .and(
+            .contains("identifier:", caseSensitive: false),
+            .previousLine(.contains("Accessibility(", caseSensitive: false))
         ),
-        .containsAnd(
-            "label:",
-            caseSensitive: false,
+        .and(
+            .contains("label:", caseSensitive: false),
+            .previousLine(.contains("Accessibility(", caseSensitive: false))
+        ),
+        .and(
+            .contains("label:", caseSensitive: false),
             .previousLine(numEarlier: 2, .contains("Accessibility(", caseSensitive: false))
         ),
         .contains("SQL(", caseSensitive: false),
-        .contains(" == ", caseSensitive: false),
         .contains("forResource:", caseSensitive: false),
         .contains("imageName:", caseSensitive: false),
+        .contains("systemName:", caseSensitive: false),
         .contains(".userInfo[", caseSensitive: false),
         .contains("payload[", caseSensitive: false),
         .contains(".infoDictionary?[", caseSensitive: false),
         .contains("accessibilityId:", caseSensitive: false),
-        .contains("key:", caseSensitive: false),
-        .contains("separator:", caseSensitive: false),
-        .contains("separatedBy:", caseSensitive: false),
-        .nextLine(.contains(".put(key:", caseSensitive: false)),
-        .nextLine(.contains(".putNumber(", caseSensitive: false)),
-        .nextLine(.contains(".localized()", caseSensitive: false)),
-        .regex(".*static var databaseTableName: String"),
-        .regex("case .* = "),
-        .regex("Error.*\\("),
-        .belowLineContaining("PreviewProvider")
+        .belowLineContaining("PreviewProvider"),
+        .regex(Regex.logging),
+        .regex(Regex.errorCreation),
+        .regex(Regex.databaseTableName),
+        .regex(Regex.enumCaseDefinition),
+        .regex(Regex.imageInitialization),
+        .regex(Regex.variableToStringConversion)
     ]
 }
 
@@ -131,12 +133,9 @@ let targetActions: Set<ScriptAction> = {
 }()
 
 print("------------ Searching Through Files ------------")
-let projectState: ProjectState = ProjectState(
-    path: (
-        ProcessInfo.processInfo.environment["PROJECT_DIR"] ??
-        FileManager.default.currentDirectoryPath
-    ),
-    loadSourceFiles: targetActions.contains(.lintStrings)
+let projectState: ProjectState = ProjectState(path:
+    ProcessInfo.processInfo.environment["PROJECT_DIR"] ??
+    FileManager.default.currentDirectoryPath
 )
 print("------------ Processing \(projectState.localizationFile.path) ------------")
 targetActions.forEach { $0.perform(projectState: projectState) }
@@ -205,10 +204,19 @@ enum ScriptAction: String {
                         if let original: String = ((localizations["en"] as? JSON)?["stringUnit"] as? JSON)?["value"] as? String {
                             localizations.forEach { locale, translation in
                                 if let phrase: String = ((translation as? JSON)?["stringUnit"] as? JSON)?["value"] as? String {
-                                    let numberOfVarablesOrignal = Regex.matches("\\{.*\\}", content: original).count
-                                    let numberOfVarablesPhrase = Regex.matches("\\{.*\\}", content: phrase).count
+                                    // Zero-width characters can mess with regex matching so we need to clean them
+                                    // out before matching
+                                    let numberOfVarablesOrignal: Int = original
+                                        .removingUnwantedScalars()
+                                        .matches(of: Regex.dynamicStringVariable)
+                                        .count
+                                    let numberOfVarablesPhrase: Int = phrase
+                                        .removingUnwantedScalars()
+                                        .matches(of: Regex.dynamicStringVariable)
+                                        .count
+                                    
                                     if numberOfVarablesPhrase != numberOfVarablesOrignal {
-                                        Output.warning("\(key) in \(locale) may be faulty")
+                                        Output.warning("\(key) in \(locale) may be faulty ('\(original)' contains \(numberOfVarablesOrignal) vs. '\(phrase)' contains \(numberOfVarablesPhrase))")
                                     }
                                 }
                             }
@@ -220,11 +228,15 @@ enum ScriptAction: String {
                 duplicates.forEach { Output.duplicate(key: $0) }
 
                 // Process the source code
-                print("------------ Processing \(projectState.sourceFiles.count) Source File(s) ------------")
+                print("------------ Processing Source Files ------------")
+                let results = projectState.lintSourceFiles()
+                print("------------ Processed \(results.sourceFiles.count) File(s), Ignored \(results.ignoredPaths.count) File(s) ------------")
+                var totalUnlocalisedStrings: Int = 0
   
-                projectState.sourceFiles.forEach { file in
+                results.sourceFiles.forEach { file in
                     // Add logs for unlocalized strings
                     file.unlocalizedPhrases.forEach { phrase in
+                        totalUnlocalisedStrings += 1
                         Output.warning(phrase, "Found unlocalized string '\(phrase.key)'")
                     }
                     
@@ -237,6 +249,8 @@ enum ScriptAction: String {
                         }
                     }
                 }
+                
+                print("------------ Found \(totalUnlocalisedStrings) unlocalized string(s) ------------")
                 break
             case .updatePermissionStrings:
                 print("------------ Updating permission strings ------------")
@@ -281,25 +295,31 @@ enum ScriptAction: String {
 // MARK: - Functionality
 
 enum Regex {
+    // Initializing these as static variables means we don't init them every time they are used
+    // which can speed up processing
+    static let comment = #/\/\/[^"]*(?:"[^"]*"[^"]*)*/#
+    static let allStrings = #/"[^"\\]*(?:\\.[^"\\]*)*"/#
+    static let localizedString = #/^(?:\.put(?:Number)?\([^)]+\))*\.localized/#
+    static let localizedFunctionCall = #/\.localized(?:Formatted)?\(.*\)/#
+    
+    static let logging = #/(?:SN)?Log.*\(/#
+    static let errorCreation = #/Error.*\(/#
+    static let databaseTableName = #/.*static var databaseTableName: String/#
+    static let enumCaseDefinition = #/case .* = /#
+    static let imageInitialization = #/(?:UI)?Image\((?:named:)?(?:imageName:)?(?:systemName:)?.*\)/#
+    static let variableToStringConversion = #/"\\(.*)"/#
+    
+    static let dynamicStringVariable = #/\{\w+\}/#
+    
     /// Returns a list of strings that match regex pattern from content
     ///
     /// - Parameters:
     ///   - pattern: regex pattern
     ///   - content: content to match
     /// - Returns: list of results
-    static func matches(_ pattern: String, content: String) -> [String] {
-        guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else {
-            fatalError("Regex not formatted correctly: \(pattern)")
-        }
-        
-        let matches = regex.matches(in: content, options: [], range: NSRange(location: 0, length: content.utf16.count))
-        
-        return matches.map {
-            guard let range = Range($0.range(at: 0), in: content) else {
-                fatalError("Incorrect range match")
-            }
-            
-            return String(content[range])
+    static func matches(_ regex: some RegexComponent, content: String) -> [String] {
+        return content.matches(of: regex).map { match in
+            String(content[match.range])
         }
     }
 }
@@ -342,11 +362,13 @@ enum Output {
 // MARK: - ProjectState
 
 struct ProjectState {
-    let sourceFiles: [SourceFile]
+    let queue = DispatchQueue(label: "session.stringlint", attributes: .concurrent)
+    let group = DispatchGroup()
+    let validFileUrls: [URL]
     let localizationFile: XCStringsFile
     let infoPlistLocalizationFile: XCStringsFile
     
-    init(path: String, loadSourceFiles: Bool) {
+    init(path: String) {
         guard
             let enumerator: FileManager.DirectoryEnumerator = FileManager.default.enumerator(
                 at: URL(fileURLWithPath: path),
@@ -358,7 +380,7 @@ struct ProjectState {
         
         // Get a list of valid URLs
         let lowerCaseExcludedPaths: Set<String> = Set(ProjectState.excludedPaths.map { $0.lowercased() })
-        let validFileUrls: [URL] = fileUrls.filter { fileUrl in
+        validFileUrls = fileUrls.filter { fileUrl in
             ((try? fileUrl.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == false) &&
             !lowerCaseExcludedPaths.contains { fileUrl.path.lowercased().contains($0) }
         }
@@ -372,17 +394,29 @@ struct ProjectState {
             .filter { fileUrl in fileUrl.path.contains("InfoPlist.xcstrings") }
             .map { XCStringsFile(path: $0.path) }
             .last!
-        
-        guard loadSourceFiles else {
-            self.sourceFiles = []
-            return
-        }
-        
-        // Source files
+    }
+    
+    func lintSourceFiles() -> (sourceFiles: [SourceFile], ignoredPaths: [String]) {
+        let resultLock: NSLock = NSLock()
         let lowerCaseSourceSuffixes: Set<String> = Set(ProjectState.validSourceSuffixes.map { $0.lowercased() })
-        self.sourceFiles = validFileUrls
+        var results: [(path: String, file: SourceFile?)] = []
+        validFileUrls
             .filter { fileUrl in lowerCaseSourceSuffixes.contains(".\(fileUrl.pathExtension)") }
-            .compactMap { SourceFile(path: $0.path) }
+            .forEach { fileUrl in
+                queue.async(group: group) {
+                    let file: SourceFile? = SourceFile(path: fileUrl.path)
+                    resultLock.lock()
+                    results.append((fileUrl.path, file))
+                    resultLock.unlock()
+                }
+            }
+        
+        group.wait()
+        
+        let sourceFiles: [SourceFile] = results.compactMap { _, file in file }
+        let ignoredPaths: [String] = results.filter { _, file in file == nil }.map { path, _ in path }
+        
+        return (sourceFiles, ignoredPaths)
     }
 }
 
@@ -434,6 +468,19 @@ extension ProjectState {
     // MARK: - SourceFile
     
     struct SourceFile: Locatable {
+        struct LintState {
+            var isDisabled: Bool = false
+            var isInIgnoredSection: Bool = false
+            var isInIgnoredContents: Bool = false
+            var ignoredContentsDepth: Int = 0
+        }
+        
+        struct TemplateStringState {
+            var key: String
+            var lineNumber: Int
+            var chainedCalls: [String]
+        }
+        
         struct Phrase: KeyedLocatable {
             let term: String
             let filePath: String
@@ -470,8 +517,7 @@ extension ProjectState {
             // If the file has the lint supression before the first import then ignore the file
             let preImportContent: String = (content.components(separatedBy: "import").first ?? "")
             
-            guard !preImportContent.contains(ProjectState.lintSuppression) else {
-                print("Explicitly ignoring \(path)")
+            guard !preImportContent.contains(ProjectState.LintControl.disable.rawValue) else {
                 return nil
             }
             
@@ -481,124 +527,275 @@ extension ProjectState {
             var unlocalizedKeyPhrase: [String: Phrase] = [:]
             var phrases: [Phrase] = []
             var unlocalizedPhrases: [Phrase] = []
+            var lintState = LintState()
+            var templateState: TemplateStringState?
             
             lines.enumerated().forEach { lineNumber, line in
                 let trimmedLine: String = line.trimmingCharacters(in: .whitespacesAndNewlines)
                 
-                // Ignore the line if it doesn't contain a quotation character (optimisation), it's
-                // been suppressed or it's explicitly excluded due to the rules at the top of the file
+                // Check for lint control commands
+                if let controlCommand: ProjectState.LintControl = checkLintControl(line: trimmedLine) {
+                    updateLintState(&lintState, command: controlCommand, line: trimmedLine)
+                    return
+                }
+                
+                // Track function depth for ignored functions
+                if lintState.isInIgnoredContents {
+                    updateContentsDepth(&lintState, line: trimmedLine)
+                }
+                
+                // Skip linting if disabled
+                guard !shouldSkipLinting(state: lintState) else { return }
+                
+                // Skip lines without quotes (optimization)
+                guard trimmedLine.contains("\"") else { return }
+                
+                // Skip explicitly excluded lines
                 guard
-                    trimmedLine.contains("\"") &&
                     !ProjectState.excludedUnlocalizedStringLineMatching
                         .contains(where: { $0.matches(trimmedLine, lineNumber, lines) })
                 else { return }
                 
-                // Split line based on commented out content and exclude the comment from the linting
-                let commentMatches: [String] = Regex.matches(
-                    "//[^\\\"]*(?:\\\"[^\\\"]*\\\"[^\\\"]*)*",
-                    content: line
+                // Process the line for strings
+                processLine(
+                    line: line,
+                    lineNumber: lineNumber,
+                    path: path,
+                    keyPhrase: &keyPhrase,
+                    unlocalizedKeyPhrase: &unlocalizedKeyPhrase,
+                    phrases: &phrases,
+                    unlocalizedPhrases: &unlocalizedPhrases,
+                    templateState: &templateState,
+                    lines: lines
                 )
-                let targetLine: String = (commentMatches.isEmpty ? line :
-                    line.components(separatedBy: commentMatches[0])[0]
-                )
-                
-                // Use regex to find `NSLocalizedString("", "")`, `"".localized()` and any other `""`
-                // values in the source code
-                //
-                // Note: It's more complex because we need to exclude escaped quotation marks from
-                // strings and also want to ignore any strings that have been commented out, Swift
-                // also doesn't support "lookbehind" in regex so we can use that approach
-                var isUnlocalized: Bool = false
-                var allMatches: Set<String> = Set(
-                    Regex
-                        .matches(
-                            "NSLocalizedString\\(@{0,1}\\\"[^\\\"\\\\]*(?:\\\\.[^\\\"\\\\]*)*(?:\\\")",
-                            content: targetLine
-                        )
-                        .map { match in
-                            match
-                                .removingPrefixIfPresent("NSLocalizedString(@\"")
-                                .removingPrefixIfPresent("NSLocalizedString(\"")
-                                .removingSuffixIfPresent("\")")
-                                .removingSuffixIfPresent("\"")
-                        }
-                )
-                
-                // If we didn't get any matches for the standard `NSLocalizedString` then try our
-                // custom extension `"".localized()`
-                if allMatches.isEmpty {
-                    allMatches = allMatches.union(Set(
-                        Regex
-                            .matches(
-                                "\\\"[^\\\"\\\\]*(?:\\\\.[^\\\"\\\\]*)*\\\"\\.localized",
-                                content: targetLine
-                            )
-                            .map { match in
-                                match
-                                    .removingPrefixIfPresent("\"")
-                                    .removingSuffixIfPresent("\".localized")
-                            }
-                    ))
-                }
-                
-                /// If we still don't have any matches then try to match any strings as unlocalized strings (handling
-                /// nested `"Test\"string\" value"`, empty strings and strings only composed of quotes `"""""""`)
-                ///
-                /// **Note:** While it'd be nice to have the regex automatically exclude the quotes doing so makes it _far_ less
-                /// efficient (approx. by a factor of 8 times) so we remove those ourselves)
-                if allMatches.isEmpty {
-                    // Find strings which are just not localized
-                    let potentialUnlocalizedStrings: [String] = Regex
-                        .matches("\\\"[^\\\"\\\\]*(?:\\\\.[^\\\"\\\\]*)*(?:\\\")", content: targetLine)
-                        // Remove the leading and trailing quotation marks
-                        .map { $0.removingPrefixIfPresent("\"").removingSuffixIfPresent("\"") }
-                        // Remove any empty strings
-                        .filter { !$0.isEmpty }
-                        // Remove any string conversations (ie. `.map { "\($0)" }`
-                        .filter { value in !value.hasPrefix("\\(") || !value.hasSuffix(")") }
-                    
-                    allMatches = allMatches.union(Set(potentialUnlocalizedStrings))
-                    isUnlocalized = true
-                }
-                
-                // Remove any excluded phrases from the matches
-                allMatches = allMatches.subtracting(ProjectState.excludedPhrases.map { "\($0)" })
-                
-                allMatches.forEach { match in
-                    // Files are 1-indexed but arrays are 0-indexed so add 1 to the lineNumber
-                    let result: Phrase = Phrase(
-                        term: match,
-                        filePath: path,
-                        lineNumber: (lineNumber + 1)
-                    )
-                    
-                    if !isUnlocalized {
-                        keyPhrase[match] = result
-                        phrases.append(result)
-                    }
-                    else {
-                        unlocalizedKeyPhrase[match] = result
-                        unlocalizedPhrases.append(result)
-                    }
-                }
             }
             
             return (keyPhrase, phrases, unlocalizedKeyPhrase, unlocalizedPhrases)
         }
+        
+        private static func checkLintControl(line: String) -> ProjectState.LintControl? {
+            /// Need to sort by length to ensure we don't unintentionally detect one control mechanism over another
+            /// due to it containing the full other command - eg. `disable_start` vs `disable`
+            ProjectState.LintControl.allCases
+                .sorted { lhs, rhs in lhs.rawValue.count > rhs.rawValue.count }
+                .first { line.contains($0.rawValue) }
+        }
+        
+        private static func updateLintState(_ state: inout LintState, command: ProjectState.LintControl, line: String) {
+            switch command {
+                case .disable: state.isDisabled = true
+                case .ignoreStart: state.isInIgnoredSection = true
+                case .ignoreStop: state.isInIgnoredSection = false
+                case .ignoreContents:
+                    guard !state.isInIgnoredContents else { return }
+                    
+                    state.isInIgnoredContents = true
+                    state.ignoredContentsDepth = 0
+                    
+                case .ignoreLine: break // Handle single-line ignore in the caller
+            }
+        }
+        
+        private static func updateContentsDepth(_ state: inout LintState, line: String) {
+            if line.contains("{") {
+                state.ignoredContentsDepth += 1
+            }
+            if line.contains("}") {
+                state.ignoredContentsDepth -= 1
+                if state.ignoredContentsDepth == 0 {
+                    state.isInIgnoredContents = false
+                }
+            }
+        }
+        
+        private static func shouldSkipLinting(state: LintState) -> Bool {
+            state.isDisabled || state.isInIgnoredSection || state.isInIgnoredContents
+        }
+        
+        private static func processLine(
+            line: String,
+            lineNumber: Int,
+            path: String,
+            keyPhrase: inout [String: Phrase],
+            unlocalizedKeyPhrase: inout [String: Phrase],
+            phrases: inout [Phrase],
+            unlocalizedPhrases: inout [Phrase],
+            templateState: inout TemplateStringState?,
+            lines: [String]
+        ) {
+            // Handle commented sections
+            let commentMatches = line.matches(of: Regex.comment)
+            let targetLine: String = (commentMatches.isEmpty ?
+                line :
+                String(line[..<commentMatches[0].range.lowerBound])
+            )
+            
+            switch templateState {
+                case .none:
+                    // Extract the strings and remove any excluded phrases
+                    let keyMatches: [String] = extractMatches(from: targetLine, with: Regex.allStrings)
+                        .filter { !ProjectState.excludedPhrases.contains($0) }
+                    
+                    if !keyMatches.isEmpty {
+                        // Iterate through each match to determine localization
+                        for match in keyMatches {
+                            // Find the range of the matched string
+                            if let range = targetLine.range(of: "\"\(match)\"") {
+                                // Check if .localized or a template func is called immediately following
+                                // this specific string
+                                let afterString = targetLine[range.upperBound...]
+                                let isLocalized: Bool = (afterString.firstMatch(of: Regex.localizedString) != nil)
+                                
+                                if isLocalized {
+                                    // Add as a localized phrase
+                                    let phrase = Phrase(
+                                        term: match,
+                                        filePath: path,
+                                        lineNumber: lineNumber + 1 // Files are 1-indexed so add 1 to lineNumber
+                                    )
+                                    keyPhrase[match] = phrase
+                                    phrases.append(phrase)
+                                    return
+                                }
+                                else if (match != keyMatches.last) {
+                                    // There is another string after this one so this couldn't be localized
+                                    // or a multi-line template
+                                    let unlocalizedPhrase = Phrase(
+                                        term: match,
+                                        filePath: path,
+                                        lineNumber: lineNumber + 1 // Files are 1-indexed so add 1 to lineNumber
+                                    )
+                                    unlocalizedKeyPhrase[match] = unlocalizedPhrase
+                                    unlocalizedPhrases.append(unlocalizedPhrase)
+                                }
+                                else {
+                                    // Look ahead to verify if put/putNumber/localized are called in the next lines
+                                    let lookAheadLimit: Int = 2
+                                    var isTemplateChain: Bool = false
+                                    
+                                    for offset in 1...lookAheadLimit {
+                                        let lookAheadIndex: Int = lineNumber + offset
+                                        
+                                        if lookAheadIndex < lines.count {
+                                            let lookAheadLine = lines[lookAheadIndex].trimmingCharacters(in: .whitespacesAndNewlines)
+                                            
+                                            if
+                                                lookAheadLine.hasPrefix(".put(") ||
+                                                lookAheadLine.hasPrefix(".putNumber(") ||
+                                                lookAheadLine.hasPrefix(".localized")
+                                            {
+                                                isTemplateChain = true
+                                                break
+                                            }
+                                        }
+                                    }
+                                    
+                                    if isTemplateChain {
+                                        templateState = TemplateStringState(
+                                            key: keyMatches[0],
+                                            lineNumber: lineNumber,
+                                            chainedCalls: []
+                                        )
+                                        return
+                                    }
+                                    else {
+                                        // We didn't find any of the expected functions when looking ahead
+                                        // so we can assume it's an unlocalised string
+                                        let unlocalizedPhrase = Phrase(
+                                            term: match,
+                                            filePath: path,
+                                            lineNumber: lineNumber + 1 // Files are 1-indexed so add 1 to lineNumber
+                                        )
+                                        unlocalizedKeyPhrase[match] = unlocalizedPhrase
+                                        unlocalizedPhrases.append(unlocalizedPhrase)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                        
+                case .some(let state):
+                    switch targetLine.firstMatch(of: Regex.localizedFunctionCall) {
+                        case .some:
+                            // We finished the change so add as a localized phrase
+                            let phrase = Phrase(
+                                term: state.key,
+                                filePath: path,
+                                lineNumber: state.lineNumber + 1 // Files are 1-indexed so add 1 to lineNumber
+                            )
+                            keyPhrase[state.key] = phrase
+                            phrases.append(phrase)
+                            templateState = nil
+                            
+                        case .none:
+                            // The chain is still going to append the line
+                            templateState?.chainedCalls.append(targetLine)
+                    }
+            }
+        }
+        
+        private static func extractMatches(from line: String, with regex: some RegexComponent) -> [String] {
+            return line.matches(of: regex).map { match in
+                // Clean up the matches
+                return String(line[match.range])
+                    .removingPrefixIfPresent("NSLocalizedString(@\"")
+                    .removingPrefixIfPresent("NSLocalizedString(\"")
+                    .removingPrefixIfPresent("\"")
+                    .removingSuffixIfPresent("\".localized")
+                    .removingSuffixIfPresent("\")")
+                    .removingSuffixIfPresent("\"")
+            }
+        }
+        
+        private static func createPhrases(
+            from matches: Set<String>,
+            isUnlocalized: Bool,
+            lineNumber: Int,
+            path: String,
+            keyPhrase: inout [String: Phrase],
+            unlocalizedKeyPhrase: inout [String: Phrase],
+            phrases: inout [Phrase],
+            unlocalizedPhrases: inout [Phrase]
+        ) {
+            matches.forEach { match in
+                let result = Phrase(
+                    term: match,
+                    filePath: path,
+                    lineNumber: lineNumber + 1
+                )
+                
+                if !isUnlocalized {
+                    keyPhrase[match] = result
+                    phrases.append(result)
+                } else {
+                    unlocalizedKeyPhrase[match] = result
+                    unlocalizedPhrases.append(result)
+                }
+            }
+        }
     }
 }
 
-indirect enum MatchType: Hashable {
+indirect enum MatchType {
+    case and(MatchType, MatchType)
     case prefix(String, caseSensitive: Bool)
+    case suffix(String, caseSensitive: Bool)
     case contains(String, caseSensitive: Bool)
-    case containsAnd(String, caseSensitive: Bool, MatchType)
-    case regex(String)
+    case regex(any RegexComponent)
     case previousLine(numEarlier: Int, MatchType)
-    case nextLine(MatchType)
+    case nextLine(numLater: Int, MatchType)
     case belowLineContaining(String)
+    
+    static func previousLine(_ type: MatchType) -> MatchType { return .previousLine(numEarlier: 1, type) }
+    static func nextLine(_ type: MatchType) -> MatchType { return .nextLine(numLater: 1, type) }
     
     func matches(_ value: String, _ index: Int, _ lines: [String]) -> Bool {
         switch self {
+            case .and(let firstMatch, let secondMatch):
+                guard firstMatch.matches(value, index, lines) else { return false }
+                
+                return secondMatch.matches(value, index, lines)
+                
             case .prefix(let prefix, false):
                 return value
                     .lowercased()
@@ -610,18 +807,19 @@ indirect enum MatchType: Hashable {
                     .trimmingCharacters(in: .whitespacesAndNewlines)
                     .hasPrefix(prefix)
                 
+            case .suffix(let suffix, false):
+                return value
+                    .lowercased()
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .hasSuffix(suffix.lowercased())
+                
+            case .suffix(let suffix, true):
+                return value
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .hasSuffix(suffix)
+                
             case .contains(let other, false): return value.lowercased().contains(other.lowercased())
             case .contains(let other, true): return value.contains(other)
-            case .containsAnd(let other, false, let otherMatch):
-                guard value.lowercased().contains(other.lowercased()) else { return false }
-                
-                return otherMatch.matches(value, index, lines)
-                
-            case .containsAnd(let other, true, let otherMatch):
-                guard value.contains(other) else { return false }
-                
-                return otherMatch.matches(value, index, lines)
-                
             case .regex(let regex): return !Regex.matches(regex, content: value).isEmpty
                 
             case .previousLine(let numEarlier, let type):
@@ -630,9 +828,11 @@ indirect enum MatchType: Hashable {
                 let targetIndex: Int = (index - numEarlier)
                 return type.matches(lines[targetIndex], targetIndex, lines)
             
-            case .nextLine(let type):
-                guard index + 1 < lines.count else { return false }
-                return type.matches(lines[index + 1], index + 1, lines)
+            case .nextLine(let numLater, let type):
+                guard index + numLater < lines.count else { return false }
+                
+                let targetIndex: Int = (index + numLater)
+                return type.matches(lines[targetIndex], targetIndex, lines)
             
             case .belowLineContaining(let other):
                 return lines[0..<index].contains(where: { $0.lowercased().contains(other.lowercased()) })
@@ -651,5 +851,15 @@ extension String {
         guard hasSuffix(value) else { return self }
         
         return String(self.prefix(upTo: self.index(self.endIndex, offsetBy: -value.count)))
+    }
+    
+    func removingUnwantedScalars() -> String {
+        let unwantedScalars: Set<Unicode.Scalar> = [
+            "\u{200B}", // ZERO WIDTH SPACE
+            "\u{200C}", // ZERO WIDTH NON-JOINER
+            "\u{200D}", // ZERO WIDTH JOINER
+            "\u{FEFF}"  // ZERO WIDTH NO-BREAK SPACE
+        ]
+        return String(self.unicodeScalars.filter { !unwantedScalars.contains($0) }.map { Character($0) })
     }
 }

--- a/Session/Calls/Call Management/SessionCall.swift
+++ b/Session/Calls/Call Management/SessionCall.swift
@@ -180,9 +180,10 @@ public final class SessionCall: CurrentCallProtocol, WebRTCSessionDelegate {
         }
     }
     
+    // stringlint:ignore_contents
     func reportIncomingCallIfNeeded(completion: @escaping (Error?) -> Void) {
         guard case .answer = mode else {
-            SessionCallManager.reportFakeCall(info: "Call not in answer mode") // stringlint:disable
+            SessionCallManager.reportFakeCall(info: "Call not in answer mode")
             return
         }
         

--- a/Session/Calls/Call Management/SessionCallManager.swift
+++ b/Session/Calls/Call Management/SessionCallManager.swift
@@ -44,7 +44,7 @@ public final class SessionCallManager: NSObject, CallManagerProtocol {
     }
     
     static func buildProviderConfiguration(useSystemCallLog: Bool) -> CXProviderConfiguration {
-        let providerConfiguration = CXProviderConfiguration(localizedName: "Session") // stringlint:disable
+        let providerConfiguration = CXProviderConfiguration()
         providerConfiguration.supportsVideo = true
         providerConfiguration.maximumCallGroups = 1
         providerConfiguration.maximumCallsPerCallGroup = 1

--- a/Session/Calls/CallVC.swift
+++ b/Session/Calls/CallVC.swift
@@ -630,8 +630,9 @@ final class CallVC: UIViewController, VideoPreviewDelegate {
         }
     }
     
+    // stringlint:ignore_contents
     @objc private func updateDuration() {
-        callDurationLabel.text = String(format: "%.2d:%.2d", duration/60, duration%60) // stringlint:disable
+        callDurationLabel.text = String(format: "%.2d:%.2d", duration/60, duration%60)
         duration += 1
     }
     

--- a/Session/Calls/WebRTC/WebRTCSession+DataChannel.swift
+++ b/Session/Calls/WebRTC/WebRTCSession+DataChannel.swift
@@ -6,13 +6,13 @@ import Foundation
 import SessionUtilitiesKit
 
 extension WebRTCSession: RTCDataChannelDelegate {
-    
+    // stringlint:ignore_contents
     internal func createDataChannel() -> RTCDataChannel? {
         let dataChannelConfiguration = RTCDataChannelConfiguration()
         dataChannelConfiguration.isOrdered = true
         dataChannelConfiguration.isNegotiated = true
         dataChannelConfiguration.channelId = 548
-        guard let dataChannel = peerConnection?.dataChannel(forLabel: "CONTROL", configuration: dataChannelConfiguration) else { // stringlint:disable
+        guard let dataChannel = peerConnection?.dataChannel(forLabel: "CONTROL", configuration: dataChannelConfiguration) else {
             SNLog("[Calls] Couldn't create data channel.")
             return nil
         }
@@ -35,13 +35,14 @@ extension WebRTCSession: RTCDataChannelDelegate {
         }
     }
     
+    // stringlint:ignore_contents
     public func dataChannel(_ dataChannel: RTCDataChannel, didReceiveMessageWith buffer: RTCDataBuffer) {
         if let json = try? JSONSerialization.jsonObject(with: buffer.data, options: [ .fragmentsAllowed ]) as? JSON {
             SNLog("[Calls] Data channel did receive data: \(json)")
-            if let isRemoteVideoEnabled = json["video"] as? Bool { // stringlint:disable
+            if let isRemoteVideoEnabled = json["video"] as? Bool {
                 delegate?.isRemoteVideoDidChange(isEnabled: isRemoteVideoEnabled)
             }
-            if let _ = json["hangup"] { // stringlint:disable
+            if let _ = json["hangup"] {
                 delegate?.didReceiveHangUpSignal()
             }
         }

--- a/Session/Calls/WebRTC/WebRTCSession.swift
+++ b/Session/Calls/WebRTC/WebRTCSession.swift
@@ -84,9 +84,10 @@ public final class WebRTCSession : NSObject, RTCPeerConnectionDelegate {
     public enum WebRTCSessionError: LocalizedError {
         case noThread
         
+        // stringlint:ignore_contents
         public var errorDescription: String? {
             switch self {
-                case .noThread: return "Couldn't find thread for contact." // stringlint:disable
+                case .noThread: return "Couldn't find thread for contact."
             }
         }
     }
@@ -392,10 +393,11 @@ public final class WebRTCSession : NSObject, RTCPeerConnectionDelegate {
         return RTCMediaConstraints(mandatoryConstraints: mandatory, optionalConstraints: optional)
     }
     
+    // stringlint:ignore_contents
     private func correctSessionDescription(sdp: RTCSessionDescription?) -> RTCSessionDescription? {
         guard let sdp = sdp else { return nil }
-        let cbrSdp = sdp.sdp.description.replace(regex: "(a=fmtp:111 ((?!cbr=).)*)\r?\n", with: "$1;cbr=1\r\n") // stringlint:disable
-        let finalSdp = cbrSdp.replace(regex: ".+urn:ietf:params:rtp-hdrext:ssrc-audio-level.*\r?\n", with: "") // stringlint:disable
+        let cbrSdp = sdp.sdp.description.replace(regex: "(a=fmtp:111 ((?!cbr=).)*)\r?\n", with: "$1;cbr=1\r\n")
+        let finalSdp = cbrSdp.replace(regex: ".+urn:ietf:params:rtp-hdrext:ssrc-audio-level.*\r?\n", with: "")
         return RTCSessionDescription(type: sdp.type, sdp: finalSdp)
     }
     

--- a/Session/Conversations/ConversationVC+Interaction.swift
+++ b/Session/Conversations/ConversationVC+Interaction.swift
@@ -721,7 +721,7 @@ extension ConversationVC:
         
         let newText: String = snInputView.text.replacingCharacters(
             in: currentMentionStartIndex...,
-            with: "@\(mentionInfo.profile.displayName(for: self.viewModel.threadData.threadVariant)) " // stringlint:disable
+            with: "@\(mentionInfo.profile.displayName(for: self.viewModel.threadData.threadVariant)) " // stringlint:ignore
         )
         
         snInputView.text = newText
@@ -756,6 +756,7 @@ extension ConversationVC:
             isCharacterBeforeLastWhiteSpaceOrStartOfLine = characterBeforeLast.isWhitespace
         }
         
+        // stringlint:ignore_start
         if lastCharacter == "@" && isCharacterBeforeLastWhiteSpaceOrStartOfLine {
             currentMentionStartIndex = lastCharacterIndex
             snInputView.showMentionsUI(for: self.viewModel.mentions())
@@ -770,6 +771,7 @@ extension ConversationVC:
                 snInputView.showMentionsUI(for: self.viewModel.mentions(for: query))
             }
         }
+        // stringlint:ignore_stop
     }
 
     func resetMentions() {
@@ -777,11 +779,12 @@ extension ConversationVC:
         mentions = []
     }
 
+    // stringlint:ignore_contents
     func replaceMentions(in text: String) -> String {
         var result = text
         for mention in mentions {
-            guard let range = result.range(of: "@\(mention.profile.displayName(for: mention.threadVariant))") else { continue } // stringlint:disable
-            result = result.replacingCharacters(in: range, with: "@\(mention.profile.id)") // stringlint:disable
+            guard let range = result.range(of: "@\(mention.profile.displayName(for: mention.threadVariant))") else { continue }
+            result = result.replacingCharacters(in: range, with: "@\(mention.profile.id)")
         }
         
         return result
@@ -2422,7 +2425,7 @@ extension ConversationVC:
         
         // Create URL
         let directory: String = Singleton.appContext.temporaryDirectory
-        let fileName: String = "\(SnodeAPI.currentOffsetTimestampMs()).m4a" // stringlint:disable
+        let fileName: String = "\(SnodeAPI.currentOffsetTimestampMs()).m4a" // stringlint:ignore
         let url: URL = URL(fileURLWithPath: directory).appendingPathComponent(fileName)
         
         // Set up audio session
@@ -2525,7 +2528,8 @@ extension ConversationVC:
         guard let dataSource = dataSourceOrNil else { return SNLog("Couldn't load recorded data.") }
         
         // Create attachment
-        let fileName = ("messageVoice".localized() as NSString).appendingPathExtension("m4a")
+        let fileName = ("messageVoice".localized() as NSString)
+            .appendingPathExtension("m4a") // stringlint:ignore
         dataSource.sourceFilename = fileName
         
         let attachment = SignalAttachment.voiceMessageAttachment(dataSource: dataSource, type: .mpeg4Audio)

--- a/Session/Conversations/ConversationVC.swift
+++ b/Session/Conversations/ConversationVC.swift
@@ -107,7 +107,10 @@ final class ConversationVC: BaseVC, LibSessionRespondingViewController, Conversa
         return result
     }()
 
-    lazy var recordVoiceMessageActivity = AudioActivity(audioDescription: "Voice message", behavior: .playAndRecord) // stringlint:disable
+    lazy var recordVoiceMessageActivity = AudioActivity(
+        audioDescription: "Voice message",  // stringlint:ignore
+        behavior: .playAndRecord
+    )
 
     lazy var searchController: ConversationSearchController = {
         let result: ConversationSearchController = ConversationSearchController(
@@ -1724,7 +1727,7 @@ final class ConversationVC: BaseVC, LibSessionRespondingViewController, Conversa
     func updateUnreadCountView(unreadCount: UInt?) {
         let unreadCount: Int = Int(unreadCount ?? 0)
         let fontSize: CGFloat = (unreadCount < 10000 ? Values.verySmallFontSize : 8)
-        unreadCountLabel.text = (unreadCount < 10000 ? "\(unreadCount)" : "9999+") // stringlint:disable
+        unreadCountLabel.text = (unreadCount < 10000 ? "\(unreadCount)" : "9999+") // stringlint:ignore
         unreadCountLabel.font = .boldSystemFont(ofSize: fontSize)
         unreadCountView.isHidden = (unreadCount == 0)
     }

--- a/Session/Conversations/ConversationViewModel.swift
+++ b/Session/Conversations/ConversationViewModel.swift
@@ -72,7 +72,7 @@ public class ConversationViewModel: OWSAudioPlayerDelegate, NavigatableStateHold
                 
             return "blockBlockedDescription".localized()
                 
-            default: return "Thread is blocked. Unblock it?" // Should not happen // stringlint:disable
+            default: return "blockUnblock".localized() // Should not happen
         }
     }()
     

--- a/Session/Conversations/Input View/VoiceMessageRecordingView.swift
+++ b/Session/Conversations/Input View/VoiceMessageRecordingView.swift
@@ -118,11 +118,12 @@ final class VoiceMessageRecordingView: UIView {
         return result
     }()
 
+    // stringlint:ignore_contents
     private lazy var durationLabel: UILabel = {
         let result: UILabel = UILabel()
         result.font = .systemFont(ofSize: Values.smallFontSize)
         result.themeTextColor = .textPrimary
-        result.text = "0:00" // stringlint:disable
+        result.text = "0:00"
         
         return result
     }()

--- a/Session/Conversations/Message Cells/Content Views/DisappearingMessageTimerView.swift
+++ b/Session/Conversations/Message Cells/Content Views/DisappearingMessageTimerView.swift
@@ -53,8 +53,9 @@ class DisappearingMessageTimerView: UIView {
         self.updateIcon()
     }
     
+    // stringlint:ignore_contents
     private func updateIcon() {
-        let imageName: String = "disappearing_message_\(String(format: "%02d", 5 * self.progress))" // stringlint:disable
+        let imageName: String = "disappearing_message_\(String(format: "%02d", 5 * self.progress))"
         self.iconImageView.image = UIImage(named: imageName)?.withRenderingMode(.alwaysTemplate)
     }
     

--- a/Session/Conversations/Message Cells/Content Views/MediaPlaceholderView.swift
+++ b/Session/Conversations/Message Cells/Content Views/MediaPlaceholderView.swift
@@ -34,13 +34,31 @@ final class MediaPlaceholderView: UIView {
                 cellViewModel.variant == .standardIncoming,
                 let attachment: Attachment = cellViewModel.attachments?.first
             else {
-                return ("actionsheet_document_black", "file".localized().lowercased()) // Should never occur
+                return (
+                    "actionsheet_document_black", // stringlint:ignore
+                    "file".localized().lowercased()
+                ) // Should never occur
             }
             
-            if attachment.isAudio { return ("attachment_audio", "audio".localized().lowercased()) }
-            if attachment.isImage || attachment.isVideo { return ("actionsheet_camera_roll_black", "media".localized().lowercased()) }
-            
-            return ("actionsheet_document_black", "file".localized().lowercased())
+            switch (attachment.isAudio, (attachment.isImage || attachment.isVideo)) {
+                case (true, _):
+                    return (
+                        "attachment_audio", // stringlint:ignore
+                        "audio".localized().lowercased()
+                    )
+                    
+                case (_, true):
+                    return (
+                        "actionsheet_camera_roll_black", // stringlint:ignore
+                        "media".localized().lowercased()
+                    )
+                    
+                default:
+                    return (
+                        "actionsheet_document_black", // stringlint:disable
+                        "file".localized().lowercased()
+                    )
+            }
         }()
         
         // Image view

--- a/Session/Conversations/Message Cells/Content Views/OpenGroupInvitationView.swift
+++ b/Session/Conversations/Message Cells/Content Views/OpenGroupInvitationView.swift
@@ -48,7 +48,7 @@ final class OpenGroupInvitationView: UIView {
         let urlLabel = UILabel()
         urlLabel.font = .systemFont(ofSize: Values.verySmallFontSize)
         urlLabel.text = {
-            if let range = rawUrl.range(of: "?public_key=") { // stringlint:disable
+            if let range = rawUrl.range(of: "?public_key=") { // stringlint:ignore
                 return String(rawUrl[..<range.lowerBound])
             }
 
@@ -64,7 +64,7 @@ final class OpenGroupInvitationView: UIView {
         
         // Icon
         let iconSize = OpenGroupInvitationView.iconSize
-        let iconName = (isOutgoing ? "Globe" : "Plus") // stringlint:disable
+        let iconName = (isOutgoing ? "Globe" : "Plus") // stringlint:ignore
         let iconImageViewSize = OpenGroupInvitationView.iconImageViewSize
         let iconImageView = UIImageView(
             image: UIImage(named: iconName)?

--- a/Session/Conversations/Message Cells/Content Views/QuoteView.swift
+++ b/Session/Conversations/Message Cells/Content Views/QuoteView.swift
@@ -101,7 +101,7 @@ final class QuoteView: UIView {
         
         if let attachment: Attachment = attachment {
             let isAudio: Bool = attachment.isAudio
-            let fallbackImageName: String = (isAudio ? "attachment_audio" : "actionsheet_document_black") // stringlint:disable
+            let fallbackImageName: String = (isAudio ? "attachment_audio" : "actionsheet_document_black") // stringlint:ignore
             let imageView: UIImageView = UIImageView(
                 image: UIImage(named: fallbackImageName)?
                     .resized(to: CGSize(width: iconSize, height: iconSize))?

--- a/Session/Conversations/Message Cells/Content Views/ReactionView.swift
+++ b/Session/Conversations/Message Cells/Content Views/ReactionView.swift
@@ -88,7 +88,7 @@ final class ReactionButton: UIView {
         emojiLabel.text = viewModel.emoji.rawValue
         numberLabel.text = (viewModel.number < 1000 ?
             "\(viewModel.number)" :
-            String(format: "%.1f", Float(viewModel.number) / 1000) + "k" // stringlint:disable
+            String(format: "%.1f", Float(viewModel.number) / 1000) + "k" // stringlint:ignore
         )
         numberLabel.isHidden = (!showNumber && viewModel.number <= 1)
         

--- a/Session/Conversations/Message Cells/Content Views/SwiftUI/OpenGroupInvitationView_SwiftUI.swift
+++ b/Session/Conversations/Message Cells/Content Views/SwiftUI/OpenGroupInvitationView_SwiftUI.swift
@@ -14,6 +14,7 @@ struct OpenGroupInvitationView_SwiftUI: View {
     private static let iconSize: CGFloat = 24
     private static let iconImageViewSize: CGFloat = 48
     
+    // stringlint:ignore_contents
     init(
         name: String,
         url: String,
@@ -38,7 +39,7 @@ struct OpenGroupInvitationView_SwiftUI: View {
             spacing: Values.mediumSpacing
         ) {
             // Icon
-            let iconName = (isOutgoing ? "Globe" : "Plus")
+            let iconName = (isOutgoing ? "Globe" : "Plus") // stringlint:ignore
             if let iconImage = UIImage(named: iconName)?
                 .resized(to: CGSize(width: Self.iconSize, height: Self.iconSize))?
                 .withRenderingMode(.alwaysTemplate)

--- a/Session/Conversations/Message Cells/Content Views/SwiftUI/VoiceMessageView_SwiftUI.swift
+++ b/Session/Conversations/Message Cells/Content Views/SwiftUI/VoiceMessageView_SwiftUI.swift
@@ -6,8 +6,8 @@ import SessionMessagingKit
 
 struct VoiceMessageView_SwiftUI: View {
     @State var isPlaying: Bool = false
-    @State var time: String = "0:00"
-    @State var speed: String = "1.5×"
+    @State var time: String = "0:00"  // stringlint:ignore
+    @State var speed: String = "1.5×" // stringlint:ignore
     @State var progress: Double = 0.0
     
     private static let width: CGFloat = 160

--- a/Session/Conversations/Message Cells/Content Views/TypingIndicatorView.swift
+++ b/Session/Conversations/Message Cells/Content Views/TypingIndicatorView.swift
@@ -132,6 +132,7 @@ import SessionUtilitiesKit
             }
         }
 
+        // stringlint:ignore_contents
         fileprivate func startAnimation() {
             stopAnimation()
 
@@ -199,8 +200,8 @@ import SessionUtilitiesKit
 
             let groupAnimation = CAAnimationGroup()
             groupAnimation.animations = [
-                makeAnimation("fillColor", colorValues), // stringlint:disable
-                makeAnimation("path", pathValues) // stringlint:disable
+                makeAnimation("fillColor", colorValues),
+                makeAnimation("path", pathValues)
             ]
             groupAnimation.duration = animationDuration
             groupAnimation.repeatCount = MAXFLOAT

--- a/Session/Conversations/Message Cells/Content Views/VoiceMessageView.swift
+++ b/Session/Conversations/Message Cells/Content Views/VoiceMessageView.swift
@@ -74,19 +74,21 @@ public final class VoiceMessageView: UIView {
         return result
     }()
 
+    // stringlint:ignore_contents
     private lazy var countdownLabel: UILabel = {
         let result: UILabel = UILabel()
         result.font = .systemFont(ofSize: Values.smallFontSize)
-        result.text = "0:00" // stringlint:disable
+        result.text = "0:00"
         result.themeTextColor = .textPrimary
         
         return result
     }()
 
+    // stringlint:ignore_contents
     private lazy var speedUpLabel: UILabel = {
         let result: UILabel = UILabel()
         result.font = .systemFont(ofSize: Values.smallFontSize)
-        result.text = "1.5x" // stringlint:disable
+        result.text = "1.5x"
         result.themeTextColor = .textPrimary
         result.textAlignment = .center
         result.alpha = 0

--- a/Session/Conversations/Message Cells/VisibleMessageCell.swift
+++ b/Session/Conversations/Message Cells/VisibleMessageCell.swift
@@ -1097,6 +1097,7 @@ final class VisibleMessageCell: MessageCell, TappableLabelDelegate {
         }
     }
     
+    // stringlint:ignore_contents
     static func getBodyAttributedText(
         for cellViewModel: MessageViewModel,
         theme: Theme,

--- a/Session/Conversations/Settings/ThreadSettingsViewModel.swift
+++ b/Session/Conversations/Settings/ThreadSettingsViewModel.swift
@@ -515,10 +515,17 @@ class ThreadSettingsViewModel: SessionTableViewModel, NavigationItemSource, Navi
                             ),
                             confirmationInfo: ConfirmationModal.Info(
                                 title: "groupLeave".localized(),
-                                body: .attributedText(
-                                    (currentUserIsClosedGroupAdmin ? "groupDeleteDescription" : "groupLeaveDescription")
-                                        .put(key: "group_name", value: threadViewModel.displayName)
-                                        .localizedFormatted(baseFont: .boldSystemFont(ofSize: Values.smallFontSize))
+                                body: (currentUserIsClosedGroupAdmin ?
+                                    .attributedText(
+                                        "groupDeleteDescription"
+                                            .put(key: "group_name", value: threadViewModel.displayName)
+                                            .localizedFormatted(baseFont: .boldSystemFont(ofSize: Values.smallFontSize))
+                                    ) :
+                                    .attributedText(
+                                        "groupLeaveDescription"
+                                            .put(key: "group_name", value: threadViewModel.displayName)
+                                            .localizedFormatted(baseFont: .boldSystemFont(ofSize: Values.smallFontSize))
+                                    )
                                 ),
                                 confirmTitle: "leave".localized(),
                                 confirmStyle: .danger,

--- a/Session/Conversations/Views & Modals/ReactionListSheet.swift
+++ b/Session/Conversations/Views & Modals/ReactionListSheet.swift
@@ -551,7 +551,7 @@ extension ReactionListSheet {
             emojiLabel.text = emoji
             numberLabel.text = (count < 1000 ?
                 "\(count)" :
-                String(format: "%.1fk", Float(count) / 1000) // stringlint:disable
+                String(format: "%.1fk", Float(count) / 1000) // stringlint:ignore
             )
             snContentView.themeBorderColor = (isCurrentSelection ? .primary : .clear)
         }

--- a/Session/Emoji/EmojiWithSkinTones.swift
+++ b/Session/Emoji/EmojiWithSkinTones.swift
@@ -64,7 +64,7 @@ extension Emoji {
         guard withDefaultEmoji else { return recentReactionEmoji }
         
         // Add in our default emoji if desired
-        let defaultEmoji = ["😂", "🥰", "😢", "😡", "😮", "😈"] // stringlint:disable
+        let defaultEmoji = ["😂", "🥰", "😢", "😡", "😮", "😈"] // stringlint:ignore
             .filter { !recentReactionEmoji.contains($0) }
         
         return Array(recentReactionEmoji

--- a/Session/Home/GlobalSearch/GlobalSearchViewController.swift
+++ b/Session/Home/GlobalSearch/GlobalSearchViewController.swift
@@ -42,7 +42,7 @@ class GlobalSearchViewController: BaseVC, LibSessionRespondingViewController, UI
     
     private let dependencies: Dependencies
     private lazy var defaultSearchResults: SearchResultData = {
-        let nonalphabeticNameTitle: String = "#" // stringlint:disable
+        let nonalphabeticNameTitle: String = "#" // stringlint:ignore
         let contacts: [SessionThreadViewModel] = Storage.shared.read { db -> [SessionThreadViewModel]? in
             try SessionThreadViewModel
                 .defaultContactsQuery(userPublicKey: getUserHexEncodedPublicKey(db))

--- a/Session/Home/New Conversation/StartConversationScreen.swift
+++ b/Session/Home/New Conversation/StartConversationScreen.swift
@@ -61,7 +61,7 @@ struct StartConversationScreen: View {
                             .padding(.trailing, -Values.largeSpacing)
                         
                         NewConversationCell(
-                            image: "Globe",
+                            image: "Globe", // stringlint:ignore
                             title: "communityJoin".localized()
                         ) {
                             let viewController = JoinOpenGroupVC()
@@ -79,7 +79,7 @@ struct StartConversationScreen: View {
                             .padding(.trailing, -Values.largeSpacing)
                         
                         NewConversationCell(
-                            image: "icon_invite",
+                            image: "icon_invite", // stringlint:ignore
                             title: "sessionInviteAFriend".localized()
                         ) {
                             let viewController: SessionHostingViewController = SessionHostingViewController(rootView: InviteAFriendScreen())
@@ -107,7 +107,7 @@ struct StartConversationScreen: View {
                     QRCodeView(
                         string: getUserHexEncodedPublicKey(),
                         hasBackground: false,
-                        logo: "SessionWhite40", // stringlint:disable
+                        logo: "SessionWhite40", // stringlint:ignore
                         themeStyle: ThemeManager.currentTheme.interfaceStyle
                     )
                     .aspectRatio(1, contentMode: .fit)

--- a/Session/Media Viewing & Editing/GIFs/GifPickerViewController.swift
+++ b/Session/Media Viewing & Editing/GIFs/GifPickerViewController.swift
@@ -35,7 +35,7 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
     var hasSelectedCell: Bool = false
     var imageInfos = [GiphyImageInfo]()
     
-    private let kCellReuseIdentifier = "kCellReuseIdentifier"   // stringlint:disable
+    private let kCellReuseIdentifier = "kCellReuseIdentifier"   // stringlint:ignore
 
     var progressiveSearchTimer: Timer?
     

--- a/Session/Media Viewing & Editing/GIFs/GiphyAPI.swift
+++ b/Session/Media Viewing & Editing/GIFs/GiphyAPI.swift
@@ -26,6 +26,7 @@ enum GiphyError: Error, CustomStringConvertible {
 // They vary in content size (i.e. width,  height), 
 // format (.jpg, .gif, .mp4, webp, etc.),
 // quality, etc.
+// stringlint:ignore_contents
 class GiphyRendition: ProxiedContentAssetDescription {
     let format: GiphyFormat
     let name: String
@@ -51,9 +52,9 @@ class GiphyRendition: ProxiedContentAssetDescription {
 
     private class func fileExtension(forFormat format: GiphyFormat) -> String {
         switch format {
-            case .gif: return "gif"      // stringlint:disable
-            case .mp4: return "mp4"      // stringlint:disable
-            case .jpg: return "jpg"      // stringlint:disable
+            case .gif: return "gif"
+            case .mp4: return "mp4"
+            case .jpg: return "jpg"
         }
     }
 
@@ -66,11 +67,11 @@ class GiphyRendition: ProxiedContentAssetDescription {
     }
 
     public var isStill: Bool {
-        return name.hasSuffix("_still")      // stringlint:disable
+        return name.hasSuffix("_still")
     }
 
     public var isDownsampled: Bool {
-        return name.hasSuffix("_downsampled")      // stringlint:disable
+        return name.hasSuffix("_downsampled")
     }
 
     public func log() {
@@ -268,11 +269,12 @@ enum GiphyAPI {
     // MARK: - Search
     
     // This is the Signal iOS API key.
-    private static let kGiphyApiKey = "ZsUpUm2L6cVbvei347EQNp7HrROjbOdc"      // stringlint:disable
+    private static let kGiphyApiKey = "ZsUpUm2L6cVbvei347EQNp7HrROjbOdc"      // stringlint:ignore
     private static let kGiphyPageSize = 20
     
+    // stringlint:ignore_contents
     public static func trending() -> AnyPublisher<[GiphyImageInfo], Error> {
-        let urlString = "/v1/gifs/trending?api_key=\(kGiphyApiKey)&limit=\(kGiphyPageSize)"      // stringlint:disable
+        let urlString = "/v1/gifs/trending?api_key=\(kGiphyApiKey)&limit=\(kGiphyPageSize)"
         
         guard let url: URL = URL(string: "\(kGiphyBaseURL)\(urlString)") else {
             return Fail(error: NetworkError.invalidURL)
@@ -300,6 +302,7 @@ enum GiphyAPI {
             .eraseToAnyPublisher()
     }
 
+    // stringlint:ignore_contents
     public static func search(query: String) -> AnyPublisher<[GiphyImageInfo], Error> {
         let kGiphyPageOffset = 0
         
@@ -308,10 +311,10 @@ enum GiphyAPI {
             let url: URL = URL(
                 string: [
                     kGiphyBaseURL,
-                    "/v1/gifs/search?api_key=\(kGiphyApiKey)",      // stringlint:disable
-                    "&offset=\(kGiphyPageOffset)",      // stringlint:disable
-                    "&limit=\(kGiphyPageSize)",      // stringlint:disable
-                    "&q=\(queryEncoded)"      // stringlint:disable
+                    "/v1/gifs/search?api_key=\(kGiphyApiKey)",
+                    "&offset=\(kGiphyPageOffset)",
+                    "&limit=\(kGiphyPageSize)",
+                    "&q=\(queryEncoded)"
                 ].joined()
             )
         else {
@@ -349,6 +352,7 @@ enum GiphyAPI {
 
     // MARK: - Parse API Responses
 
+    // stringlint:ignore_contents
     private static func parseGiphyImages(responseData: Data?) -> [GiphyImageInfo]? {
         guard let responseData: Data = responseData else {
             Log.error("[GiphyAPI] Missing response.")
@@ -359,7 +363,7 @@ enum GiphyAPI {
             Log.error("[GiphyAPI] Invalid response.")
             return nil
         }
-        guard let imageDicts = responseDict["data"] as? [[String: Any]] else {      // stringlint:disable
+        guard let imageDicts = responseDict["data"] as? [[String: Any]] else {
             Log.error("[GiphyAPI] Invalid response data.")
             return nil
         }
@@ -369,8 +373,9 @@ enum GiphyAPI {
     }
 
     // Giphy API results are often incomplete or malformed, so we need to be defensive.
+    // stringlint:ignore_contents
     private static func parseGiphyImage(imageDict: [String: Any]) -> GiphyImageInfo? {
-        guard let giphyId = imageDict["id"] as? String else {      // stringlint:disable
+        guard let giphyId = imageDict["id"] as? String else {
             Log.warn("[GiphyAPI] Image dict missing id.")
             return nil
         }
@@ -378,7 +383,7 @@ enum GiphyAPI {
             Log.warn("[GiphyAPI] Image dict has invalid id.")
             return nil
         }
-        guard let renditionDicts = imageDict["images"] as? [String: Any] else {      // stringlint:disable
+        guard let renditionDicts = imageDict["images"] as? [String: Any] else {
             Log.warn("[GiphyAPI] Image dict missing renditions.")
             return nil
         }
@@ -411,8 +416,9 @@ enum GiphyAPI {
         )
     }
 
+    // stringlint:ignore_contents
     private static func findOriginalRendition(renditions: [GiphyRendition]) -> GiphyRendition? {
-        for rendition in renditions where rendition.name == "original" {      // stringlint:disable
+        for rendition in renditions where rendition.name == "original" {
             return rendition
         }
         return nil
@@ -421,19 +427,20 @@ enum GiphyAPI {
     // Giphy API results are often incomplete or malformed, so we need to be defensive.
     //
     // We should discard renditions which are missing or have invalid properties.
+    // stringlint:ignore_contents
     private static func parseGiphyRendition(
         renditionName: String,
         renditionDict: [String: Any]
     ) -> GiphyRendition? {
-        guard let width = parsePositiveUInt(dict: renditionDict, key: "width", typeName: "rendition") else {      // stringlint:disable
+        guard let width = parsePositiveUInt(dict: renditionDict, key: "width", typeName: "rendition") else {
             return nil
         }
-        guard let height = parsePositiveUInt(dict: renditionDict, key: "height", typeName: "rendition") else {      // stringlint:disable
+        guard let height = parsePositiveUInt(dict: renditionDict, key: "height", typeName: "rendition") else {
             return nil
         }
         // Be lenient when parsing file sizes - we don't require them for stills.
-        let fileSize = parseLenientUInt(dict: renditionDict, key: "size")      // stringlint:disable
-        guard let urlString = renditionDict["url"] as? String else {           // stringlint:disable
+        let fileSize = parseLenientUInt(dict: renditionDict, key: "size")
+        guard let urlString = renditionDict["url"] as? String else {
             return nil
         }
         guard urlString.count > 0 else {
@@ -449,13 +456,13 @@ enum GiphyAPI {
             return nil
         }
         var format = GiphyFormat.gif
-        if fileExtension == "gif" {             // stringlint:disable
+        if fileExtension == "gif" {
             format = .gif
-        } else if fileExtension == "jpg" {      // stringlint:disable
+        } else if fileExtension == "jpg" {
             format = .jpg
-        } else if fileExtension == "mp4" {      // stringlint:disable
+        } else if fileExtension == "mp4" {
             format = .mp4
-        } else if fileExtension == "webp" {     // stringlint:disable
+        } else if fileExtension == "webp" {
             return nil
         } else {
             Log.warn("[GiphyAPI] Invalid file extension: \(fileExtension).")

--- a/Session/Media Viewing & Editing/GIFs/GiphyDownloader.swift
+++ b/Session/Media Viewing & Editing/GIFs/GiphyDownloader.swift
@@ -10,5 +10,5 @@ public class GiphyDownloader: ProxiedContentDownloader {
 
     // MARK: - Properties
 
-    public static let giphyDownloader = GiphyDownloader(downloadFolderName: "GIFs") // stringlint:disable
+    public static let giphyDownloader = GiphyDownloader(downloadFolderName: "GIFs")
 }

--- a/Session/Media Viewing & Editing/MediaGalleryViewModel.swift
+++ b/Session/Media Viewing & Editing/MediaGalleryViewModel.swift
@@ -144,7 +144,7 @@ public class MediaGalleryViewModel {
     public struct GalleryDate: Differentiable, Equatable, Comparable, Hashable {
         private static let thisYearFormatter: DateFormatter = {
             let formatter = DateFormatter()
-            formatter.dateFormat = "MMMM"   // stringlint:disable
+            formatter.dateFormat = "MMMM"   // stringlint:ignore
 
             return formatter
         }()
@@ -152,7 +152,7 @@ public class MediaGalleryViewModel {
         private static let olderFormatter: DateFormatter = {
             // FIXME: localize for RTL, or is there a built in way to do this?
             let formatter = DateFormatter()
-            formatter.dateFormat = "MMMM yyyy"   // stringlint:disable
+            formatter.dateFormat = "MMMM yyyy"   // stringlint:ignore
 
             return formatter
         }()

--- a/Session/Media Viewing & Editing/PhotoCaptureViewController.swift
+++ b/Session/Media Viewing & Editing/PhotoCaptureViewController.swift
@@ -333,16 +333,14 @@ class PhotoCaptureViewController: OWSViewController {
         present(modal, animated: true)
     }
 
+    // stringlint:ignore_contents
     private func updateFlashModeControl() {
         let imageName: String
         switch photoCapture.flashMode {
-        case .auto:
-            imageName = "ic_flash_mode_auto" // stringlint:disable
-        case .on:
-            imageName = "ic_flash_mode_on" // stringlint:disable
-        case .off:
-            imageName = "ic_flash_mode_off" // stringlint:disable
-        default: preconditionFailure()
+            case .auto: imageName = "ic_flash_mode_auto"
+            case .on: imageName = "ic_flash_mode_on"
+            case .off: imageName = "ic_flash_mode_off"
+            default: preconditionFailure()
         }
 
         self.flashModeControl.setImage(imageName: imageName)
@@ -643,10 +641,11 @@ class RecordingTimerView: UIView {
 
     private var timer: Timer?
 
+    // stringlint:ignore_contents
     private lazy var timeFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "mm:ss"
-        formatter.timeZone = TimeZone(identifier: "UTC")! // stringlint:disable
+        formatter.timeZone = TimeZone(identifier: "UTC")!
 
         return formatter
     }()

--- a/Session/Media Viewing & Editing/PhotoLibrary.swift
+++ b/Session/Media Viewing & Editing/PhotoLibrary.swift
@@ -186,7 +186,7 @@ class PhotoCollectionContents {
                     exportSession.outputFileType = AVFileType.mp4
                     exportSession.metadataItemFilter = AVMetadataItemFilter.forSharing()
                     
-                    let exportPath = FileSystem.temporaryFilePath(fileExtension: "mp4") // stringlint:disable
+                    let exportPath = FileSystem.temporaryFilePath(fileExtension: "mp4") // stringlint:ignore
                     let exportURL = URL(fileURLWithPath: exportPath)
                     exportSession.outputURL = exportURL
                     
@@ -256,6 +256,7 @@ class PhotoCollection {
         return localizedTitle
     }
 
+    // stringlint:ignore_contents
     func contents() -> PhotoCollectionContents {
         let options = PHFetchOptions()
         options.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: true)]
@@ -298,6 +299,7 @@ class PhotoLibrary: NSObject, PHPhotoLibraryChangeObserver {
         PHPhotoLibrary.shared().unregisterChangeObserver(self)
     }
     
+    // stringlint:ignore_contents
     private lazy var fetchOptions: PHFetchOptions = {
         let fetchOptions = PHFetchOptions()
         fetchOptions.sortDescriptors = [NSSortDescriptor(key: "endDate", ascending: true)]
@@ -374,7 +376,7 @@ class PhotoLibrary: NSObject, PHPhotoLibraryChangeObserver {
             }
         }
         let fetchOptions = PHFetchOptions()
-        fetchOptions.sortDescriptors = [NSSortDescriptor(key: "endDate", ascending: true)]
+        fetchOptions.sortDescriptors = [NSSortDescriptor(key: "endDate", ascending: true)] // stringlint:ignore
 
         // Try to add "Camera Roll" first.
         processPHAssetCollections((fetchResult: PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .smartAlbumUserLibrary, options: fetchOptions),

--- a/Session/Meta/AppDelegate.swift
+++ b/Session/Meta/AppDelegate.swift
@@ -905,11 +905,12 @@ private enum LifecycleMethod: Equatable {
     case enterForeground(initialLaunchFailed: Bool)
     case didBecomeActive
     
+    // stringlint:ignore_contents
     var timingName: String {
         switch self {
-            case .finishLaunching: return "Launch"              // stringlint:disable
-            case .enterForeground: return "EnterForeground"     // stringlint:disable
-            case .didBecomeActive: return "BecomeActive"        // stringlint:disable
+            case .finishLaunching: return "Launch"
+            case .enterForeground: return "EnterForeground"
+            case .didBecomeActive: return "BecomeActive"
         }
     }
     

--- a/Session/Meta/MainAppContext.swift
+++ b/Session/Meta/MainAppContext.swift
@@ -151,11 +151,12 @@ final class MainAppContext: AppContext {
     func endBackgroundTask(_ backgroundTaskIdentifier: UIBackgroundTaskIdentifier) {
         UIApplication.shared.endBackgroundTask(backgroundTaskIdentifier)
     }
-        
+    
+    // stringlint:ignore_contents
     func ensureSleepBlocking(_ shouldBeBlocking: Bool, blockingObjects: [Any]) {
         if UIApplication.shared.isIdleTimerDisabled != shouldBeBlocking {
             if shouldBeBlocking {
-                var logString: String = "Blocking sleep because of: \(String(describing: blockingObjects.first))" // stringlint:disable
+                var logString: String = "Blocking sleep because of: \(String(describing: blockingObjects.first))"
                 
                 if blockingObjects.count > 1 {
                     logString = "\(logString) (and \(blockingObjects.count - 1) others)"
@@ -175,6 +176,7 @@ final class MainAppContext: AppContext {
     
     // MARK: -
     
+    // stringlint:ignore_contents
     func clearOldTemporaryDirectories() {
         // We use the lowest priority queue for this, and wait N seconds
         // to avoid interfering with app startup.
@@ -199,7 +201,7 @@ final class MainAppContext: AppContext {
                 // b) modified time before app launch time.
                 let filePath: String = URL(fileURLWithPath: dirPath).appendingPathComponent(fileName).path
                 
-                if !fileName.hasPrefix("ows_temp") { // stringlint:disable
+                if !fileName.hasPrefix("ows_temp") {
                     // It's fine if we can't get the attributes (the file may have been deleted since we found it),
                     // also don't delete files which were created in the last N minutes
                     guard

--- a/Session/Meta/SessionApp.swift
+++ b/Session/Meta/SessionApp.swift
@@ -14,16 +14,16 @@ public struct SessionApp {
     
     static var versionInfo: String {
         let buildNumber: String = (Bundle.main.infoDictionary?["CFBundleVersion"] as? String)
-            .map { " (\($0))" } // stringlint:disable
+            .map { " (\($0))" }
             .defaulting(to: "")
         let appVersion: String? = (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String)
-            .map { "App: \($0)\(buildNumber)" } // stringlint:disable
+            .map { "App: \($0)\(buildNumber)" }
         let commitInfo: String? = (Bundle.main.infoDictionary?["GitCommitHash"] as? String).map { "Commit: \($0)" }
         
         let versionInfo: [String] = [
-            "iOS \(UIDevice.current.systemVersion)",        // stringlint:disable
+            "iOS \(UIDevice.current.systemVersion)",
             appVersion,
-            "libSession: \(LibSession.libSessionVersion)",  // stringlint:disable
+            "libSession: \(LibSession.libSessionVersion)",
             commitInfo
         ].compactMap { $0 }
         

--- a/Session/Meta/Translations/remove_unused_strings.swift
+++ b/Session/Meta/Translations/remove_unused_strings.swift
@@ -1,13 +1,17 @@
 #!/usr/bin/env xcrun swift
 
-import Foundation
-
+// Copyright © 2023 Rangeproof Pty Ltd. All rights reserved.
+//
+// stringlint:disable
+//
 // The way this works is:
 // • Run the AbandonedStrings executable (see https://www.avanderlee.com/xcode/unused-localized-strings/)
 // • Paste the list of unused strings below
 // • Run this script by doing:
 //   swiftc remove_unused_strings.swift
 //   ./remove_unused_strings
+
+import Foundation
 
 let unusedStringKeys = [
     

--- a/Session/Notifications/PushRegistrationManager.swift
+++ b/Session/Notifications/PushRegistrationManager.swift
@@ -181,7 +181,7 @@ public enum PushRegistrationError: Error {
                         // so the user doesn't remain indefinitely hung for no good reason.
                         return Fail(
                             error: PushRegistrationError.pushNotSupported(
-                                description: "Device configuration disallows push notifications" // stringlint:disable
+                                description: "Device configuration disallows push notifications" // stringlint:ignore
                             )
                         ).eraseToAnyPublisher()
                         
@@ -286,7 +286,7 @@ public enum PushRegistrationError: Error {
             let caller: String = payload["caller"] as? String,
             let timestampMs: Int64 = payload["timestamp"] as? Int64
         else {
-            SessionCallManager.reportFakeCall(info: "Missing payload data") // stringlint:disable
+            SessionCallManager.reportFakeCall(info: "Missing payload data") // stringlint:ignore
             return
         }
         
@@ -336,7 +336,7 @@ public enum PushRegistrationError: Error {
         }
         
         guard let call: SessionCall = maybeCall else {
-            SessionCallManager.reportFakeCall(info: "Could not retrieve call from database") // stringlint:disable
+            SessionCallManager.reportFakeCall(info: "Could not retrieve call from database") // stringlint:ignore
             return
         }
         
@@ -354,6 +354,6 @@ public enum PushRegistrationError: Error {
 // We transmit pushToken data as hex encoded string to the server
 fileprivate extension Data {
     var hexEncodedString: String {
-        return map { String(format: "%02hhx", $0) }.joined() // stringlint:disable
+        return map { String(format: "%02hhx", $0) }.joined() // stringlint:ignore
     }
 }

--- a/Session/Notifications/SyncPushTokensJob.swift
+++ b/Session/Notifications/SyncPushTokensJob.swift
@@ -223,10 +223,11 @@ extension SyncPushTokensJob {
 
 // MARK: - Convenience
 
+// stringlint:ignore_contents
 private func redact(_ string: String) -> String {
 #if DEBUG
-    return "[ DEBUG_NOT_REDACTED \(string) ]" // stringlint:disable
+    return "[ DEBUG_NOT_REDACTED \(string) ]"
 #else
-    return "[ READACTED \(string.prefix(2))...\(string.suffix(2)) ]" // stringlint:disable
+    return "[ READACTED \(string.prefix(2))...\(string.suffix(2)) ]"
 #endif
 }

--- a/Session/Onboarding/Onboarding.swift
+++ b/Session/Onboarding/Onboarding.swift
@@ -86,11 +86,12 @@ enum Onboarding {
             return .completed
         }
         
+        // stringlint:ignore_contents
         var description: String {
             switch self {
-                case .newUser: return "New User"            // stringlint:disable
-                case .missingName: return "Missing Name"    // stringlint:disable
-                case .completed: return "Completed"         // stringlint:disable
+                case .newUser: return "New User"
+                case .missingName: return "Missing Name"
+                case .completed: return "Completed"
             }
         }
     }

--- a/Session/Settings/HelpViewModel.swift
+++ b/Session/Settings/HelpViewModel.swift
@@ -157,7 +157,7 @@ class HelpViewModel: SessionTableViewModel, NavigatableStateHolder, ObservableTa
         elements: [
             SessionCell.Info(
                 id: .support,
-                title: "Export Database", // stringlint:disable
+                title: "Export Database", // stringlint:ignore
                 rightAccessory: .icon(
                     UIImage(systemName: "square.and.arrow.up.trianglebadge.exclamationmark")?
                         .withRenderingMode(.alwaysTemplate),
@@ -189,14 +189,15 @@ class HelpViewModel: SessionTableViewModel, NavigatableStateHolder, ObservableTa
         else { return }
         
         #if targetEnvironment(simulator)
+        // stringlint:ignore_start
         let modal: ConfirmationModal = ConfirmationModal(
             info: ConfirmationModal.Info(
-                title: "Export Logs",      // stringlint:disable
+                title: "Export Logs",
                 body: .text(
-                    "How would you like to export the logs?\n\n(This modal only appears on the Simulator)" // stringlint:disable
+                    "How would you like to export the logs?\n\n(This modal only appears on the Simulator)"
                 ),
-                confirmTitle: "Copy Path", // stringlint:disable
-                cancelTitle: "Share",      // stringlint:disable
+                confirmTitle: "Copy Path",
+                cancelTitle: "Share",
                 cancelStyle: .alert_text,
                 onConfirm: { _ in UIPasteboard.general.string = latestLogFilePath },
                 onCancel: { _ in
@@ -209,6 +210,7 @@ class HelpViewModel: SessionTableViewModel, NavigatableStateHolder, ObservableTa
                 }
             )
         )
+        // stringlint:ignore_stop
         viewController.present(modal, animated: animated, completion: nil)
         #else
         HelpViewModel.shareLogsInternal(
@@ -262,6 +264,7 @@ class HelpViewModel: SessionTableViewModel, NavigatableStateHolder, ObservableTa
     }
     
 #if DEBUG
+    // stringlint:ignore_contents
     private func exportDatabase(_ targetView: UIView?) {
         let generatedPassword: String = UUID().uuidString
         self.databaseKeyEncryptionPassword = generatedPassword
@@ -269,7 +272,7 @@ class HelpViewModel: SessionTableViewModel, NavigatableStateHolder, ObservableTa
         self.transitionToScreen(
             ConfirmationModal(
                 info: ConfirmationModal.Info(
-                    title: "Export Database", // stringlint:disable
+                    title: "Export Database",
                     body: .input(
                         explanation: NSAttributedString(
                             string: """
@@ -280,12 +283,12 @@ class HelpViewModel: SessionTableViewModel, NavigatableStateHolder, ObservableTa
                             This password will be used to encrypt the database decryption key and will be exported alongside the database
                             """
                         ),
-                        placeholder: "Enter a password", // stringlint:disable
+                        placeholder: "Enter a password",
                         initialValue: generatedPassword,
                         clearButton: true,
                         onChange: { [weak self] value in self?.databaseKeyEncryptionPassword = value }
                     ),
-                    confirmTitle: "Export", // stringlint:disable
+                    confirmTitle: "Export",
                     dismissOnConfirm: false,
                     onConfirm: { [weak self] modal in
                         modal.dismiss(animated: true) {
@@ -293,8 +296,8 @@ class HelpViewModel: SessionTableViewModel, NavigatableStateHolder, ObservableTa
                                 self?.transitionToScreen(
                                     ConfirmationModal(
                                         info: ConfirmationModal.Info(
-                                            title: "Error", // stringlint:disable
-                                            body: .text("Password must be at least 6 characters") // stringlint:disable
+                                            title: "Error",
+                                            body: .text("Password must be at least 6 characters")
                                         )
                                     ),
                                     transitionType: .present
@@ -320,14 +323,14 @@ class HelpViewModel: SessionTableViewModel, NavigatableStateHolder, ObservableTa
                                     self?.transitionToScreen(
                                         ConfirmationModal(
                                             info: ConfirmationModal.Info(
-                                                title: "Password", // stringlint:disable
+                                                title: "Password",
                                                 body: .text("""
                                                 The generated password was:
                                                 \(generatedPassword)
                                                 
                                                 Avoid sending this via the same means as the database
                                                 """),
-                                                confirmTitle: "Share", // stringlint:disable
+                                                confirmTitle: "Share",
                                                 dismissOnConfirm: false,
                                                 onConfirm: { [weak self] modal in
                                                     modal.dismiss(animated: true) {
@@ -364,16 +367,16 @@ class HelpViewModel: SessionTableViewModel, NavigatableStateHolder, ObservableTa
                                 let message: String = {
                                     switch error {
                                         case CryptoKitError.incorrectKeySize:
-                                            return "The password must be between 6 and 32 characters (padded to 32 bytes)" // stringlint:disable
+                                            return "The password must be between 6 and 32 characters (padded to 32 bytes)"
                                         
-                                        default: return "Failed to export database" // stringlint:disable
+                                        default: return "Failed to export database"
                                     }
                                 }()
                                 
                                 self?.transitionToScreen(
                                     ConfirmationModal(
                                         info: ConfirmationModal.Info(
-                                            title: "Error", // stringlint:disable
+                                            title: "Error",
                                             body: .text(message)
                                         )
                                     ),

--- a/Session/Settings/NotificationSettingsViewModel.swift
+++ b/Session/Settings/NotificationSettingsViewModel.swift
@@ -102,6 +102,7 @@ class NotificationSettingsViewModel: SessionTableViewModel, NavigatableStateHold
                                 allowedSeparators: [.top],
                                 customPadding: SessionCell.Padding(bottom: Values.verySmallSpacing)
                             ),
+                            // stringlint:ignore_contents
                             onTap: { [weak self] in
                                 UserDefaults.standard.set(
                                     !UserDefaults.standard.bool(forKey: "isUsingFullAPNs"),

--- a/Session/Settings/QRCodeScreen.swift
+++ b/Session/Settings/QRCodeScreen.swift
@@ -70,7 +70,7 @@ struct MyQRCodeScreen: View {
             QRCodeView(
                 string: getUserHexEncodedPublicKey(),
                 hasBackground: false,
-                logo: "SessionWhite40",
+                logo: "SessionWhite40", // stringlint:ignore
                 themeStyle: ThemeManager.currentTheme.interfaceStyle
             )
             .accessibility(

--- a/Session/Settings/RecoveryPasswordScreen.swift
+++ b/Session/Settings/RecoveryPasswordScreen.swift
@@ -73,7 +73,7 @@ struct RecoveryPasswordScreen: View {
                                 QRCodeView(
                                     string: hexEncodedSeed ?? "",
                                     hasBackground: false,
-                                    logo: "SessionShieldFilled",
+                                    logo: "SessionShieldFilled", // stringlint:ignore
                                     themeStyle: ThemeManager.currentTheme.interfaceStyle
                                 )
                                 .padding(.all, Values.smallSpacing)

--- a/Session/Settings/SettingsViewModel.swift
+++ b/Session/Settings/SettingsViewModel.swift
@@ -329,7 +329,7 @@ class SettingsViewModel: SessionTableViewModel, NavigationItemSource, Navigatabl
                     elements: [
                         SessionCell.Info(
                             id: .path,
-                            leftAccessory: .customView(hashValue: "PathStatusView") {   // stringlint:disable
+                            leftAccessory: .customView(hashValue: "PathStatusView") {   // stringlint:ignore
                                 // Need to ensure this view is the same size as the icons so
                                 // wrap it in a larger view
                                 let result: UIView = UIView()
@@ -576,7 +576,7 @@ class SettingsViewModel: SessionTableViewModel, NavigationItemSource, Navigatabl
             DispatchQueue.main.async {
                 let picker: UIImagePickerController = UIImagePickerController()
                 picker.sourceType = .photoLibrary
-                picker.mediaTypes = [ "public.image" ]  // stringlint:disable
+                picker.mediaTypes = [ "public.image" ]  // stringlint:ignore
                 picker.delegate = self?.imagePickerHandler
                 
                 self?.transitionToScreen(picker, transitionType: .present)

--- a/Session/Settings/Views/VersionFooterView.swift
+++ b/Session/Settings/Views/VersionFooterView.swift
@@ -33,13 +33,15 @@ class VersionFooterView: UIView {
         result.lineBreakMode = .byCharWrapping
         result.numberOfLines = 0
         
+        // stringlint:ignore_start
         let infoDict = Bundle.main.infoDictionary
-        let version: String = ((infoDict?["CFBundleShortVersionString"] as? String) ?? "0.0.0")   // stringlint:disable
-        let buildNumber: String? = (infoDict?["CFBundleVersion"] as? String)                      // stringlint:disable
-        let commitInfo: String? = (infoDict?["GitCommitHash"] as? String)                         // stringlint:disable
+        let version: String = ((infoDict?["CFBundleShortVersionString"] as? String) ?? "0.0.0")
+        let buildNumber: String? = (infoDict?["CFBundleVersion"] as? String)
+        let commitInfo: String? = (infoDict?["GitCommitHash"] as? String)
         let buildInfo: String = [buildNumber, commitInfo]
             .compactMap { $0 }
             .joined(separator: " - ")
+        // stringlint:ignore_stop
         result.text = [
             "Version \(version)",
             (!buildInfo.isEmpty ? " (" : ""),

--- a/Session/Shared/FullConversationCell.swift
+++ b/Session/Shared/FullConversationCell.swift
@@ -7,7 +7,7 @@ import SessionMessagingKit
 import SessionUtilitiesKit
 
 public final class FullConversationCell: UITableViewCell, SwipeActionOptimisticCell {
-    public static let mutePrefix: String = "\u{e067}  " // stringlint:disable
+    public static let mutePrefix: String = "\u{e067}  " // stringlint:ignore
     public static let unreadCountViewSize: CGFloat = 20
     private static let statusIndicatorSize: CGFloat = 14
     
@@ -105,7 +105,7 @@ public final class FullConversationCell: UITableViewCell, SwipeActionOptimisticC
         let result: UILabel = UILabel()
         result.font = .boldSystemFont(ofSize: Values.verySmallFontSize)
         result.themeTextColor = .conversationButton_unreadBubbleText
-        result.text = "@" // stringlint:disable
+        result.text = "@" // stringlint:ignore
         result.textAlignment = .center
         
         return result
@@ -427,7 +427,7 @@ public final class FullConversationCell: UITableViewCell, SwipeActionOptimisticC
         unreadImageView.isHidden = (!unreadCountView.isHidden || !threadIsUnread)
         unreadCountLabel.text = (unreadCount <= 0 ?
             "" :
-            (unreadCount < 10000 ? "\(unreadCount)" : "9999+") // stringlint:disable
+            (unreadCount < 10000 ? "\(unreadCount)" : "9999+") // stringlint:ignore
         )
         unreadCountLabel.font = .boldSystemFont(
             ofSize: (unreadCount < 10000 ? Values.verySmallFontSize : 8)
@@ -553,7 +553,7 @@ public final class FullConversationCell: UITableViewCell, SwipeActionOptimisticC
         if let hasUnread: Bool = hasUnread {
             if hasUnread {
                 unreadCountView.isHidden = false
-                unreadCountLabel.text = "1" // stringlint:disable
+                unreadCountLabel.text = "1" // stringlint:ignore
                 unreadCountLabel.font = .boldSystemFont(ofSize: Values.verySmallFontSize)
                 accentLineView.alpha = 1
             } else {
@@ -707,8 +707,8 @@ public final class FullConversationCell: UITableViewCell, SwipeActionOptimisticC
                 normalizedSnippet
                     .ranges(
                         of: (Singleton.hasAppContext && Singleton.appContext.isRTL ?
-                             "(\(part.lowercased()))(^|[^a-zA-Z0-9])" : // stringlint:disable
-                             "(^|[^a-zA-Z0-9])(\(part.lowercased()))" // stringlint:disable
+                             "(\(part.lowercased()))(^|[^a-zA-Z0-9])" : // stringlint:ignore
+                             "(^|[^a-zA-Z0-9])(\(part.lowercased()))"   // stringlint:ignore
                         ),
                         options: [.regularExpression]
                     )

--- a/Session/Shared/SessionCarouselView+SwiftUI.swift
+++ b/Session/Shared/SessionCarouselView+SwiftUI.swift
@@ -62,7 +62,7 @@ struct ArrowView: View {
     }
     
     var body: some View {
-        let imageName = self.type == .decrement ? "chevron.left" : "chevron.right"
+        let imageName = (self.type == .decrement ? "chevron.left" : "chevron.right") // stringlint:ignore
         Button {
             if self.type == .decrement {
                 decrement()

--- a/Session/Utilities/BackgroundPoller.swift
+++ b/Session/Utilities/BackgroundPoller.swift
@@ -155,7 +155,7 @@ public final class BackgroundPoller {
         using dependencies: Dependencies
     ) -> [AnyPublisher<Void, Never>] {
         return pollerInfo.map { poller, server -> AnyPublisher<Void, Never> in
-            let pollerName: String = "Community poller for server: \(server)"   // stringlint:disable
+            let pollerName: String = "Community poller for server: \(server)"   // stringlint:ignore
             let pollStart: TimeInterval = dependencies.dateNow.timeIntervalSince1970
             
             return poller

--- a/Session/Utilities/Date+Utilities.swift
+++ b/Session/Utilities/Date+Utilities.swift
@@ -1,5 +1,5 @@
 // Copyright © 2022 Rangeproof Pty Ltd. All rights reserved.
-
+//
 // stringlint:disable
 
 import Foundation

--- a/Session/Utilities/MentionUtilities.swift
+++ b/Session/Utilities/MentionUtilities.swift
@@ -52,7 +52,7 @@ public enum MentionUtilities {
         attributes: [NSAttributedString.Key: Any]
     ) -> NSAttributedString {
         guard
-            let regex: NSRegularExpression = try? NSRegularExpression(pattern: "@[0-9a-fA-F]{66}", options: []) // stringlint:disable
+            let regex: NSRegularExpression = try? NSRegularExpression(pattern: "@[0-9a-fA-F]{66}", options: [])
         else {
             return NSAttributedString(string: string)
         }
@@ -89,7 +89,7 @@ public enum MentionUtilities {
             }()
             else { continue }
             
-            string = string.replacingCharacters(in: range, with: "@\(targetString)") // stringlint:disable
+            string = string.replacingCharacters(in: range, with: "@\(targetString)")    // stringlint:ignore
             lastMatchEnd = (match.range.location + targetString.utf16.count)
             
             mentions.append((

--- a/Session/Utilities/QRCode.swift
+++ b/Session/Utilities/QRCode.swift
@@ -7,15 +7,17 @@ enum QRCode {
     ///
     /// **Note:** If the `hasBackground` value is true then the QRCode will be black and white and
     /// the `withRenderingMode(.alwaysTemplate)` won't work correctly on some iOS versions (eg. iOS 16)
+    ///
+    /// stringlint:ignore_contents
     static func generate(for string: String, hasBackground: Bool) -> UIImage {
         let data = string.data(using: .utf8)
         var qrCodeAsCIImage: CIImage
-        let filter1 = CIFilter(name: "CIQRCodeGenerator")! // stringlint:disable
+        let filter1 = CIFilter(name: "CIQRCodeGenerator")!
         filter1.setValue(data, forKey: "inputMessage")
         qrCodeAsCIImage = filter1.outputImage!
         
         guard !hasBackground else {
-            let filter2 = CIFilter(name: "CIFalseColor")! // stringlint:disable
+            let filter2 = CIFilter(name: "CIFalseColor")!
             filter2.setValue(qrCodeAsCIImage, forKey: "inputImage")
             filter2.setValue(CIColor(color: .black), forKey: "inputColor0")
             filter2.setValue(CIColor(color: .white), forKey: "inputColor1")
@@ -25,10 +27,10 @@ enum QRCode {
             return UIImage(ciImage: scaledQRCodeAsCIImage)
         }
         
-        let filter2 = CIFilter(name: "CIColorInvert")! // stringlint:disable
+        let filter2 = CIFilter(name: "CIColorInvert")!
         filter2.setValue(qrCodeAsCIImage, forKey: "inputImage")
         qrCodeAsCIImage = filter2.outputImage!
-        let filter3 = CIFilter(name: "CIMaskToAlpha")! // stringlint:disable
+        let filter3 = CIFilter(name: "CIMaskToAlpha")!
         filter3.setValue(qrCodeAsCIImage, forKey: "inputImage")
         qrCodeAsCIImage = filter3.outputImage!
         

--- a/SessionMessagingKit/Database/Migrations/_001_InitialSetupMigration.swift
+++ b/SessionMessagingKit/Database/Migrations/_001_InitialSetupMigration.swift
@@ -1,4 +1,6 @@
 // Copyright © 2022 Rangeproof Pty Ltd. All rights reserved.
+//
+// stringlint:disable
 
 import Foundation
 import GRDB
@@ -6,7 +8,7 @@ import SessionUtilitiesKit
 
 enum _001_InitialSetupMigration: Migration {
     static let target: TargetMigrations.Identifier = .messagingKit
-    static let identifier: String = "initialSetup" // stringlint:disable
+    static let identifier: String = "initialSetup"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.1
     static let fetchedTables: [(TableRecord & FetchableRecord).Type] = []
@@ -74,7 +76,7 @@ enum _001_InitialSetupMigration: Migration {
             t.column(.variant, .integer).notNull()
             t.column(.creationDateTimestamp, .double).notNull()
             t.column(.shouldBeVisible, .boolean).notNull()
-            t.deprecatedColumn(name: "isPinned", .boolean).notNull() // stringlint:disable
+            t.deprecatedColumn(name: "isPinned", .boolean).notNull()
             t.column(.messageDraft, .text)
             t.column(.notificationSound, .integer)
             t.column(.mutedUntilTimestamp, .double)

--- a/SessionMessagingKit/Database/Migrations/_002_SetupStandardJobs.swift
+++ b/SessionMessagingKit/Database/Migrations/_002_SetupStandardJobs.swift
@@ -9,7 +9,7 @@ import SessionSnodeKit
 /// before running the `YDBToGRDBMigration`
 enum _002_SetupStandardJobs: Migration {
     static let target: TargetMigrations.Identifier = .messagingKit
-    static let identifier: String = "SetupStandardJobs" // stringlint:disable
+    static let identifier: String = "SetupStandardJobs"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.1
     static let fetchedTables: [(TableRecord & FetchableRecord).Type] = []

--- a/SessionMessagingKit/Database/Migrations/_003_YDBToGRDBMigration.swift
+++ b/SessionMessagingKit/Database/Migrations/_003_YDBToGRDBMigration.swift
@@ -6,7 +6,7 @@ import SessionUtilitiesKit
 
 enum _003_YDBToGRDBMigration: Migration {
     static let target: TargetMigrations.Identifier = .messagingKit
-    static let identifier: String = "YDBToGRDBMigration" // stringlint:disable
+    static let identifier: String = "YDBToGRDBMigration"
     static let needsConfigSync: Bool = true
     static let minExpectedRunDuration: TimeInterval = 0.1
     static let fetchedTables: [(TableRecord & FetchableRecord).Type] = [Identity.self]

--- a/SessionMessagingKit/Database/Migrations/_004_RemoveLegacyYDB.swift
+++ b/SessionMessagingKit/Database/Migrations/_004_RemoveLegacyYDB.swift
@@ -8,7 +8,7 @@ import SessionSnodeKit
 /// This migration used to remove the legacy YapDatabase files (the old logic has been removed and is no longer supported so it now does nothing)
 enum _004_RemoveLegacyYDB: Migration {
     static let target: TargetMigrations.Identifier = .messagingKit
-    static let identifier: String = "RemoveLegacyYDB" // stringlint:disable
+    static let identifier: String = "RemoveLegacyYDB"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.1
     static let fetchedTables: [(TableRecord & FetchableRecord).Type] = []

--- a/SessionMessagingKit/Database/Migrations/_005_FixDeletedMessageReadState.swift
+++ b/SessionMessagingKit/Database/Migrations/_005_FixDeletedMessageReadState.swift
@@ -7,7 +7,7 @@ import SessionUtilitiesKit
 /// This migration fixes a bug where certain message variants could incorrectly be counted as unread messages
 enum _005_FixDeletedMessageReadState: Migration {
     static let target: TargetMigrations.Identifier = .messagingKit
-    static let identifier: String = "FixDeletedMessageReadState" // stringlint:disable
+    static let identifier: String = "FixDeletedMessageReadState"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.01
     static let fetchedTables: [(TableRecord & FetchableRecord).Type] = []

--- a/SessionMessagingKit/Database/Migrations/_006_FixHiddenModAdminSupport.swift
+++ b/SessionMessagingKit/Database/Migrations/_006_FixHiddenModAdminSupport.swift
@@ -8,7 +8,7 @@ import SessionUtilitiesKit
 /// for open groups so they will fully re-fetch their mod/admin lists
 enum _006_FixHiddenModAdminSupport: Migration {
     static let target: TargetMigrations.Identifier = .messagingKit
-    static let identifier: String = "FixHiddenModAdminSupport" // stringlint:disable
+    static let identifier: String = "FixHiddenModAdminSupport"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.01
     static let fetchedTables: [(TableRecord & FetchableRecord).Type] = []

--- a/SessionMessagingKit/Database/Migrations/_007_HomeQueryOptimisationIndexes.swift
+++ b/SessionMessagingKit/Database/Migrations/_007_HomeQueryOptimisationIndexes.swift
@@ -1,4 +1,6 @@
 // Copyright © 2022 Rangeproof Pty Ltd. All rights reserved.
+//
+// stringlint:disable
 
 import Foundation
 import GRDB
@@ -7,7 +9,7 @@ import SessionUtilitiesKit
 /// This migration adds an index to the interaction table in order to improve the performance of retrieving the number of unread interactions
 enum _007_HomeQueryOptimisationIndexes: Migration {
     static let target: TargetMigrations.Identifier = .messagingKit
-    static let identifier: String = "HomeQueryOptimisationIndexes" // stringlint:disable
+    static let identifier: String = "HomeQueryOptimisationIndexes"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.01
     static let fetchedTables: [(TableRecord & FetchableRecord).Type] = []
@@ -16,7 +18,7 @@ enum _007_HomeQueryOptimisationIndexes: Migration {
     
     static func migrate(_ db: Database, using dependencies: Dependencies) throws {
         try db.create(
-            index: "interaction_on_wasRead_and_hasMention_and_threadId", // stringlint:disable
+            index: "interaction_on_wasRead_and_hasMention_and_threadId",
             on: Interaction.databaseTableName,
             columns: [
                 Interaction.Columns.wasRead.name,
@@ -26,7 +28,7 @@ enum _007_HomeQueryOptimisationIndexes: Migration {
         )
         
         try db.create(
-            index: "interaction_on_threadId_and_timestampMs_and_variant", // stringlint:disable
+            index: "interaction_on_threadId_and_timestampMs_and_variant",
             on: Interaction.databaseTableName,
             columns: [
                 Interaction.Columns.threadId.name,

--- a/SessionMessagingKit/Database/Migrations/_008_EmojiReacts.swift
+++ b/SessionMessagingKit/Database/Migrations/_008_EmojiReacts.swift
@@ -7,7 +7,7 @@ import SessionUtilitiesKit
 /// This migration adds the new types needed for Emoji Reacts
 enum _008_EmojiReacts: Migration {
     static let target: TargetMigrations.Identifier = .messagingKit
-    static let identifier: String = "EmojiReacts" // stringlint:disable
+    static let identifier: String = "EmojiReacts"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.01
     static let fetchedTables: [(TableRecord & FetchableRecord).Type] = []

--- a/SessionMessagingKit/Database/Migrations/_009_OpenGroupPermission.swift
+++ b/SessionMessagingKit/Database/Migrations/_009_OpenGroupPermission.swift
@@ -6,7 +6,7 @@ import SessionUtilitiesKit
 
 enum _009_OpenGroupPermission: Migration {
     static let target: TargetMigrations.Identifier = .messagingKit
-    static let identifier: String = "OpenGroupPermission" // stringlint:disable
+    static let identifier: String = "OpenGroupPermission"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.01
     static let fetchedTables: [(TableRecord & FetchableRecord).Type] = []

--- a/SessionMessagingKit/Database/Migrations/_010_AddThreadIdToFTS.swift
+++ b/SessionMessagingKit/Database/Migrations/_010_AddThreadIdToFTS.swift
@@ -8,7 +8,7 @@ import SessionUtilitiesKit
 /// searh (currently it's much slower than the global search)
 enum _010_AddThreadIdToFTS: Migration {
     static let target: TargetMigrations.Identifier = .messagingKit
-    static let identifier: String = "AddThreadIdToFTS" // stringlint:disable
+    static let identifier: String = "AddThreadIdToFTS"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 3
     static let fetchedTables: [(TableRecord & FetchableRecord).Type] = []

--- a/SessionMessagingKit/Database/Migrations/_011_AddPendingReadReceipts.swift
+++ b/SessionMessagingKit/Database/Migrations/_011_AddPendingReadReceipts.swift
@@ -8,7 +8,7 @@ import SessionUtilitiesKit
 /// message due to how one-to-one conversations work, by storing pending read receipts we should be able to prevent this case)
 enum _011_AddPendingReadReceipts: Migration {
     static let target: TargetMigrations.Identifier = .messagingKit
-    static let identifier: String = "AddPendingReadReceipts" // stringlint:disable
+    static let identifier: String = "AddPendingReadReceipts"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.01
     static let fetchedTables: [(TableRecord & FetchableRecord).Type] = []

--- a/SessionMessagingKit/Database/Migrations/_012_AddFTSIfNeeded.swift
+++ b/SessionMessagingKit/Database/Migrations/_012_AddFTSIfNeeded.swift
@@ -7,7 +7,7 @@ import SessionUtilitiesKit
 /// This migration adds the FTS table back for internal test users whose FTS table was removed unintentionally
 enum _012_AddFTSIfNeeded: Migration {
     static let target: TargetMigrations.Identifier = .messagingKit
-    static let identifier: String = "AddFTSIfNeeded" // stringlint:disable
+    static let identifier: String = "AddFTSIfNeeded"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.01
     static let fetchedTables: [(TableRecord & FetchableRecord).Type] = []

--- a/SessionMessagingKit/Database/Migrations/_014_GenerateInitialUserConfigDumps.swift
+++ b/SessionMessagingKit/Database/Migrations/_014_GenerateInitialUserConfigDumps.swift
@@ -8,7 +8,7 @@ import SessionUtilitiesKit
 /// This migration goes through the current state of the database and generates config dumps for the user config types
 enum _014_GenerateInitialUserConfigDumps: Migration {
     static let target: TargetMigrations.Identifier = .messagingKit
-    static let identifier: String = "GenerateInitialUserConfigDumps" // stringlint:disable
+    static let identifier: String = "GenerateInitialUserConfigDumps"
     static let needsConfigSync: Bool = true
     static let minExpectedRunDuration: TimeInterval = 4.0
     static let fetchedTables: [(TableRecord & FetchableRecord).Type] = [

--- a/SessionMessagingKit/Database/Migrations/_015_BlockCommunityMessageRequests.swift
+++ b/SessionMessagingKit/Database/Migrations/_015_BlockCommunityMessageRequests.swift
@@ -7,7 +7,7 @@ import SessionUtilitiesKit
 /// This migration adds a flag indicating whether a profile has indicated it is blocking community message requests
 enum _015_BlockCommunityMessageRequests: Migration {
     static let target: TargetMigrations.Identifier = .messagingKit
-    static let identifier: String = "BlockCommunityMessageRequests" // stringlint:disable
+    static let identifier: String = "BlockCommunityMessageRequests"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.01
     static var requirements: [MigrationRequirement] = [.libSessionStateLoaded]

--- a/SessionMessagingKit/Database/Migrations/_016_MakeBrokenProfileTimestampsNullable.swift
+++ b/SessionMessagingKit/Database/Migrations/_016_MakeBrokenProfileTimestampsNullable.swift
@@ -8,7 +8,7 @@ import SessionUtilitiesKit
 /// results in migration issues when a user jumps between multiple versions)
 enum _016_MakeBrokenProfileTimestampsNullable: Migration {
     static let target: TargetMigrations.Identifier = .messagingKit
-    static let identifier: String = "MakeBrokenProfileTimestampsNullable" // stringlint:disable
+    static let identifier: String = "MakeBrokenProfileTimestampsNullable"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.1
     static var requirements: [MigrationRequirement] = [.libSessionStateLoaded]
@@ -20,7 +20,7 @@ enum _016_MakeBrokenProfileTimestampsNullable: Migration {
         /// SQLite doesn't support altering columns after creation so we need to create a new table with the setup we
         /// want, copy data from the old table over, drop the old table and rename the new table
         struct TmpProfile: Codable, TableRecord, FetchableRecord, PersistableRecord, ColumnExpressible {
-            static var databaseTableName: String { "tmpProfile" } // stringlint:disable
+            static var databaseTableName: String { "tmpProfile" }
             
             public typealias Columns = CodingKeys
             public enum CodingKeys: String, CodingKey, ColumnExpression {

--- a/SessionMessagingKit/Database/Migrations/_017_RebuildFTSIfNeeded_2_4_5.swift
+++ b/SessionMessagingKit/Database/Migrations/_017_RebuildFTSIfNeeded_2_4_5.swift
@@ -9,7 +9,7 @@ import SessionUtilitiesKit
 /// This migration adds the FTS table back if either the tables or any of the triggers no longer exist
 enum _017_RebuildFTSIfNeeded_2_4_5: Migration {
     static let target: TargetMigrations.Identifier = .messagingKit
-    static let identifier: String = "RebuildFTSIfNeeded_2_4_5" // stringlint:disable
+    static let identifier: String = "RebuildFTSIfNeeded_2_4_5"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.01
     static let fetchedTables: [(TableRecord & FetchableRecord).Type] = []

--- a/SessionMessagingKit/Database/Migrations/_018_DisappearingMessagesConfiguration.swift
+++ b/SessionMessagingKit/Database/Migrations/_018_DisappearingMessagesConfiguration.swift
@@ -6,7 +6,7 @@ import SessionUtilitiesKit
 
 enum _018_DisappearingMessagesConfiguration: Migration {
     static let target: TargetMigrations.Identifier = .messagingKit
-    static let identifier: String = "DisappearingMessagesWithTypes" // stringlint:disable
+    static let identifier: String = "DisappearingMessagesWithTypes"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.1
     static var requirements: [MigrationRequirement] = [.libSessionStateLoaded]

--- a/SessionMessagingKit/Database/Migrations/_019_ScheduleAppUpdateCheckJob.swift
+++ b/SessionMessagingKit/Database/Migrations/_019_ScheduleAppUpdateCheckJob.swift
@@ -6,7 +6,7 @@ import SessionUtilitiesKit
 
 enum _019_ScheduleAppUpdateCheckJob: Migration {
     static let target: TargetMigrations.Identifier = .messagingKit
-    static let identifier: String = "ScheduleAppUpdateCheckJob" // stringlint:disable
+    static let identifier: String = "ScheduleAppUpdateCheckJob"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.1
     static var requirements: [MigrationRequirement] = [.libSessionStateLoaded]

--- a/SessionMessagingKit/Database/Models/Attachment.swift
+++ b/SessionMessagingKit/Database/Models/Attachment.swift
@@ -283,21 +283,22 @@ extension Attachment: CustomStringConvertible {
             .localized()
     }
     
+    // stringlint:ignore_contents
     public static func emoji(for contentType: String) -> String {
         if UTType.isAnimated(contentType) {
-            return "🎡"     // stringlint:disable
+            return "🎡"
         }
         else if UTType.isVideo(contentType) {
-            return "🎥"     // stringlint:disable
+            return "🎥"
         }
         else if UTType.isAudio(contentType) {
-            return "🎧"     // stringlint:disable
+            return "🎧"
         }
         else if UTType.isImage(contentType) {
-            return "📷"     // stringlint:disable
+            return "📷"
         }
         
-        return "📎"         // stringlint:disable
+        return "📎"
     }
     
     public var description: String {
@@ -594,7 +595,7 @@ extension Attachment {
     
     private static var sharedDataAttachmentsDirPath: String = {
         URL(fileURLWithPath: FileManager.default.appSharedDataDirectoryPath)
-            .appendingPathComponent("Attachments") // stringlint:disable
+            .appendingPathComponent("Attachments") // stringlint:ignore
             .path
     }()
     
@@ -753,7 +754,7 @@ extension Attachment {
 // MARK: - Convenience
 
 extension Attachment {
-    public static let nonMediaQuoteFileId: String = "NON_MEDIA_QUOTE_FILE_ID" // stringlint:disable
+    public static let nonMediaQuoteFileId: String = "NON_MEDIA_QUOTE_FILE_ID" // stringlint:ignore
     
     public enum ThumbnailSize {
         case small
@@ -786,7 +787,7 @@ extension Attachment {
     var thumbnailsDirPath: String {
         // Thumbnails are written to the caches directory, so that iOS can
         // remove them if necessary
-        return "\(FileSystem.cachesDirectoryPath)/\(id)-thumbnails" // stringlint:disable
+        return "\(FileSystem.cachesDirectoryPath)/\(id)-thumbnails" // stringlint:ignore
     }
     
     var legacyThumbnailPath: String? {
@@ -799,7 +800,7 @@ extension Attachment {
         let filename: String = fileUrl.lastPathComponent.filenameWithoutExtension
         let containingDir: String = fileUrl.deletingLastPathComponent().path
         
-        return "\(containingDir)/\(filename)-signal-ios-thumbnail.jpg" // stringlint:disable
+        return "\(containingDir)/\(filename)-signal-ios-thumbnail.jpg" // stringlint:ignore
     }
     
     var originalImage: UIImage? {
@@ -852,7 +853,7 @@ extension Attachment {
     }
     
     public func thumbnailPath(for dimensions: UInt) -> String {
-        return "\(thumbnailsDirPath)/thumbnail-\(dimensions).jpg" // stringlint:disable
+        return "\(thumbnailsDirPath)/thumbnail-\(dimensions).jpg" // stringlint:ignore
     }
     
     private func loadThumbnail(with dimensions: UInt, success: @escaping (UIImage, () throws -> Data) -> (), failure: @escaping () -> ()) {
@@ -930,7 +931,7 @@ extension Attachment {
     
     public func cloneAsQuoteThumbnail() -> Attachment? {
         let cloneId: String = UUID().uuidString
-        let thumbnailName: String = "quoted-thumbnail-\(sourceFilename ?? "null")" // stringlint:disable
+        let thumbnailName: String = "quoted-thumbnail-\(sourceFilename ?? "null")" // stringlint:ignore
         
         guard self.isVisualMedia else { return nil }
         

--- a/SessionMessagingKit/Database/Models/ConfigDump.swift
+++ b/SessionMessagingKit/Database/Models/ConfigDump.swift
@@ -87,6 +87,7 @@ public extension ConfigDump.Variant {
 
 // MARK: - CustomStringConvertible
 
+// stringlint:ignore_contents
 extension ConfigDump.Variant: CustomStringConvertible {
     public var description: String {
         switch self {

--- a/SessionMessagingKit/Database/Models/Interaction.swift
+++ b/SessionMessagingKit/Database/Models/Interaction.swift
@@ -28,13 +28,15 @@ public struct Interaction: Codable, Identifiable, Equatable, FetchableRecord, Mu
     /// Whenever using this `linkPreview` association make sure to filter the result using
     /// `.filter(literal: Interaction.linkPreviewFilterLiteral)` to ensure the correct LinkPreview is returned
     public static let linkPreview = hasOne(LinkPreview.self, using: LinkPreview.interactionForeignKey)
+    
+    // stringlint:ignore_contents
     public static func linkPreviewFilterLiteral(
         interaction: TypedTableAlias<Interaction> = TypedTableAlias(),
         linkPreview: TypedTableAlias<LinkPreview> = TypedTableAlias()
     ) -> SQL {
         let halfResolution: Double = LinkPreview.timstampResolution
 
-        return "(\(interaction[.timestampMs]) BETWEEN (\(linkPreview[.timestamp]) - \(halfResolution)) * 1000 AND (\(linkPreview[.timestamp]) + \(halfResolution)) * 1000)" // stringlint:disable
+        return "(\(interaction[.timestampMs]) BETWEEN (\(linkPreview[.timestamp]) - \(halfResolution)) * 1000 AND (\(linkPreview[.timestamp]) + \(halfResolution)) * 1000)"
     }
     public static let recipientStates = hasMany(RecipientState.self, using: RecipientState.interactionForeignKey)
     
@@ -916,7 +918,8 @@ public extension Interaction {
             quoteAuthorId: quoteAuthorId
         )
     }
-        
+    
+    // stringlint:ignore_contents
     static func isUserMentioned(
         publicKeysToCheck: [String],
         body: String?,
@@ -927,7 +930,7 @@ public extension Interaction {
         return publicKeysToCheck.contains { publicKey in
             (
                 body != nil &&
-                (body ?? "").contains("@\(publicKey)") // stringlint:disable
+                (body ?? "").contains("@\(publicKey)")
             ) || (
                 quoteAuthorId == publicKey
             )

--- a/SessionMessagingKit/Database/Models/Profile.swift
+++ b/SessionMessagingKit/Database/Models/Profile.swift
@@ -330,13 +330,15 @@ public extension Profile {
     }
     
     /// A standardised mechanism for truncating a user id
+    ///
+    /// stringlint:ignore_contents
     static func truncated(id: String, truncating: Truncation) -> String {
         guard id.count > 8 else { return id }
         
         switch truncating {
-            case .start: return "...\(id.suffix(8))"                    //stringlint:disable
-            case .middle: return "\(id.prefix(4))...\(id.suffix(4))"    //stringlint:disable
-            case .end: return "\(id.prefix(8))..."                      //stringlint:disable
+            case .start: return "...\(id.suffix(8))"
+            case .middle: return "\(id.prefix(4))...\(id.suffix(4))"
+            case .end: return "\(id.prefix(8))..."
         }
     }
     

--- a/SessionMessagingKit/Jobs/Types/AttachmentDownloadJob.swift
+++ b/SessionMessagingKit/Jobs/Types/AttachmentDownloadJob.swift
@@ -230,10 +230,11 @@ extension AttachmentDownloadJob {
         case failedToSaveFile
         case invalidUrl
 
+        // stringlint:ignore_contents
         public var errorDescription: String? {
             switch self {
-                case .failedToSaveFile: return "Failed to save file" // stringlint:disable
-                case .invalidUrl: return "Invalid file URL" // stringlint:disable
+                case .failedToSaveFile: return "Failed to save file"
+                case .invalidUrl: return "Invalid file URL"
             }
         }
     }

--- a/SessionMessagingKit/Jobs/Types/GarbageCollectionJob.swift
+++ b/SessionMessagingKit/Jobs/Types/GarbageCollectionJob.swift
@@ -413,12 +413,14 @@ public enum GarbageCollectionJob: JobExecutor {
                         // distinguish empty directories from ones with content so we don't unintentionally delete a
                         // directory which contains content to keep as well as delete (directories which end up empty after
                         // this clean up will be removed during the next run)
+                        // stringlint:ignore_start
                         let directoryNamesContainingContent: [String] = allAttachmentFilePaths
-                            .filter { path -> Bool in path.contains("/") }  // stringlint:disable
-                            .compactMap { path -> String? in path.components(separatedBy: "/").first }  // stringlint:disable
+                            .filter { path -> Bool in path.contains("/") }
+                            .compactMap { path -> String? in path.components(separatedBy: "/").first }
                         let orphanedAttachmentFiles: Set<String> = allAttachmentFilePaths
                             .subtracting(fileInfo.attachmentLocalRelativePaths)
                             .subtracting(directoryNamesContainingContent)
+                        // stringlint:ignore_stop
                         
                         orphanedAttachmentFiles.forEach { filepath in
                             // We don't want a single deletion failure to block deletion of the other files so try

--- a/SessionMessagingKit/LibSession/LibSession+SessionMessagingKit.swift
+++ b/SessionMessagingKit/LibSession/LibSession+SessionMessagingKit.swift
@@ -51,8 +51,9 @@ public extension LibSession {
     
     // MARK: - Variables
     
+    // stringlint:ignore_contents
     internal static func syncDedupeId(_ publicKey: String) -> String {
-        return "EnqueueConfigurationSyncJob-\(publicKey)"   // stringlint:disable
+        return "EnqueueConfigurationSyncJob-\(publicKey)"
     }
     
     static var libSessionVersion: String { String(cString: LIBSESSION_UTIL_VERSION_STR) }
@@ -203,6 +204,7 @@ public extension LibSession {
     
     // MARK: - Pushes
     
+    // stringlint:ignore_contents
     static func pendingChanges(
         _ db: Database,
         publicKey: String,
@@ -257,11 +259,11 @@ public extension LibSession {
                         guard let cPushData: UnsafeMutablePointer<config_push_data> = config_push(conf) else {
                             let configCountInfo: String = {
                                 switch variant {
-                                    case .userProfile: return "1 profile"  // stringlint:disable
-                                    case .contacts: return "\(contacts_size(conf)) contacts"  // stringlint:disable
-                                    case .userGroups: return "\(user_groups_size(conf)) group conversations"  // stringlint:disable
-                                    case .convoInfoVolatile: return "\(convo_info_volatile_size(conf)) volatile conversations"  // stringlint:disable
-                                    case .invalid: return "Invalid"  // stringlint:disable
+                                    case .userProfile: return "1 profile"
+                                    case .contacts: return "\(contacts_size(conf)) contacts"
+                                    case .userGroups: return "\(user_groups_size(conf)) group conversations"
+                                    case .convoInfoVolatile: return "\(convo_info_volatile_size(conf)) volatile conversations"
+                                    case .invalid: return "Invalid"
                                 }
                             }()
                             

--- a/SessionMessagingKit/Messages/Control Messages/CallMessage.swift
+++ b/SessionMessagingKit/Messages/Control Messages/CallMessage.swift
@@ -43,14 +43,15 @@ public final class CallMessage: ControlMessage {
         case iceCandidates(sdpMLineIndexes: [UInt32], sdpMids: [String])
         case endCall
         
+        // stringlint:ignore_contents
         public var description: String {
             switch self {
-                case .preOffer: return "preOffer" // stringlint:disable
-                case .offer: return "offer" // stringlint:disable
-                case .answer: return "answer" // stringlint:disable
-                case .provisionalAnswer: return "provisionalAnswer" // stringlint:disable
-                case .iceCandidates(_, _): return "iceCandidates" // stringlint:disable
-                case .endCall: return "endCall" // stringlint:disable
+                case .preOffer: return "preOffer"
+                case .offer: return "offer"
+                case .answer: return "answer"
+                case .provisionalAnswer: return "provisionalAnswer"
+                case .iceCandidates(_, _): return "iceCandidates"
+                case .endCall: return "endCall"
             }
         }
         

--- a/SessionMessagingKit/Messages/Control Messages/ClosedGroupControlMessage.swift
+++ b/SessionMessagingKit/Messages/Control Messages/ClosedGroupControlMessage.swift
@@ -47,15 +47,16 @@ public final class ClosedGroupControlMessage: ControlMessage {
         case memberLeft
         case encryptionKeyPairRequest
 
+        // stringlint:ignore_contents
         public var description: String {
             switch self {
-                case .new: return "new" // stringlint:disable
-                case .encryptionKeyPair: return "encryptionKeyPair" // stringlint:disable
-                case .nameChange: return "nameChange" // stringlint:disable
-                case .membersAdded: return "membersAdded" // stringlint:disable
-                case .membersRemoved: return "membersRemoved" // stringlint:disable
-                case .memberLeft: return "memberLeft" // stringlint:disable
-                case .encryptionKeyPairRequest: return "encryptionKeyPairRequest" // stringlint:disable
+                case .new: return "new"
+                case .encryptionKeyPair: return "encryptionKeyPair"
+                case .nameChange: return "nameChange"
+                case .membersAdded: return "membersAdded"
+                case .membersRemoved: return "membersRemoved"
+                case .memberLeft: return "memberLeft"
+                case .encryptionKeyPairRequest: return "encryptionKeyPairRequest"
             }
         }
         

--- a/SessionMessagingKit/Messages/Control Messages/DataExtractionNotification.swift
+++ b/SessionMessagingKit/Messages/Control Messages/DataExtractionNotification.swift
@@ -21,8 +21,8 @@ public final class DataExtractionNotification: ControlMessage {
 
         public var description: String {
             switch self {
-                case .screenshot: return "screenshot" // stringlint:disable
-                case .mediaSaved: return "mediaSaved" // stringlint:disable
+                case .screenshot: return "screenshot"
+                case .mediaSaved: return "mediaSaved"
             }
         }
     }

--- a/SessionMessagingKit/Messages/Control Messages/TypingIndicator.swift
+++ b/SessionMessagingKit/Messages/Control Messages/TypingIndicator.swift
@@ -32,10 +32,11 @@ public final class TypingIndicator: ControlMessage {
             }
         }
         
+        // stringlint:ignore_contents
         public var description: String {
             switch self {
-                case .started: return "started" // stringlint:disable
-                case .stopped: return "stopped" // stringlint:disable
+                case .started: return "started"
+                case .stopped: return "stopped"
             }
         }
     }

--- a/SessionMessagingKit/Messages/Visible Messages/VisibleMessage+Reaction.swift
+++ b/SessionMessagingKit/Messages/Visible Messages/VisibleMessage+Reaction.swift
@@ -26,10 +26,11 @@ public extension VisibleMessage {
             case react
             case remove
             
+            // stringlint:ignore_contents
             var description: String {
                 switch self {
-                    case .react: return "react" // stringlint:disable
-                    case .remove: return "remove" // stringlint:disable
+                    case .react: return "react"
+                    case .remove: return "remove"
                 }
             }
             

--- a/SessionMessagingKit/Open Groups/OpenGroupManager.swift
+++ b/SessionMessagingKit/Open Groups/OpenGroupManager.swift
@@ -62,9 +62,10 @@ public final class OpenGroupManager {
 
     // MARK: - Adding & Removing
     
+    // stringlint:ignore_contents
     private static func port(for server: String, serverUrl: URL) -> String {
         if let port: Int = serverUrl.port {
-            return ":\(port)" // stringlint:disable
+            return ":\(port)"
         }
         
         let components: [String] = server.components(separatedBy: ":")
@@ -77,7 +78,7 @@ public final class OpenGroupManager {
             )
         else { return "" }
         
-        return ":\(port)" // stringlint:disable
+        return ":\(port)"
     }
     
     public static func isSessionRunOpenGroup(server: String) -> Bool {

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+VisibleMessages.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+VisibleMessages.swift
@@ -151,6 +151,7 @@ extension MessageReceiver {
             expiresStartedAtMs: message.expiresStartedAtMs
         )
         do {
+            // stringlint:ignore_start
             interaction = try Interaction(
                 serverHash: message.serverHash, // Keep track of server hash
                 threadId: thread.id,
@@ -183,6 +184,7 @@ extension MessageReceiver {
                     return recipientParts[2]
                 }()
             ).inserted(db)
+            // stringlint:ignore_stop
         }
         catch {
             switch error {

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageSender+ClosedGroups.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageSender+ClosedGroups.swift
@@ -117,6 +117,7 @@ extension MessageSender {
                 // Prepare the notification subscription
                 var preparedNotificationSubscription: Network.PreparedRequest<PushNotificationAPI.LegacyPushServerResponse>?
                 
+                // stringlint:ignore_start
                 if let token: String = dependencies.standardUserDefaults[.deviceToken] {
                     preparedNotificationSubscription = try? PushNotificationAPI
                         .preparedSubscribeToLegacyGroups(
@@ -124,7 +125,7 @@ extension MessageSender {
                             currentUserPublicKey: userPublicKey,
                             legacyGroupIds: try ClosedGroup
                                 .select(.threadId)
-                                .filter(!ClosedGroup.Columns.threadId.like("\(SessionId.Prefix.group.rawValue)%")) // stringlint:disable
+                                .filter(!ClosedGroup.Columns.threadId.like("\(SessionId.Prefix.group.rawValue)%"))
                                 .joining(
                                     required: ClosedGroup.members
                                         .filter(GroupMember.Columns.profileId == userPublicKey)
@@ -135,6 +136,7 @@ extension MessageSender {
                             using: dependencies
                         )
                 }
+                // stringlint:ignore_stop
                 
                 return (thread, memberSendData, preparedNotificationSubscription)
             }

--- a/SessionMessagingKit/Sending & Receiving/MessageReceiver.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageReceiver.swift
@@ -389,7 +389,7 @@ public enum MessageReceiver {
                 // For disappear after send, this is necessary so the message will disappear even if it is not read
                 if threadVariant != .community {
                     db.afterNextTransactionNestedOnce(
-                        dedupeId: "PostInsertDisappearingMessagesJob",  // stringlint:disable
+                        dedupeId: "PostInsertDisappearingMessagesJob",  // stringlint:ignore
                         onCommit: { db in
                             JobRunner.upsert(
                                 db,

--- a/SessionMessagingKit/Sending & Receiving/MessageSender.swift
+++ b/SessionMessagingKit/Sending & Receiving/MessageSender.swift
@@ -358,6 +358,7 @@ public final class MessageSender {
     ) throws -> PreparedSendData {
         let threadId: String
         
+        // stringlint:ignore_start
         switch destination {
             case .contact, .syncMessage, .closedGroup, .openGroupInbox: preconditionFailure()
             case .openGroup(let roomToken, let server, let whisperTo, let whisperMods, _):
@@ -371,6 +372,7 @@ public final class MessageSender {
                 .compactMap { $0 }
                 .joined(separator: ".")
         }
+        // stringlint:ignore_stop
         
         // Note: It's possible to send a message and then delete the open group you sent the message to
         // which would go into this case, so rather than handling it as an invalid state we just want to

--- a/SessionMessagingKit/Sending & Receiving/Notifications/Models/SubscribeRequest.swift
+++ b/SessionMessagingKit/Sending & Receiving/Notifications/Models/SubscribeRequest.swift
@@ -1,4 +1,6 @@
 // Copyright © 2023 Rangeproof Pty Ltd. All rights reserved.
+//
+// stringlint:disable
 
 import Foundation
 import SessionSnodeKit
@@ -125,10 +127,10 @@ extension PushNotificationAPI {
             /// on whether the subscription wants message data included; and the trailing `NS[i]` values are a
             /// comma-delimited list of namespaces that should be subscribed to, in the same sorted order as
             /// the `namespaces` parameter.
-            let verificationBytes: [UInt8] = "MONITOR".bytes // stringlint:disable
+            let verificationBytes: [UInt8] = "MONITOR".bytes
                 .appending(contentsOf: pubkey.bytes)
                 .appending(contentsOf: "\(timestamp)".bytes)
-                .appending(contentsOf: (includeMessageData ? "1" : "0").bytes) // stringlint:disable
+                .appending(contentsOf: (includeMessageData ? "1" : "0").bytes)
                 .appending(
                     contentsOf: namespaces
                         .map { $0.rawValue }    // Intentionally not using `verificationString` here

--- a/SessionMessagingKit/Sending & Receiving/Notifications/Models/UnsubscribeRequest.swift
+++ b/SessionMessagingKit/Sending & Receiving/Notifications/Models/UnsubscribeRequest.swift
@@ -94,7 +94,7 @@ extension PushNotificationAPI {
             /// `"UNSUBSCRIBE" || HEX(ACCOUNT) || SIG_TS`
             ///
             /// Where `SIG_TS` is the `sig_ts` value as a base-10 string and must be within 24 hours of the current time.
-            let verificationBytes: [UInt8] = "UNSUBSCRIBE".bytes // stringlint:disable
+            let verificationBytes: [UInt8] = "UNSUBSCRIBE".bytes
                 .appending(contentsOf: pubkey.bytes)
                 .appending(contentsOf: "\(timestamp)".data(using: .ascii)?.bytes)
             

--- a/SessionMessagingKit/Sending & Receiving/Pollers/CurrentUserPoller.swift
+++ b/SessionMessagingKit/Sending & Receiving/Pollers/CurrentUserPoller.swift
@@ -46,8 +46,9 @@ public final class CurrentUserPoller: Poller {
     
     // MARK: - Abstract Methods
     
+    // stringlint:ignore_contents
     override public func pollerName(for publicKey: String) -> String {
-        return "Main Poller" // stringlint:disable
+        return "Main Poller"
     }
     
     override func nextPollDelay(for publicKey: String, using dependencies: Dependencies) -> TimeInterval {

--- a/SessionMessagingKit/Sending & Receiving/Pollers/OpenGroupPoller.swift
+++ b/SessionMessagingKit/Sending & Receiving/Pollers/OpenGroupPoller.swift
@@ -272,6 +272,7 @@ extension OpenGroupAPI {
                 .eraseToAnyPublisher()
         }
         
+        // stringlint:ignore_contents
         private func updateCapabilitiesAndRetryIfNeeded(
             server: String,
             isPostCapabilitiesRetry: Bool,
@@ -287,7 +288,7 @@ extension OpenGroupAPI {
                 !isPostCapabilitiesRetry,
                 let error: NetworkError = error as? NetworkError,
                 case .badRequest(let dataString, _) = error,
-                dataString.contains("Invalid authentication: this server requires the use of blinded ids") // stringlint:disable
+                dataString.contains("Invalid authentication: this server requires the use of blinded ids")
             else {
                 return Just(false)
                     .setFailureType(to: Error.self)

--- a/SessionMessagingKit/Shared Models/MentionInfo.swift
+++ b/SessionMessagingKit/Shared Models/MentionInfo.swift
@@ -19,6 +19,7 @@ public struct MentionInfo: FetchableRecord, Decodable, ColumnExpressible {
 }
 
 public extension MentionInfo {
+    // stringlint:ignore_contents
     static func query(
         userPublicKey: String,
         threadId: String,

--- a/SessionMessagingKit/Utilities/OWSAudioPlayer.m
+++ b/SessionMessagingKit/Utilities/OWSAudioPlayer.m
@@ -70,8 +70,10 @@ NS_ASSUME_NONNULL_BEGIN
     _mediaUrl = mediaUrl;
     _delegate = delegate;
 
+    // stringlint:ignore_start
     NSString *audioActivityDescription = [NSString stringWithFormat:@"%@ %@", @"OWSAudioPlayer", self.mediaUrl];
     _audioActivity = [[OWSAudioActivity alloc] initWithAudioDescription:audioActivityDescription behavior:audioBehavior];
+    // stringlint:ignore_stop
 
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(applicationDidEnterBackground:)

--- a/SessionMessagingKit/Utilities/OWSWindowManager.m
+++ b/SessionMessagingKit/Utilities/OWSWindowManager.m
@@ -1,6 +1,7 @@
 //
 //  Copyright (c) 2019 Open Whisper Systems. All rights reserved.
 //
+// stringlint:disable
 
 #import "OWSWindowManager.h"
 #import <SessionMessagingKit/SessionMessagingKit-Swift.h>

--- a/SessionMessagingKit/Utilities/Preferences.swift
+++ b/SessionMessagingKit/Utilities/Preferences.swift
@@ -6,6 +6,7 @@ import GRDB
 import DifferenceKit
 import SessionUtilitiesKit
 
+// stringlint:ignore_contents
 public extension Setting.EnumKey {
     /// Controls how notifications should appear for the user (See `NotificationPreviewType` for the options)
     static let preferencesNotificationPreviewType: Setting.EnumKey = "preferencesNotificationPreviewType"
@@ -14,6 +15,7 @@ public extension Setting.EnumKey {
     static let defaultNotificationSound: Setting.EnumKey = "defaultNotificationSound"
 }
 
+// stringlint:ignore_contents
 public extension Setting.BoolKey {
     /// Controls whether typing indicators are enabled
     ///
@@ -73,6 +75,7 @@ public extension Setting.BoolKey {
     static let checkForCommunityMessageRequests: Setting.BoolKey = "checkForCommunityMessageRequests"
 }
 
+// stringlint:ignore_contents
 public extension Setting.StringKey {
     /// This is the most recently recorded Push Notifications token
     static let lastRecordedPushToken: Setting.StringKey = "lastRecordedPushToken"
@@ -89,12 +92,14 @@ public extension Setting.StringKey {
     }
 }
 
+// stringlint:ignore_contents
 public extension Setting.DoubleKey {
     /// The duration of the timeout for screen lock in seconds
     @available(*, unavailable, message: "Screen Lock should always be instant now")
     static let screenLockTimeoutSeconds: Setting.DoubleKey = "screenLockTimeoutSeconds"
 }
 
+// stringlint:ignore_contents
 public extension Setting.IntKey {
     /// This is the number of times the app has successfully become active, it's not actually used for anything but allows us to make
     /// a database change on launch so the database will output an error if it fails to write
@@ -221,6 +226,7 @@ public enum Preferences {
         
         // MARK: - Functions
         
+        // stringlint:ignore_contents
         public func filename(quiet: Bool = false) -> String? {
             switch self {
                 case .`default`: return ""
@@ -319,6 +325,7 @@ public enum Preferences {
         }
     }
     
+    // stringlint:ignore_contents
     public static var isCallKitSupported: Bool {
 #if targetEnvironment(simulator)
         /// The iOS simulator doesn't support CallKit, when receiving a call on the simulator and routing it via CallKit it

--- a/SessionMessagingKit/Utilities/ProfileManager.swift
+++ b/SessionMessagingKit/Utilities/ProfileManager.swift
@@ -161,9 +161,10 @@ public struct ProfileManager {
     
     // MARK: - File Paths
     
+    // stringlint:ignore_contents
     public static let sharedDataProfileAvatarsDirPath: String = {
         let path: String = URL(fileURLWithPath: FileManager.default.appSharedDataDirectoryPath)
-            .appendingPathComponent("ProfileAvatars")   // stringlint:disable
+            .appendingPathComponent("ProfileAvatars")
             .path
         try? FileSystem.ensureDirectoryExists(at: path)
         
@@ -219,7 +220,7 @@ public struct ProfileManager {
             profileKeyAtStart.count > 0
         else { return }
         
-        let fileName: String = UUID().uuidString.appendingFileExtension("jpg")  // stringlint:disable
+        let fileName: String = UUID().uuidString.appendingFileExtension("jpg")  // stringlint:ignore
         let filePath: String = ProfileManager.profileAvatarFilepath(filename: fileName)
         var backgroundTask: SessionBackgroundTask? = SessionBackgroundTask(label: #function)
         
@@ -328,10 +329,12 @@ public struct ProfileManager {
                             profileAvatarCache.mutate { $0[fileName] = nil }
                         }
                         
+                        // stringlint:ignore_start
                         Log.debug(existingProfileUrl != nil ?
-                            "Updating local profile on service with cleared avatar." :  // stringlint:disable
-                            "Updating local profile on service with no avatar."         // stringlint:disable
+                            "Updating local profile on service with cleared avatar." :
+                            "Updating local profile on service with no avatar."
                         )
+                        // stringlint:ignore_stop
                     }
                     
                     try ProfileManager.updateProfileIfNeeded(
@@ -434,11 +437,12 @@ public struct ProfileManager {
                 }()
                 
                 newProfileKey = try Randomness.generateRandomBytes(numberBytes: ProfileManager.avatarAES256KeyByteLength)
+                // stringlint:ignore_contents
                 fileExtension = {
                     switch guessedFormat {
-                        case .gif: return "gif"     // stringlint:disable
-                        case .webp: return "webp"   // stringlint:disable
-                        default: return "jpg"       // stringlint:disable
+                        case .gif: return "gif"
+                        case .webp: return "webp"
+                        default: return "jpg"
                     }
                 }()
             }
@@ -609,7 +613,7 @@ public struct ProfileManager {
         // FIXME: We don't want to trigger the download within the notification extension, as part of the groups rebuild this has been moved into a Job which won't be run so this logic can be removed
         guard avatarNeedsDownload && Singleton.hasAppContext && Singleton.appContext.isMainApp else { return }
         
-        let dedupeIdentifier: String = "AvatarDownload-\(publicKey)-\(targetAvatarUrl ?? "remove")" // stringlint:disable
+        let dedupeIdentifier: String = "AvatarDownload-\(publicKey)-\(targetAvatarUrl ?? "remove")" // stringlint:ignore
         
         db.afterNextTransactionNestedOnce(dedupeId: dedupeIdentifier) { db in
             // Need to refetch to ensure the db changes have occurred

--- a/SessionNotificationServiceExtension/NSENotificationPresenter.swift
+++ b/SessionNotificationServiceExtension/NSENotificationPresenter.swift
@@ -280,7 +280,7 @@ private extension String {
             var matchEnd = m1.range.location + m1.range.length
             
             if let displayName: String = Profile.displayNameNoFallback(id: publicKey) {
-                result = (result as NSString).replacingCharacters(in: m1.range, with: "@\(displayName)") // stringlint:disable
+                result = (result as NSString).replacingCharacters(in: m1.range, with: "@\(displayName)")
                 mentions.append((range: NSRange(location: m1.range.location, length: displayName.utf16.count + 1), publicKey: publicKey)) // + 1 to include the @
                 matchEnd = m1.range.location + displayName.utf16.count
             }

--- a/SessionNotificationServiceExtension/NotificationServiceExtension.swift
+++ b/SessionNotificationServiceExtension/NotificationServiceExtension.swift
@@ -18,11 +18,13 @@ public final class NotificationServiceExtension: UNNotificationServiceExtension 
     private var request: UNNotificationRequest?
     private var hasCompleted: Atomic<Bool> = Atomic(false)
 
-    public static let isFromRemoteKey = "remote"                                                                   // stringlint:disable
-    public static let threadIdKey = "Signal.AppNotificationsUserInfoKey.threadId"                                  // stringlint:disable
-    public static let threadVariantRaw = "Signal.AppNotificationsUserInfoKey.threadVariantRaw"                     // stringlint:disable
-    public static let threadNotificationCounter = "Session.AppNotificationsUserInfoKey.threadNotificationCounter"  // stringlint:disable
+    // stringlint:ignore_start
+    public static let isFromRemoteKey = "remote"
+    public static let threadIdKey = "Signal.AppNotificationsUserInfoKey.threadId"
+    public static let threadVariantRaw = "Signal.AppNotificationsUserInfoKey.threadVariantRaw"
+    public static let threadNotificationCounter = "Session.AppNotificationsUserInfoKey.threadNotificationCounter"
     private static let callPreOfferLargeNotificationSupressionDuration: TimeInterval = 30
+    // stringlint:ignore_stop
 
     // MARK: Did receive a remote push notification request
     

--- a/SessionShareExtension/ShareNavController.swift
+++ b/SessionShareExtension/ShareNavController.swift
@@ -52,11 +52,13 @@ final class ShareNavController: UINavigationController, ShareViewDelegate {
 
         AppSetup.setupEnvironment(
             appSpecificBlock: {
+                // stringlint:ignore_start
                 Log.setup(with: Logger(
-                    primaryPrefix: "SessionShareExtension",                                              // stringlint:disable
+                    primaryPrefix: "SessionShareExtension",
                     level: .info,
-                    customDirectory: "\(FileManager.default.appSharedDataDirectoryPath)/Logs/ShareExtension" // stringlint:disable
+                    customDirectory: "\(FileManager.default.appSharedDataDirectoryPath)/Logs/ShareExtension"
                 ))
+                // stringlint:ignore_stop
                 
                 SessionEnvironment.shared?.notificationsManager.mutate {
                     $0 = NoopNotificationsManager()
@@ -426,7 +428,7 @@ final class ShareNavController: UINavigationController, ShareViewDelegate {
                     
                     switch value {
                         case let data as Data:
-                            let customFileName = "Contact.vcf" // stringlint:disable
+                            let customFileName = "Contact.vcf" // stringlint:ignore
                             let customFileExtension: String? = srcType.sessionFileExtension
                             
                             guard let tempFilePath = try? FileSystem.write(data: data, toTemporaryFileWithExtension: customFileExtension) else {
@@ -457,7 +459,7 @@ final class ShareNavController: UINavigationController, ShareViewDelegate {
                                 )
                                 return
                             }
-                            guard let tempFilePath: String = try? FileSystem.write(data: data, toTemporaryFileWithExtension: "txt") else { // stringlint:disable
+                            guard let tempFilePath: String = try? FileSystem.write(data: data, toTemporaryFileWithExtension: "txt") else { // stringlint:ignore
                                 resolver(
                                     Result.failure(ShareViewControllerError.assertionError(description: "Error writing item data: \(String(describing: error))"))
                                 )
@@ -527,7 +529,7 @@ final class ShareNavController: UINavigationController, ShareViewDelegate {
                             
                         case let image as UIImage:
                             if let data = image.pngData() {
-                                let tempFilePath: String = FileSystem.temporaryFilePath(fileExtension: "png") // stringlint:disable
+                                let tempFilePath: String = FileSystem.temporaryFilePath(fileExtension: "png") // stringlint:ignore
                                 do {
                                     let url = NSURL.fileURL(withPath: tempFilePath)
                                     try data.write(to: url)

--- a/SessionShareExtension/ThreadPickerVC.swift
+++ b/SessionShareExtension/ThreadPickerVC.swift
@@ -233,7 +233,7 @@ final class ThreadPickerVC: UIViewController, UITableViewDataSource, UITableView
             (
                 (messageText?.isEmpty == true || (attachments[0].text() == messageText) ?
                     attachments[0].text() :
-                    "\(attachments[0].text() ?? "")\n\n\(messageText ?? "")" // stringlint:disable
+                    "\(attachments[0].text() ?? "")\n\n\(messageText ?? "")" // stringlint:ignore
                 )
             ) :
             messageText

--- a/SessionSnodeKit/Database/Migrations/_001_InitialSetupMigration.swift
+++ b/SessionSnodeKit/Database/Migrations/_001_InitialSetupMigration.swift
@@ -8,7 +8,7 @@ import SessionUtilitiesKit
 
 enum _001_InitialSetupMigration: Migration {
     static let target: TargetMigrations.Identifier = .snodeKit
-    static let identifier: String = "initialSetup" // stringlint:disable
+    static let identifier: String = "initialSetup"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.1
     static let fetchedTables: [(TableRecord & FetchableRecord).Type] = []
@@ -33,7 +33,7 @@ enum _001_InitialSetupMigration: Migration {
         }
         
         try db.create(table: SnodeReceivedMessageInfo.self) { t in
-            t.deprecatedColumn(name: "id", .integer)                  // stringlint:disable
+            t.deprecatedColumn(name: "id", .integer)
                 .notNull()
                 .primaryKey(autoincrement: true)
             t.column(.key, .text)
@@ -72,7 +72,7 @@ internal extension _001_InitialSetupMigration {
     }
     
     struct LegacySnodeSet: Codable, FetchableRecord, EncodableRecord, PersistableRecord, TableRecord, ColumnExpressible {
-        public static let onionRequestPathPrefix = "OnionRequestPath-"  // stringlint:disable
+        public static let onionRequestPathPrefix = "OnionRequestPath-"
         public static var databaseTableName: String { "snodeSet" }
             
         public typealias Columns = CodingKeys

--- a/SessionSnodeKit/Database/Migrations/_002_SetupStandardJobs.swift
+++ b/SessionSnodeKit/Database/Migrations/_002_SetupStandardJobs.swift
@@ -8,7 +8,7 @@ import SessionUtilitiesKit
 /// before running the `YDBToGRDBMigration`
 enum _002_SetupStandardJobs: Migration {
     static let target: TargetMigrations.Identifier = .snodeKit
-    static let identifier: String = "SetupStandardJobs" // stringlint:disable
+    static let identifier: String = "SetupStandardJobs"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.1
     static let fetchedTables: [(TableRecord & FetchableRecord).Type] = []

--- a/SessionSnodeKit/Database/Migrations/_003_YDBToGRDBMigration.swift
+++ b/SessionSnodeKit/Database/Migrations/_003_YDBToGRDBMigration.swift
@@ -6,7 +6,7 @@ import SessionUtilitiesKit
 
 enum _003_YDBToGRDBMigration: Migration {
     static let target: TargetMigrations.Identifier = .snodeKit
-    static let identifier: String = "YDBToGRDBMigration" // stringlint:disable
+    static let identifier: String = "YDBToGRDBMigration"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.1
     static let fetchedTables: [(TableRecord & FetchableRecord).Type] = [Identity.self]

--- a/SessionSnodeKit/Database/Migrations/_004_FlagMessageHashAsDeletedOrInvalid.swift
+++ b/SessionSnodeKit/Database/Migrations/_004_FlagMessageHashAsDeletedOrInvalid.swift
@@ -9,7 +9,7 @@ import SessionUtilitiesKit
 /// messages from the beginning of time)
 enum _004_FlagMessageHashAsDeletedOrInvalid: Migration {
     static let target: TargetMigrations.Identifier = .snodeKit
-    static let identifier: String = "FlagMessageHashAsDeletedOrInvalid" // stringlint:disable
+    static let identifier: String = "FlagMessageHashAsDeletedOrInvalid"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.2
     static let fetchedTables: [(TableRecord & FetchableRecord).Type] = []

--- a/SessionSnodeKit/Database/Migrations/_005_AddSnodeReveivedMessageInfoPrimaryKey.swift
+++ b/SessionSnodeKit/Database/Migrations/_005_AddSnodeReveivedMessageInfoPrimaryKey.swift
@@ -7,7 +7,7 @@ import SessionUtilitiesKit
 /// This migration adds a primary key to `SnodeReceivedMessageInfo` based on the key and hash to speed up lookup
 enum _005_AddSnodeReveivedMessageInfoPrimaryKey: Migration {
     static let target: TargetMigrations.Identifier = .snodeKit
-    static let identifier: String = "AddSnodeReveivedMessageInfoPrimaryKey" // stringlint:disable
+    static let identifier: String = "AddSnodeReveivedMessageInfoPrimaryKey"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.2
     static let fetchedTables: [(TableRecord & FetchableRecord).Type] = [SnodeReceivedMessageInfo.self]

--- a/SessionSnodeKit/Database/Migrations/_006_DropSnodeCache.swift
+++ b/SessionSnodeKit/Database/Migrations/_006_DropSnodeCache.swift
@@ -7,7 +7,7 @@ import SessionUtilitiesKit
 /// This migration drops the current `SnodePool` and `SnodeSet` and their associated jobs as they are handled by `libSession` now
 enum _006_DropSnodeCache: Migration {
     static let target: TargetMigrations.Identifier = .snodeKit
-    static let identifier: String = "DropSnodeCache" // stringlint:disable
+    static let identifier: String = "DropSnodeCache"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.1
     static let fetchedTables: [(TableRecord & FetchableRecord).Type] = []

--- a/SessionSnodeKit/Database/Models/SnodeReceivedMessageInfo.swift
+++ b/SessionSnodeKit/Database/Models/SnodeReceivedMessageInfo.swift
@@ -1,4 +1,6 @@
 // Copyright © 2022 Rangeproof Pty Ltd. All rights reserved.
+//
+// stringlint:disable
 
 import Foundation
 import GRDB

--- a/SessionUIKit/Components/ConfirmationModal.swift
+++ b/SessionUIKit/Components/ConfirmationModal.swift
@@ -274,11 +274,11 @@ public class ConfirmationModal: Modal, UITextFieldDelegate {
         closeButton.isHidden = !info.hasCloseButton
         
         titleLabel.isAccessibilityElement = true
-        titleLabel.accessibilityIdentifier = "Modal heading" // stringlint:disable
+        titleLabel.accessibilityIdentifier = "Modal heading"
         titleLabel.accessibilityLabel = titleLabel.text
         
         explanationLabel.isAccessibilityElement = true
-        explanationLabel.accessibilityIdentifier = "Modal description" // stringlint:disable
+        explanationLabel.accessibilityIdentifier = "Modal description"
         explanationLabel.accessibilityLabel = explanationLabel.text
     }
     

--- a/SessionUIKit/Components/PlaceholderIcon.swift
+++ b/SessionUIKit/Components/PlaceholderIcon.swift
@@ -43,6 +43,7 @@ public class PlaceholderIcon {
     
     // MARK: - Convenience
     
+    // stringlint:ignore_contents
     public static func generate(seed: String, text: String, size: CGFloat) -> UIImage {
         let icon = PlaceholderIcon(seed: seed)
         

--- a/SessionUIKit/Database/Migrations/_001_ThemePreferences.swift
+++ b/SessionUIKit/Database/Migrations/_001_ThemePreferences.swift
@@ -1,4 +1,6 @@
 // Copyright © 2022 Rangeproof Pty Ltd. All rights reserved.
+//
+// stringlint:disable
 
 import Foundation
 import GRDB
@@ -8,7 +10,7 @@ import SessionUtilitiesKit
 /// theme preferences
 enum _001_ThemePreferences: Migration {
     static let target: TargetMigrations.Identifier = .uiKit
-    static let identifier: String = "ThemePreferences" // stringlint:disable
+    static let identifier: String = "ThemePreferences"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.1
     static let fetchedTables: [(TableRecord & FetchableRecord).Type] = [Identity.self]
@@ -21,11 +23,11 @@ enum _001_ThemePreferences: Migration {
         let isExistingUser: Bool = Identity.userExists(db)
         let hadCustomLegacyThemeSetting: Bool = UserDefaults.standard.dictionaryRepresentation()
             .keys
-            .contains("appMode") // stringlint:disable
+            .contains("appMode")
         let matchSystemNightModeSetting: Bool = (isExistingUser && !hadCustomLegacyThemeSetting)
         let targetTheme: Theme = (!hadCustomLegacyThemeSetting ?
             Theme.classicDark :
-            (UserDefaults.standard.integer(forKey: "appMode") == 0 ? // stringlint:disable
+            (UserDefaults.standard.integer(forKey: "appMode") == 0 ?
                 Theme.classicLight :
                 Theme.classicDark
             )

--- a/SessionUIKit/Style Guide/Format.swift
+++ b/SessionUIKit/Style Guide/Format.swift
@@ -39,6 +39,6 @@ public enum Format {
     }
     
     public static func duration(_ duration: TimeInterval) -> String {
-        return (Format.durationFormatter.string(from: duration) ?? "0:00") // stringlint:disable
+        return (Format.durationFormatter.string(from: duration) ?? "0:00") // stringlint:ignore
     }
 }

--- a/SessionUtilitiesKit/Combine/Publisher+Utilities.swift
+++ b/SessionUtilitiesKit/Combine/Publisher+Utilities.swift
@@ -7,6 +7,7 @@ public protocol CombineCompatible {}
 public enum PublisherError: Error, CustomStringConvertible {
     case targetPublisherIsNull
     
+    // stringlint:ignore_contents
     public var description: String {
         switch self {
             case .targetPublisherIsNull: return "The target publisher is null, likely due to a 'weak self' (PublisherError.targetPublisherIsNull)."

--- a/SessionUtilitiesKit/Configuration.swift
+++ b/SessionUtilitiesKit/Configuration.swift
@@ -5,7 +5,7 @@ import GRDB
 
 public enum SNUtilitiesKit: MigratableTarget { // Just to make the external API nice
     public static var isRunningTests: Bool {
-        ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil   // stringlint:disable
+        ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil   // stringlint:ignore
     }
 
     public static func migrations() -> TargetMigrations {

--- a/SessionUtilitiesKit/Crypto/Crypto+SessionUtilitiesKit.swift
+++ b/SessionUtilitiesKit/Crypto/Crypto+SessionUtilitiesKit.swift
@@ -1,4 +1,6 @@
 // Copyright © 2023 Rangeproof Pty Ltd. All rights reserved.
+//
+// stringlint:disable
 
 import Foundation
 import SessionUtil

--- a/SessionUtilitiesKit/Crypto/Hex.swift
+++ b/SessionUtilitiesKit/Crypto/Hex.swift
@@ -3,8 +3,9 @@
 import Foundation
 
 public enum Hex {
+    // stringlint:ignore_contents
     public static func isValid(_ string: String) -> Bool {
-        let allowedCharacters = CharacterSet(charactersIn: "0123456789ABCDEF") // stringlint:disable
+        let allowedCharacters = CharacterSet(charactersIn: "0123456789ABCDEF")
         
         return string.uppercased().unicodeScalars.allSatisfy { allowedCharacters.contains($0) }
     }
@@ -27,12 +28,13 @@ public extension Data {
 // MARK: - Array
 
 public extension Array where Element == UInt8 {
+    // stringlint:ignore_contents
     init(hex: String) {
         self = Array<Element>()
         self.reserveCapacity(hex.unicodeScalars.lazy.underestimatedCount)
         
         var buffer: UInt8?
-        var skip = (hex.hasPrefix("0x") ? 2 : 0) // stringlint:disable
+        var skip = (hex.hasPrefix("0x") ? 2 : 0)
           
         for char in hex.unicodeScalars.lazy {
             guard skip == 0 else {
@@ -72,8 +74,9 @@ public extension Array where Element == UInt8 {
         }
     }
     
+    // stringlint:ignore_contents
     func toHexString() -> String {
-        return map { String(format: "%02x", $0) }.joined() // stringlint:disable
+        return map { String(format: "%02x", $0) }.joined()
     }
 
     func toBase64(options: Data.Base64EncodingOptions = []) -> String {

--- a/SessionUtilitiesKit/Database/Migrations/_001_InitialSetupMigration.swift
+++ b/SessionUtilitiesKit/Database/Migrations/_001_InitialSetupMigration.swift
@@ -1,11 +1,13 @@
 // Copyright © 2022 Rangeproof Pty Ltd. All rights reserved.
+//
+// stringlint:ignore
 
 import Foundation
 import GRDB
 
 enum _001_InitialSetupMigration: Migration {
     static let target: TargetMigrations.Identifier = .utilitiesKit
-    static let identifier: String = "initialSetup" // stringlint:disable
+    static let identifier: String = "initialSetup"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.1
     static let fetchedTables: [(TableRecord & FetchableRecord).Type] = []

--- a/SessionUtilitiesKit/Database/Migrations/_002_SetupStandardJobs.swift
+++ b/SessionUtilitiesKit/Database/Migrations/_002_SetupStandardJobs.swift
@@ -7,7 +7,7 @@ import GRDB
 /// before running the `YDBToGRDBMigration`
 enum _002_SetupStandardJobs: Migration {
     static let target: TargetMigrations.Identifier = .utilitiesKit
-    static let identifier: String = "SetupStandardJobs" // stringlint:disable
+    static let identifier: String = "SetupStandardJobs"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.1
     static let fetchedTables: [(TableRecord & FetchableRecord).Type] = []

--- a/SessionUtilitiesKit/Database/Migrations/_003_YDBToGRDBMigration.swift
+++ b/SessionUtilitiesKit/Database/Migrations/_003_YDBToGRDBMigration.swift
@@ -5,7 +5,7 @@ import GRDB
 
 enum _003_YDBToGRDBMigration: Migration {
     static let target: TargetMigrations.Identifier = .utilitiesKit
-    static let identifier: String = "YDBToGRDBMigration" // stringlint:disable
+    static let identifier: String = "YDBToGRDBMigration"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.1
     static let fetchedTables: [(TableRecord & FetchableRecord).Type] = [Identity.self]

--- a/SessionUtilitiesKit/Database/Migrations/_004_AddJobPriority.swift
+++ b/SessionUtilitiesKit/Database/Migrations/_004_AddJobPriority.swift
@@ -5,7 +5,7 @@ import GRDB
 
 enum _004_AddJobPriority: Migration {
     static let target: TargetMigrations.Identifier = .utilitiesKit
-    static let identifier: String = "AddJobPriority" // stringlint:disable
+    static let identifier: String = "AddJobPriority"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.1
     static let fetchedTables: [(TableRecord & FetchableRecord).Type] = []

--- a/SessionUtilitiesKit/Database/Migrations/_005_AddJobUniqueHash.swift
+++ b/SessionUtilitiesKit/Database/Migrations/_005_AddJobUniqueHash.swift
@@ -5,7 +5,7 @@ import GRDB
 
 enum _005_AddJobUniqueHash: Migration {
     static let target: TargetMigrations.Identifier = .utilitiesKit
-    static let identifier: String = "AddJobUniqueHash" // stringlint:disable
+    static let identifier: String = "AddJobUniqueHash"
     static let needsConfigSync: Bool = false
     static let minExpectedRunDuration: TimeInterval = 0.1
     static let fetchedTables: [(TableRecord & FetchableRecord).Type] = []

--- a/SessionUtilitiesKit/Database/Models/Identity.swift
+++ b/SessionUtilitiesKit/Database/Models/Identity.swift
@@ -148,6 +148,7 @@ public extension Identity {
             return Mnemonic.encode(hexEncodedString: hexEncodedSeed)
         }
         
+        // stringlint:ignore_contents
         guard let legacyPrivateKey: String = Identity.fetchUserPrivateKey()?.toHexString() else {
             let hasStoredPublicKey: Bool = (Identity.fetchUserPublicKey() != nil)
             let hasStoredEdKeyPair: Bool = (Identity.fetchUserEd25519KeyPair() != nil)

--- a/SessionUtilitiesKit/Database/Types/PagedDatabaseObserver.swift
+++ b/SessionUtilitiesKit/Database/Types/PagedDatabaseObserver.swift
@@ -14,7 +14,7 @@ import DifferenceKit
 /// **Note:** We **MUST** have accurate `filterSQL` and `orderSQL` values otherwise the indexing won't work
 public class PagedDatabaseObserver<ObservedTable, T>: TransactionObserver where ObservedTable: TableRecord & ColumnExpressible & Identifiable, T: FetchableRecordWithRowId & Identifiable {
     private let commitProcessingQueue: DispatchQueue = DispatchQueue(
-        label: "PagedDatabaseObserver.commitProcessingQueue",   // stringlint:disable
+        label: "PagedDatabaseObserver.commitProcessingQueue",
         qos: .userInitiated,
         attributes: [] // Must be serial in order to avoid updates getting processed in the wrong order
     )

--- a/SessionUtilitiesKit/Database/Utilities/QueryInterfaceRequest+Utilities.swift
+++ b/SessionUtilitiesKit/Database/Utilities/QueryInterfaceRequest+Utilities.swift
@@ -10,6 +10,8 @@ public extension QueryInterfaceRequest {
     ///
     /// - parameter db: A database connection.
     /// - returns: Whether the request matches a row in the database.
+    ///
+    /// stringlint:ignore_contents
     func isNotEmpty(_ db: Database) -> Bool {
         return ((try? SQLRequest("SELECT \(exists())").fetchOne(db)) ?? false)
     }

--- a/SessionUtilitiesKit/General/AppContext.swift
+++ b/SessionUtilitiesKit/General/AppContext.swift
@@ -58,7 +58,7 @@ public extension AppContext {
     var temporaryDirectory: String {
         if let dir: String = _temporaryDirectory { return dir }
         
-        let dirName: String = "ows_temp_\(UUID().uuidString)"   // stringlint:disable
+        let dirName: String = "ows_temp_\(UUID().uuidString)"   // stringlint:ignore
         let dirPath: String = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent(dirName)
             .path

--- a/SessionUtilitiesKit/General/FileSystem.swift
+++ b/SessionUtilitiesKit/General/FileSystem.swift
@@ -67,7 +67,7 @@ public enum FileSystem {
             }
             
             // Not ideal but fallback to creating a new temp directory
-            let dirName: String = "ows_temp_\(UUID().uuidString)"   // stringlint:disable
+            let dirName: String = "ows_temp_\(UUID().uuidString)"   // stringlint:ignore
             let tempDir: String = URL(fileURLWithPath: NSTemporaryDirectory())
                 .appendingPathComponent(dirName)
                 .path

--- a/SessionUtilitiesKit/General/NSTimer+Proxying.m
+++ b/SessionUtilitiesKit/General/NSTimer+Proxying.m
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)timerFired:(NSDictionary *)userInfo
 {
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"  // stringlint:ignore
     [self.target performSelector:self.selector withObject:userInfo];
 #pragma clang diagnostic pop
 }

--- a/SessionUtilitiesKit/General/SNUserDefaults.swift
+++ b/SessionUtilitiesKit/General/SNUserDefaults.swift
@@ -64,10 +64,11 @@ public enum SNUserDefaults {
 public extension UserDefaults {
     private static let _applicationGroup: Atomic<String?> = Atomic(nil)
     
+    // stringlint:ignore_contents
     static let applicationGroup: String = {
         guard let appGroup: String = _applicationGroup.wrappedValue else {
-            let dynamicAppGroupsId: String = (Bundle.main.infoDictionary?["AppGroupsId"] as? String)  // stringlint:disable
-                .defaulting(to: "group.com.loki-project.loki-messenger")                              // stringlint:disable
+            let dynamicAppGroupsId: String = (Bundle.main.infoDictionary?["AppGroupsId"] as? String)
+                .defaulting(to: "group.com.loki-project.loki-messenger")
             
             _applicationGroup.mutate { $0 = dynamicAppGroupsId }
             return dynamicAppGroupsId

--- a/SessionUtilitiesKit/General/SessionId.swift
+++ b/SessionUtilitiesKit/General/SessionId.swift
@@ -102,12 +102,13 @@ public enum SessionIdError: LocalizedError {
     case invalidPrefix
     case invalidSessionId
     
+    // stringlint:ignore_contents
     public var errorDescription: String? {
         switch self {
-            case .emptyValue: return "Empty value."             // stringlint:disable
-            case .invalidLength: return "Invalid length."       // stringlint:disable
-            case .invalidPrefix: return "Invalid prefix."       // stringlint:disable
-            case .invalidSessionId: return "Invalid sessionId." // stringlint:disable
+            case .emptyValue: return "Empty value."
+            case .invalidLength: return "Invalid length."
+            case .invalidPrefix: return "Invalid prefix."
+            case .invalidSessionId: return "Invalid sessionId."
         }
     }
 }

--- a/SessionUtilitiesKit/General/String+Utilities.swift
+++ b/SessionUtilitiesKit/General/String+Utilities.swift
@@ -81,7 +81,7 @@ public extension String {
 
 public extension String.StringInterpolation {
     mutating func appendInterpolation(_ value: TimeUnit, unit: TimeUnit.Unit, resolution: Int = 2) {
-        appendLiteral("\(TimeUnit(value, unit: unit, resolution: resolution))") // stringlint:disable
+        appendLiteral("\(TimeUnit(value, unit: unit, resolution: resolution))")
     }
     
     mutating func appendInterpolation(_ value: Int, format: String) {

--- a/SessionUtilitiesKit/General/UIDevice+featureSupport.swift
+++ b/SessionUtilitiesKit/General/UIDevice+featureSupport.swift
@@ -46,16 +46,16 @@ public extension UIDevice {
         return UIScreen.main.bounds.height < 568
     }
 
-    @objc
-    var isIPad: Bool {
+    // stringlint:ignore_contents
+    @objc var isIPad: Bool {
         let isNativeIPad = UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiom.pad
         let isCompatabilityModeIPad = UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiom.phone && self.model.hasPrefix("iPad")
 
         return isNativeIPad || isCompatabilityModeIPad
     }
 
-    @objc
-    func ows_setOrientation(_ orientation: UIInterfaceOrientation) {
+    // stringlint:ignore_contents
+    @objc func ows_setOrientation(_ orientation: UIInterfaceOrientation) {
         // XXX - This is not officially supported, but there's no other way to programmatically rotate
         // the interface.
         let orientationKey = "orientation"

--- a/SessionUtilitiesKit/JobRunner/JobRunner.swift
+++ b/SessionUtilitiesKit/JobRunner/JobRunner.swift
@@ -1864,24 +1864,24 @@ public final class JobQueue: Hashable {
 
 private extension String.StringInterpolation {
     mutating func appendInterpolation(_ job: Job) {
-        appendLiteral("\(job.variant) job (id: \(job.id ?? -1))") // stringlint:disable
+        appendLiteral("\(job.variant) job (id: \(job.id ?? -1))")
     }
     
     mutating func appendInterpolation(_ job: Job?) {
         switch job {
             case .some(let job): appendInterpolation(job)
-            case .none: appendLiteral("null job") // stringlint:disable
+            case .none: appendLiteral("null job")
         }
     }
 }
 
 extension String.StringInterpolation {
     mutating func appendInterpolation(_ variant: Job.Variant?) {
-        appendLiteral(variant.map { "\($0)" } ?? "unknown") // stringlint:disable
+        appendLiteral(variant.map { "\($0)" } ?? "unknown")
     }
     
     mutating func appendInterpolation(_ behaviour: Job.Behaviour?) {
-        appendLiteral(behaviour.map { "\($0)" } ?? "unknown") // stringlint:disable
+        appendLiteral(behaviour.map { "\($0)" } ?? "unknown")
     }
 }
 

--- a/SessionUtilitiesKit/Networking/BatchResponse.swift
+++ b/SessionUtilitiesKit/Networking/BatchResponse.swift
@@ -155,6 +155,7 @@ protocol ErasedBatchSubResponse: ResponseInfoType {
 // MARK: - Convenience
 
 internal extension Network.BatchResponse {
+    // stringlint:ignore_contents
     static func decodingResponses(
         from data: Data?,
         as types: [Decodable.Type],
@@ -179,7 +180,7 @@ internal extension Network.BatchResponse {
                 
             case let anyDict as [String: Any]:
                 guard
-                    let resultsArray: [Data] = (anyDict["results"] as? [Any])?   // stringlint:disable
+                    let resultsArray: [Data] = (anyDict["results"] as? [Any])?
                         .compactMap({ try? JSONSerialization.data(withJSONObject: $0) }),
                     (
                         !requireAllResults ||

--- a/SessionUtilitiesKit/Networking/ProxiedContentDownloader.swift
+++ b/SessionUtilitiesKit/Networking/ProxiedContentDownloader.swift
@@ -408,7 +408,9 @@ open class ProxiedContentDownloader: NSObject, URLSessionTaskDelegate, URLSessio
     // MARK: - Properties
 
     @objc
-    public static let defaultDownloader = ProxiedContentDownloader(downloadFolderName: "proxiedContent")
+    public static let defaultDownloader = ProxiedContentDownloader(
+        downloadFolderName: "proxiedContent" // stringlint:ignore
+    )
 
     private let downloadFolderName: String
 
@@ -620,6 +622,7 @@ open class ProxiedContentDownloader: NSObject, URLSessionTaskDelegate, URLSessio
     // * Start a segment request or content length request if possible.
     // * Complete/cancel asset requests if possible.
     //
+    // stringlint:ignore_contents
     private func processRequestQueueSync() {
         guard let assetRequest = popNextAssetRequest() else {
             return
@@ -741,7 +744,7 @@ open class ProxiedContentDownloader: NSObject, URLSessionTaskDelegate, URLSessio
                 print("Invalid header: \(header)")
                 continue
             }
-            if headerString.lowercased() == "content-range" {
+            if headerString.lowercased() == "content-range" { // stringlint:ignore
                 firstContentRangeString = httpResponse.allHeaderFields[header] as? String
             }
         }
@@ -753,11 +756,13 @@ open class ProxiedContentDownloader: NSObject, URLSessionTaskDelegate, URLSessio
         }
 
         // Example: content-range: bytes 0-1023/7630
-        guard let contentLengthString = NSRegularExpression.parseFirstMatch(pattern: "^bytes \\d+\\-\\d+/(\\d+)$",
-                                                                            text: contentRangeString) else {
-                                                                assetRequest.state = .failed
-                                                                self.assetRequestDidFail(assetRequest: assetRequest)
-                                                                return
+        guard let contentLengthString = NSRegularExpression.parseFirstMatch(
+            pattern: "^bytes \\d+\\-\\d+/(\\d+)$",  // stringlint:ignore
+            text: contentRangeString
+        ) else {
+            assetRequest.state = .failed
+            self.assetRequestDidFail(assetRequest: assetRequest)
+            return
         }
         guard contentLengthString.count > 0,
             let contentLength = Int(contentLengthString) else {

--- a/SessionUtilitiesKit/Utilities/Version.swift
+++ b/SessionUtilitiesKit/Utilities/Version.swift
@@ -8,6 +8,7 @@ public struct Version: Comparable {
     public let minor: Int
     public let patch: Int
     
+    // stringlint:ignore_contents
     public var stringValue: String { "\(major).\(minor).\(patch)" }
     
     // MARK: - Initialization
@@ -24,9 +25,10 @@ public struct Version: Comparable {
     
     // MARK: - Functions
     
+    // stringlint:ignore_contents
     public static func from(_ versionString: String) -> Version {
         var tokens: [Int] = versionString
-            .split(separator: ".")  // stringlint:disable
+            .split(separator: ".")
             .map { (Int($0) ?? 0) }
         
         // Extend to '{major}.{minor}.{patch}' if any parts were omitted

--- a/SignalUtilitiesKit/Media Viewing & Editing/Attachment Approval/AttachmentTextToolbar.swift
+++ b/SignalUtilitiesKit/Media Viewing & Editing/Attachment Approval/AttachmentTextToolbar.swift
@@ -240,7 +240,7 @@ class AttachmentTextToolbar: UIView, UITextViewDelegate {
 
         // Though we can wrap the text, we don't want to encourage multline captions, plus a "done" button
         // allows the user to get the keyboard out of the way while in the attachment approval view.
-        if text == "\n" {   // stringlint:disable
+        if text == "\n" {   // stringlint:ignore
             textView.resignFirstResponder()
             return false
         }

--- a/SignalUtilitiesKit/Media Viewing & Editing/Image Editing/ImageEditorCropViewController.swift
+++ b/SignalUtilitiesKit/Media Viewing & Editing/Image Editing/ImageEditorCropViewController.swift
@@ -237,13 +237,11 @@ class ImageEditorCropViewController: OWSViewController {
     }
 
     private func updateCropLockButton() {
-        guard let cropLockButton = cropLockButton else {
-            Log.error("[ImageEditorCropViewController] Missing cropLockButton")
-            return
+        switch (cropLockButton, isCropLocked) {
+            case (.none, _): Log.error("[ImageEditorCropViewController] Missing cropLockButton")
+            case (.some(let button), true): button.setImage(imageName: "image_editor_crop_lock")
+            case (.some(let button), false): button.setImage(imageName: "image_editor_crop_unlock")
         }
-        cropLockButton.setImage(imageName: (isCropLocked
-            ? "image_editor_crop_lock"
-            : "image_editor_crop_unlock"))
     }
 
     @objc

--- a/SignalUtilitiesKit/Media Viewing & Editing/Image Editing/ImageEditorTextViewController.swift
+++ b/SignalUtilitiesKit/Media Viewing & Editing/Image Editing/ImageEditorTextViewController.swift
@@ -1,6 +1,4 @@
 //  Copyright (c) 2019 Open Whisper Systems. All rights reserved.
-//
-// stringlint:disable
 
 import UIKit
 import SessionUIKit
@@ -43,7 +41,7 @@ private class VAlignTextView: UITextView {
 
         super.init(frame: .zero, textContainer: nil)
 
-        self.addObserver(self, forKeyPath: "contentSize", options: .new, context: nil)  // stringlint:disable
+        self.addObserver(self, forKeyPath: "contentSize", options: .new, context: nil)  // stringlint:ignore
     }
 
     @available(*, unavailable, message: "use other init() instead.")
@@ -52,7 +50,7 @@ private class VAlignTextView: UITextView {
     }
 
     deinit {
-        self.removeObserver(self, forKeyPath: "contentSize")    // stringlint:disable
+        self.removeObserver(self, forKeyPath: "contentSize")    // stringlint:ignore
     }
 
     private func updateInsets() {
@@ -76,8 +74,8 @@ private class VAlignTextView: UITextView {
 
     override var keyCommands: [UIKeyCommand]? {
         return [
-            UIKeyCommand(input: "\r", modifierFlags: .command, action: #selector(self.modifiedReturnPressed(sender:)), discoverabilityTitle: "Add Text"),
-            UIKeyCommand(input: "\r", modifierFlags: .alternate, action: #selector(self.modifiedReturnPressed(sender:)), discoverabilityTitle: "Add Text")
+            UIKeyCommand(input: "\r", modifierFlags: .command, action: #selector(self.modifiedReturnPressed(sender:))),
+            UIKeyCommand(input: "\r", modifierFlags: .alternate, action: #selector(self.modifiedReturnPressed(sender:)))
         ]
     }
 

--- a/SignalUtilitiesKit/Media Viewing & Editing/Image Editing/ImageEditorTransform.swift
+++ b/SignalUtilitiesKit/Media Viewing & Editing/Image Editing/ImageEditorTransform.swift
@@ -243,7 +243,8 @@ public class ImageEditorTransform: NSObject {
             isFlipped.hashValue)
     }
 
+    // stringlint:ignore_contents
     open override var description: String {
-        return "[outputSizePixels: \(outputSizePixels), unitTranslation: \(unitTranslation), rotationRadians: \(rotationRadians), scaling: \(scaling), isFlipped: \(isFlipped)]"    // stringlint:disable
+        return "[outputSizePixels: \(outputSizePixels), unitTranslation: \(unitTranslation), rotationRadians: \(rotationRadians), scaling: \(scaling), isFlipped: \(isFlipped)]"
     }
 }

--- a/SignalUtilitiesKit/Media Viewing & Editing/MediaMessageView.swift
+++ b/SignalUtilitiesKit/Media Viewing & Editing/MediaMessageView.swift
@@ -278,7 +278,9 @@ public class MediaMessageView: UIView {
         if attachment.isUrl {
             // We only load Link Previews for HTTPS urls so append an explanation for not
             if let linkPreviewURL: String = linkPreviewInfo?.url {
-                if let targetUrl: URL = URL(string: linkPreviewURL), targetUrl.scheme?.lowercased() != "https" {
+                let httpsScheme: String = "https"   // stringlint:ignore
+                
+                if let targetUrl: URL = URL(string: linkPreviewURL), targetUrl.scheme?.lowercased() != httpsScheme {
                     label.font = UIFont.systemFont(ofSize: Values.verySmallFontSize)
                     label.text = "linkPreviewsErrorUnsecure".localized()
                     label.themeTextColor = (mode == .attachmentApproval ?

--- a/SignalUtilitiesKit/Media Viewing & Editing/OWSVideoPlayer.swift
+++ b/SignalUtilitiesKit/Media Viewing & Editing/OWSVideoPlayer.swift
@@ -18,7 +18,10 @@ public class OWSVideoPlayer {
 
     @objc public init(url: URL) {
         self.avPlayer = AVPlayer(url: url)
-        self.audioActivity = AudioActivity(audioDescription: "[OWSVideoPlayer] url:\(url)", behavior: .playback)
+        self.audioActivity = AudioActivity(
+            audioDescription: "[OWSVideoPlayer] url:\(url)", // stringlint:ignore
+            behavior: .playback
+        )
 
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(playerItemDidPlayToCompletion(_:)),

--- a/SignalUtilitiesKit/Screen Lock/ScreenLockViewController.swift
+++ b/SignalUtilitiesKit/Screen Lock/ScreenLockViewController.swift
@@ -95,7 +95,7 @@ open class ScreenLockViewController: UIViewController {
 
         self.logoView.isHidden = !shouldShowBlockWindow
 
-        let signature: String = String(format: "%d", shouldHaveScreenLock)
+        let signature: String = "\(shouldHaveScreenLock)"
         
         // Skip redundant work to avoid interfering with ongoing animations
         guard signature != self.screenBlockingSignature else { return }


### PR DESCRIPTION
- Added new 'LintControl' mechanisms to allow for ignoring sections of code
- Added new 'MatchType' mechanisms for excluding unlocalized cases
- Updated the code to explicitly handle localized template strings (both single and multiline)
- Updated the code to process files across multiple threads to improve performance
- Updated the code to use Swift 5.7 regex and store in static variables to prevent reconstruction every time they are used
- Removed the list of individual files which are ignored (now just output a count)
- Fixed an issue where having a localized string on a subsequent line could result in an unlocalized (or incorrectly localized) string not being detected
- Fixed an issue where having multiple strings on a single line could result in an unlocalized string not being detected
- Fixed an issue where zero-width characters would result in the variable count comparison between translations failing
- Fixed a number of localization warnings