### PR TITLE
Updated the SQL for checking session id prefixes

### DIFF
--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+Contacts.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+Contacts.swift
@@ -201,8 +201,11 @@ internal extension LibSession {
         let threadIdsToRemove: [String] = try SessionThread
             .filter(!syncedContactIds.contains(SessionThread.Columns.id))
             .filter(SessionThread.Columns.variant == SessionThread.Variant.contact)
-            .filter(!SessionThread.Columns.id.like("\(SessionId.Prefix.blinded15.rawValue)%"))
-            .filter(!SessionThread.Columns.id.like("\(SessionId.Prefix.blinded25.rawValue)%"))
+            .filter(
+                /// Only want to include include standard contact conversations (not blinded conversations)
+                ClosedGroup.Columns.threadId > SessionId.Prefix.standard.rawValue &&
+                ClosedGroup.Columns.threadId < SessionId.Prefix.standard.endOfRangeString
+            )
             .select(.id)
             .asRequest(of: String.self)
             .fetchAll(db)

--- a/SessionMessagingKit/LibSession/Config Handling/LibSession+UserGroups.swift
+++ b/SessionMessagingKit/LibSession/Config Handling/LibSession+UserGroups.swift
@@ -826,7 +826,6 @@ extension LibSession {
             let thread: TypedTableAlias<SessionThread> = TypedTableAlias()
             let keyPair: TypedTableAlias<ClosedGroupKeyPair> = TypedTableAlias()
             
-            let prefixLiteral: SQL = SQL(stringLiteral: "\(SessionId.Prefix.standard.rawValue)%")
             let keyPairThreadIdColumnLiteral: SQL = SQL(stringLiteral: ClosedGroupKeyPair.Columns.threadId.name)
             let receivedTimestampColumnLiteral: SQL = SQL(stringLiteral: ClosedGroupKeyPair.Columns.receivedTimestamp.name)
             let threadIdColumnLiteral: SQL = SQL(stringLiteral: DisappearingMessagesConfiguration.Columns.threadId.name)
@@ -861,7 +860,10 @@ extension LibSession {
                 ) AS \(LegacyGroupInfo.lastKeyPairKey) ON \(LegacyGroupInfo.lastKeyPairKey).\(keyPairThreadIdColumnLiteral) = \(closedGroup[.threadId])
                 LEFT JOIN \(DisappearingMessagesConfiguration.self) AS \(LegacyGroupInfo.disappearingConfigKey) ON \(LegacyGroupInfo.disappearingConfigKey).\(threadIdColumnLiteral) = \(closedGroup[.threadId])
                 
-                WHERE \(SQL("\(closedGroup[.threadId]) LIKE '\(prefixLiteral)'"))
+                WHERE (
+                    \(closedGroup[.threadId]) > \(SessionId.Prefix.standard.rawValue) AND
+                    \(closedGroup[.threadId]) < \(SessionId.Prefix.standard.endOfRangeString)
+                )
             """
             
             let legacyGroupInfoNoMembers: [LegacyGroupInfo] = try request

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+ClosedGroups.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+ClosedGroups.swift
@@ -246,7 +246,10 @@ extension MessageReceiver {
                 currentUserPublicKey: currentUserPublicKey,
                 legacyGroupIds: try ClosedGroup
                     .select(.threadId)
-                    .filter(!ClosedGroup.Columns.threadId.like("\(SessionId.Prefix.group.rawValue)%"))
+                    .filter(
+                        ClosedGroup.Columns.threadId > SessionId.Prefix.standard.rawValue &&
+                        ClosedGroup.Columns.threadId < SessionId.Prefix.standard.endOfRangeString
+                    )
                     .joining(
                         required: ClosedGroup.members
                             .filter(GroupMember.Columns.profileId == currentUserPublicKey)

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+MessageRequests.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageReceiver+MessageRequests.swift
@@ -59,8 +59,14 @@ extension MessageReceiver {
             .select(.id)
             .filter(SessionThread.Columns.variant == SessionThread.Variant.contact)
             .filter(
-                SessionThread.Columns.id.like("\(SessionId.Prefix.blinded15.rawValue)%") ||
-                SessionThread.Columns.id.like("\(SessionId.Prefix.blinded25.rawValue)%")
+                (
+                    ClosedGroup.Columns.threadId > SessionId.Prefix.blinded15.rawValue &&
+                    ClosedGroup.Columns.threadId < SessionId.Prefix.blinded15.endOfRangeString
+                ) ||
+                (
+                    ClosedGroup.Columns.threadId > SessionId.Prefix.blinded25.rawValue &&
+                    ClosedGroup.Columns.threadId < SessionId.Prefix.blinded25.endOfRangeString
+                )
             )
             .asRequest(of: String.self)
             .fetchSet(db))

--- a/SessionMessagingKit/Sending & Receiving/Message Handling/MessageSender+ClosedGroups.swift
+++ b/SessionMessagingKit/Sending & Receiving/Message Handling/MessageSender+ClosedGroups.swift
@@ -125,7 +125,10 @@ extension MessageSender {
                             currentUserPublicKey: userPublicKey,
                             legacyGroupIds: try ClosedGroup
                                 .select(.threadId)
-                                .filter(!ClosedGroup.Columns.threadId.like("\(SessionId.Prefix.group.rawValue)%"))
+                                .filter(
+                                    ClosedGroup.Columns.threadId > SessionId.Prefix.standard.rawValue &&
+                                    ClosedGroup.Columns.threadId < SessionId.Prefix.standard.endOfRangeString
+                                )
                                 .joining(
                                     required: ClosedGroup.members
                                         .filter(GroupMember.Columns.profileId == userPublicKey)

--- a/SessionMessagingKit/Sending & Receiving/Notifications/PushNotificationAPI.swift
+++ b/SessionMessagingKit/Sending & Receiving/Notifications/PushNotificationAPI.swift
@@ -86,7 +86,10 @@ public enum PushNotificationAPI {
                         currentUserPublicKey: currentUserPublicKey,
                         legacyGroupIds: try ClosedGroup
                             .select(.threadId)
-                            .filter(!ClosedGroup.Columns.threadId.like("\(SessionId.Prefix.group.rawValue)%"))
+                            .filter(
+                                ClosedGroup.Columns.threadId > SessionId.Prefix.standard.rawValue &&
+                                ClosedGroup.Columns.threadId < SessionId.Prefix.standard.endOfRangeString
+                            )
                             .joining(
                                 required: ClosedGroup.members
                                     .filter(GroupMember.Columns.profileId == currentUserPublicKey)
@@ -167,7 +170,10 @@ public enum PushNotificationAPI {
                     getUserHexEncodedPublicKey(db, using: dependencies),
                     try ClosedGroup
                         .select(.threadId)
-                        .filter(!ClosedGroup.Columns.threadId.like("\(SessionId.Prefix.group.rawValue)%"))
+                        .filter(
+                            ClosedGroup.Columns.threadId > SessionId.Prefix.standard.rawValue &&
+                            ClosedGroup.Columns.threadId < SessionId.Prefix.standard.endOfRangeString
+                        )
                         .asRequest(of: String.self)
                         .fetchSet(db)
                 )

--- a/SessionUtilitiesKit/General/SessionId.swift
+++ b/SessionUtilitiesKit/General/SessionId.swift
@@ -29,6 +29,20 @@ public struct SessionId: Equatable, Hashable, CustomStringConvertible {
                 case .some: throw SessionIdError.invalidSessionId   // Should be covered by above cases
             }
         }
+        
+        /// In SQLite it's more efficient to check if an indexed column is `{column} > '05' AND {column} < '06'` then it is to use
+        /// a wildcard like`{column} LIKE '05%'` as the wildcard can't use the index, so this variable is here to streamline this behaviour
+        ///
+        /// stringlint:ignore_contents
+        public var endOfRangeString: String {
+            switch self {
+                case .standard: return "06"
+                case .blinded15: return "16"
+                case .blinded25: return "26"
+                case .unblinded: return "01"
+                case .group: return "04"
+            }
+        }
     }
     
     public let prefix: Prefix


### PR DESCRIPTION
Updated the SQLite queries wherever we were using `{column} LIKE '05%'` to instead check `{column} > '05' AND {column} < '06'` so that we get the benefits of the indexed column